### PR TITLE
feat(query-builder): QueryDSL Tier 2 — scalar expressions, CAST, date parts, subqueries, CASE

### DIFF
--- a/__tests__/unit/qdsl-tier2-aliased-expression.test.ts
+++ b/__tests__/unit/qdsl-tier2-aliased-expression.test.ts
@@ -1,0 +1,239 @@
+import "reflect-metadata";
+import { SelectQueryBuilder, qAlias } from "../../src/core/SelectQueryBuilder";
+import {
+  AliasedExpression,
+  isAliasedExpression,
+} from "../../src/core/expressions/AliasedExpression";
+import { Entity, PrimaryGeneratedColumn, Column } from "../../src/decorators";
+import { EntityManager } from "../../src/core/EntityManager";
+import { RelationMetadataResolver } from "../../src/core/RelationMetadataResolver";
+import { createDialectExpression } from "../../src/dialects/DialectExpression";
+
+@Entity()
+class User {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @Column({ type: "varchar", length: 255 })
+  name!: string;
+
+  @Column({ type: "varchar", length: 50, nullable: true })
+  status!: string | null;
+
+  @Column({ type: "int" })
+  age!: number;
+
+  @Column({ type: "json" })
+  metadata!: { profile?: { email?: string; score?: number }; tags?: string[] };
+}
+
+type DbType = "mysql" | "postgresql" | "sqlite";
+
+function createMockEm(dbType: DbType = "postgresql") {
+  const resolver = new RelationMetadataResolver();
+  function wrap(col: string) {
+    if (dbType === "mysql") return `\`${col.replace(/`/g, "``")}\``;
+    return `"${col.replace(/"/g, '""')}"`;
+  }
+  return {
+    wrap,
+    wrapTable: (t: string) => wrap(t),
+    resolver,
+    _ctx: {
+      isMySqlFamily: () => dbType === "mysql",
+      isPostgres: () => dbType === "postgresql",
+      isSqlite: () => dbType === "sqlite",
+      getDialect: () =>
+        dbType === "mysql" ? "mysql" : dbType === "sqlite" ? "sqlite" : "postgresql",
+    },
+  } as unknown as EntityManager;
+}
+
+function createQb(dbType: DbType = "postgresql") {
+  const em = createMockEm(dbType);
+  const qb = new SelectQueryBuilder<User>(User, "u", em);
+  const resolver = (em as any).resolver as RelationMetadataResolver;
+  const meta = resolver.resolveEntityMetadata(User);
+  if (meta) {
+    const map = new Map<string, string>();
+    for (const c of meta.columns) {
+      map.set((c as any).propertyKey ?? c.name!, c.name!);
+    }
+    qb.setPropertyToColumnMap(map);
+  }
+  const dialectName = dbType === "postgresql" ? "postgres" : dbType;
+  qb.setDialectExpression(createDialectExpression(dialectName));
+  return qb;
+}
+
+describe("AliasedExpression (QueryDSL Tier 2)", () => {
+  describe("ColumnExpression.as()", () => {
+    it("returns an AliasedExpression carrying the alias", () => {
+      const u = qAlias(User, "u");
+      const a = u.name.as("n");
+      expect(isAliasedExpression(a)).toBe(true);
+      expect(a).toBeInstanceOf(AliasedExpression);
+      expect(a.alias).toBe("n");
+    });
+
+    it("does not mutate the original ColumnExpression", () => {
+      const u = qAlias(User, "u");
+      const col = u.name;
+      col.as("x");
+      // subsequent .as() returns independent objects
+      const a1 = col.as("a1");
+      const a2 = col.as("a2");
+      expect(a1.alias).toBe("a1");
+      expect(a2.alias).toBe("a2");
+      expect(a1).not.toBe(a2);
+    });
+
+    it("renderer produces a qualified column reference (no params)", () => {
+      const u = qAlias(User, "u");
+      const a = u.name.as("n");
+      const sql = a.renderer((ref) => {
+        const [alias, col] = ref.split(".");
+        return `"${alias}"."${col}"`;
+      });
+      expect(sql.sql).toBe(`"u"."name"`);
+      expect(sql.values).toEqual([]);
+    });
+  });
+
+  describe("JsonPathExpression.as()", () => {
+    it("returns an AliasedExpression carrying the alias", () => {
+      const u = qAlias(User, "u");
+      const a = u.metadata.profile.email.as("contact");
+      expect(isAliasedExpression(a)).toBe(true);
+      expect(a.alias).toBe("contact");
+    });
+
+    it("renderer throws when no dialect is provided", () => {
+      const u = qAlias(User, "u");
+      const a = u.metadata.profile.email.as("contact");
+      expect(() =>
+        a.renderer((ref) => `"${ref.replace(".", '"."')}"`),
+      ).toThrow(/requires a DialectExpression/);
+    });
+
+    it("renderer delegates to the dialect's jsonExtract (PostgreSQL)", () => {
+      const u = qAlias(User, "u");
+      const a = u.metadata.profile.email.as("contact");
+      const dialect = createDialectExpression("postgres");
+      const sql = a.renderer(
+        (ref) => {
+          const [alias, col] = ref.split(".");
+          return `"${alias}"."${col}"`;
+        },
+        dialect,
+      );
+      // PG uses #>> for text extraction
+      expect(sql.sql).toContain("#>>");
+    });
+  });
+
+  describe("SelectQueryBuilder — select(AliasedExpression)", () => {
+    it("renders a single column alias via SELECT", () => {
+      const qb = createQb();
+      const u = qAlias(User, "u");
+      qb.select(u.name.as("display_name"));
+      const { text, values } = qb.getSql();
+      expect(text).toMatch(/SELECT "u"\."name" AS "display_name"/);
+      expect(values).toEqual([]);
+    });
+
+    it("renders multiple column aliases", () => {
+      const qb = createQb();
+      const u = qAlias(User, "u");
+      qb.select([u.name.as("n"), u.age.as("years")]);
+      const { text } = qb.getSql();
+      expect(text).toMatch(
+        /SELECT "u"\."name" AS "n", "u"\."age" AS "years"/,
+      );
+    });
+
+    it("renders DISTINCT with aliased expressions", () => {
+      const qb = createQb();
+      const u = qAlias(User, "u");
+      qb.setDistinct(true).select([u.name.as("n")]);
+      const { text } = qb.getSql();
+      expect(text).toMatch(/SELECT DISTINCT "u"\."name" AS "n"/);
+    });
+
+    it("renders JSON extract with its path bound as a parameter (MySQL)", () => {
+      const qb = createQb("mysql");
+      const u = qAlias(User, "u");
+      qb.select(u.metadata.profile.email.as("email"));
+      const { text, values } = qb.getSql();
+      expect(text).toContain("JSON_UNQUOTE(JSON_EXTRACT(");
+      expect(text).toMatch(/AS `email`/);
+      // JSON path is bound, not inlined
+      expect(values).toContain("$.profile.email");
+    });
+
+    it("renders JSON extract via #>> on PostgreSQL", () => {
+      const qb = createQb("postgresql");
+      const u = qAlias(User, "u");
+      qb.select(u.metadata.profile.email.as("email"));
+      const { text } = qb.getSql();
+      expect(text).toContain("#>>");
+      expect(text).toMatch(/AS "email"/);
+    });
+
+    it("mixes AliasedExpression and AggregateExpression in one select()", () => {
+      const qb = createQb();
+      const u = qAlias(User, "u");
+      qb.select([u.name.as("n"), u.id.count().as("total")]);
+      const { text } = qb.getSql();
+      expect(text).toContain(`"u"."name" AS "n"`);
+      expect(text).toContain(`COUNT("u"."id") AS "total"`);
+    });
+  });
+
+  describe("SelectQueryBuilder — addSelect(AliasedExpression)", () => {
+    it("appends an aliased column to an existing SELECT list", () => {
+      const qb = createQb();
+      const u = qAlias(User, "u");
+      qb.select(["id", "name"]);
+      qb.addSelect(u.age.as("years"));
+      const { text } = qb.getSql();
+      expect(text).toMatch(
+        /SELECT "u"\."id", "u"\."name", "u"\."age" AS "years"/,
+      );
+    });
+
+    it("appends a JSON-aliased expression with params preserved", () => {
+      const qb = createQb("mysql");
+      const u = qAlias(User, "u");
+      qb.select(["id"]);
+      qb.addSelect(u.metadata.profile.email.as("email"));
+      const { text, values } = qb.getSql();
+      expect(text).toContain("JSON_UNQUOTE(JSON_EXTRACT(");
+      expect(values).toContain("$.profile.email");
+    });
+
+    it("appends aliased expression onto the default SELECT *", () => {
+      const qb = createQb();
+      const u = qAlias(User, "u");
+      qb.addSelect(u.name.as("n"));
+      const { text } = qb.getSql();
+      // SELECT "u".*, "u"."name" AS "n"
+      expect(text).toMatch(/"u"\.\*, "u"\."name" AS "n"/);
+    });
+  });
+
+  describe("clone() preserves aliased projection", () => {
+    it("clone mirrors the aliased SELECT list without sharing the array", () => {
+      const qb = createQb();
+      const u = qAlias(User, "u");
+      qb.select([u.name.as("n")]);
+      const c = qb.clone();
+      const originalSql = qb.getSql().text;
+      const cloneSql = c.getSql().text;
+      expect(cloneSql).toBe(originalSql);
+      // Append a further select to the original — clone should not change
+      qb.addSelect(u.age.as("years"));
+      expect(c.getSql().text).toBe(originalSql);
+    });
+  });
+});

--- a/__tests__/unit/qdsl-tier2-case-builder.test.ts
+++ b/__tests__/unit/qdsl-tier2-case-builder.test.ts
@@ -1,0 +1,288 @@
+import "reflect-metadata";
+import { SelectQueryBuilder, qAlias } from "../../src/core/SelectQueryBuilder";
+import { Entity, PrimaryGeneratedColumn, Column } from "../../src/decorators";
+import { EntityManager } from "../../src/core/EntityManager";
+import { RelationMetadataResolver } from "../../src/core/RelationMetadataResolver";
+import { createDialectExpression } from "../../src/dialects/DialectExpression";
+import { Expressions } from "../../src/core/expressions/LogicalCondition";
+import {
+  CaseBuilder,
+  CaseValueBuilder,
+  caseBuilder,
+  cases,
+} from "../../src/core/expressions/CaseExpression";
+import { isScalarExpression } from "../../src/core/expressions/ScalarExpression";
+
+@Entity()
+class User {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @Column({ type: "varchar", length: 50 })
+  status!: string;
+
+  @Column({ type: "int" })
+  score!: number;
+
+  @Column({ type: "varchar", length: 50 })
+  role!: string;
+}
+
+type DbType = "mysql" | "postgresql" | "sqlite";
+
+function createMockEm(dbType: DbType = "postgresql") {
+  const resolver = new RelationMetadataResolver();
+  function wrap(col: string) {
+    if (dbType === "mysql") return `\`${col.replace(/`/g, "``")}\``;
+    return `"${col.replace(/"/g, '""')}"`;
+  }
+  return {
+    wrap,
+    wrapTable: (t: string) => wrap(t),
+    resolver,
+    _ctx: {
+      isMySqlFamily: () => dbType === "mysql",
+      isPostgres: () => dbType === "postgresql",
+      isSqlite: () => dbType === "sqlite",
+      getDialect: () =>
+        dbType === "mysql" ? "mysql" : dbType === "sqlite" ? "sqlite" : "postgresql",
+    },
+  } as unknown as EntityManager;
+}
+
+function createQb(dbType: DbType = "postgresql") {
+  const em = createMockEm(dbType);
+  const qb = new SelectQueryBuilder<User>(User, "u", em);
+  const resolver = (em as any).resolver as RelationMetadataResolver;
+  const meta = resolver.resolveEntityMetadata(User);
+  if (meta) {
+    const map = new Map<string, string>();
+    for (const c of meta.columns) {
+      map.set((c as any).propertyKey ?? c.name!, c.name!);
+    }
+    qb.setPropertyToColumnMap(map);
+  }
+  const dialectName = dbType === "postgresql" ? "postgres" : dbType;
+  qb.setDialectExpression(createDialectExpression(dialectName));
+  return qb;
+}
+
+describe("CaseBuilder (QueryDSL Tier 2)", () => {
+  describe("searched CASE — caseBuilder()", () => {
+    it("factory returns a CaseBuilder", () => {
+      expect(caseBuilder()).toBeInstanceOf(CaseBuilder);
+    });
+
+    it("single WHEN/THEN + ELSE renders CASE WHEN cond THEN v ELSE d END", () => {
+      const u = qAlias(User, "u");
+      const qb = createQb();
+      const tier = Expressions.caseBuilder()
+        .when(u.score.gte(90))
+        .then("gold")
+        .otherwise("bronze")
+        .end();
+      qb.select([tier.as("tier")]);
+      const { text, values } = qb.getSql();
+      expect(text).toContain(
+        `CASE WHEN "u"."score" >= ? THEN ? ELSE ? END AS "tier"`,
+      );
+      expect(values).toEqual(expect.arrayContaining([90, "gold", "bronze"]));
+    });
+
+    it("multiple WHENs preserve order and emit one CASE block", () => {
+      const u = qAlias(User, "u");
+      const qb = createQb();
+      const tier = Expressions.caseBuilder()
+        .when(u.score.gte(90)).then("gold")
+        .when(u.score.gte(70)).then("silver")
+        .otherwise("bronze")
+        .end();
+      qb.select([tier.as("tier")]);
+      const { text } = qb.getSql();
+      expect(text).toMatch(
+        /CASE WHEN .+ THEN .+ WHEN .+ THEN .+ ELSE .+ END AS "tier"/,
+      );
+    });
+
+    it("omitting otherwise() is valid — renders without ELSE", () => {
+      const u = qAlias(User, "u");
+      const qb = createQb();
+      const tier = Expressions.caseBuilder()
+        .when(u.score.gte(90)).then("gold")
+        .end();
+      qb.select([tier.as("tier")]);
+      const { text } = qb.getSql();
+      expect(text).toContain(`CASE WHEN "u"."score" >= ? THEN ? END`);
+      expect(text).not.toContain(" ELSE ");
+    });
+
+    it("supports column expression as the THEN value", () => {
+      const u = qAlias(User, "u");
+      const qb = createQb();
+      const tier = Expressions.caseBuilder()
+        .when(u.score.gte(90)).then(u.status)
+        .otherwise("default")
+        .end();
+      qb.select([tier.as("tier")]);
+      const { text } = qb.getSql();
+      expect(text).toContain(`THEN "u"."status"`);
+    });
+
+    it("result returned by end() is a ScalarExpression", () => {
+      const u = qAlias(User, "u");
+      const scalar = Expressions.caseBuilder()
+        .when(u.score.gt(0)).then(1)
+        .end();
+      expect(isScalarExpression(scalar)).toBe(true);
+    });
+
+    it("CaseExpression composes with .as() and cast", () => {
+      const u = qAlias(User, "u");
+      const qb = createQb();
+      const tier = Expressions.caseBuilder()
+        .when(u.score.gte(90)).then("gold")
+        .otherwise("bronze")
+        .end()
+        .stringValue()
+        .as("tier");
+      qb.select([tier]);
+      const { text } = qb.getSql();
+      expect(text).toMatch(/CAST\(CASE WHEN .+ END AS TEXT\) AS "tier"/);
+    });
+
+    it("CaseExpression composes with .eq() to form a WHERE condition", () => {
+      const u = qAlias(User, "u");
+      const qb = createQb();
+      const tier = Expressions.caseBuilder()
+        .when(u.score.gte(90)).then("gold")
+        .otherwise("bronze")
+        .end();
+      qb.where(tier.eq("gold"));
+      const { text, values } = qb.getSql();
+      expect(text).toMatch(/CASE WHEN .+ END = \?/);
+      expect(values).toContain("gold");
+    });
+
+    it("throws on end() without any WHEN", () => {
+      expect(() => caseBuilder().end()).toThrow(/at least one WHEN/);
+    });
+
+    it("throws on when() after otherwise()", () => {
+      const u = qAlias(User, "u");
+      expect(() =>
+        Expressions.caseBuilder()
+          .when(u.score.gt(0))
+          .then("a")
+          .otherwise("b")
+          .when(u.score.gt(10)),
+      ).toThrow(/cannot add .when/);
+    });
+
+    it("throws on duplicate otherwise()", () => {
+      const u = qAlias(User, "u");
+      expect(() =>
+        Expressions.caseBuilder()
+          .when(u.score.gt(0))
+          .then("a")
+          .otherwise("b")
+          .otherwise("c"),
+      ).toThrow(/already set/);
+    });
+
+    it("throws on when() with non-condition argument", () => {
+      expect(() => caseBuilder().when({} as any)).toThrow(
+        /ConditionLike/,
+      );
+    });
+  });
+
+  describe("simple CASE — cases(subject)", () => {
+    it("factory returns a CaseValueBuilder", () => {
+      expect(cases(1)).toBeInstanceOf(CaseValueBuilder);
+    });
+
+    it("cases(col).when(val, result).otherwise().end()", () => {
+      const u = qAlias(User, "u");
+      const qb = createQb();
+      const weight = Expressions.cases(u.status)
+        .when("active", 1)
+        .when("pending", 0)
+        .otherwise(-1)
+        .end();
+      qb.select([weight.as("w")]);
+      const { text, values } = qb.getSql();
+      expect(text).toContain(
+        `CASE "u"."status" WHEN ? THEN ? WHEN ? THEN ? ELSE ? END AS "w"`,
+      );
+      expect(values).toEqual(
+        expect.arrayContaining(["active", 1, "pending", 0, -1]),
+      );
+    });
+
+    it("end() result is a ScalarExpression suitable for comparison", () => {
+      const u = qAlias(User, "u");
+      const qb = createQb();
+      const weight = Expressions.cases(u.status)
+        .when("active", 1)
+        .otherwise(0)
+        .end();
+      qb.where(weight.eq(1));
+      const { text } = qb.getSql();
+      expect(text).toMatch(/CASE "u"\."status" WHEN .+ THEN .+ ELSE .+ END = \?/);
+    });
+
+    it("simple CASE without otherwise() is valid", () => {
+      const u = qAlias(User, "u");
+      const qb = createQb();
+      const w = Expressions.cases(u.status).when("active", 1).end();
+      qb.select([w.as("x")]);
+      expect(qb.getSql().text).toContain(
+        `CASE "u"."status" WHEN ? THEN ? END AS "x"`,
+      );
+    });
+
+    it("throws on end() without any WHEN", () => {
+      const u = qAlias(User, "u");
+      expect(() => cases(u.status).end()).toThrow(/at least one WHEN/);
+    });
+
+    it("throws on duplicate otherwise()", () => {
+      const u = qAlias(User, "u");
+      expect(() =>
+        cases(u.status)
+          .when("a", 1)
+          .otherwise(0)
+          .otherwise(-1),
+      ).toThrow(/already set/);
+    });
+  });
+
+  describe("integration with other expression types", () => {
+    it("CASE result feeds into coalesce()", () => {
+      const u = qAlias(User, "u");
+      const qb = createQb();
+      const ranked = Expressions.caseBuilder()
+        .when(u.score.gte(90)).then("gold")
+        .end();
+      qb.select([
+        Expressions.coalesce(ranked, u.status, "unknown").as("tier"),
+      ]);
+      const { text } = qb.getSql();
+      expect(text).toContain("COALESCE(CASE WHEN ");
+      expect(text).toContain(`"u"."status"`);
+    });
+
+    it("CASE composes inside Expressions.and() via .eq() result", () => {
+      const u = qAlias(User, "u");
+      const qb = createQb();
+      const band = Expressions.caseBuilder()
+        .when(u.score.gte(90)).then("gold")
+        .otherwise("other")
+        .end();
+      qb.where(Expressions.and(band.eq("gold"), u.role.eq("member")));
+      const { text } = qb.getSql();
+      expect(text).toContain(" AND ");
+      expect(text).toMatch(/CASE WHEN .+ END = \?/);
+    });
+  });
+});

--- a/__tests__/unit/qdsl-tier2-cast.test.ts
+++ b/__tests__/unit/qdsl-tier2-cast.test.ts
@@ -1,0 +1,204 @@
+import "reflect-metadata";
+import { SelectQueryBuilder, qAlias } from "../../src/core/SelectQueryBuilder";
+import { Entity, PrimaryGeneratedColumn, Column } from "../../src/decorators";
+import { EntityManager } from "../../src/core/EntityManager";
+import { RelationMetadataResolver } from "../../src/core/RelationMetadataResolver";
+import { createDialectExpression } from "../../src/dialects/DialectExpression";
+import { coalesce } from "../../src/core/expressions/NullishExpression";
+
+@Entity()
+class Item {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @Column({ type: "varchar", length: 50 })
+  sku!: string;
+
+  @Column({ type: "int" })
+  quantity!: number;
+
+  @Column({ type: "double" })
+  price!: number;
+
+  @Column({ type: "varchar", length: 10 })
+  status!: string;
+}
+
+type DbType = "mysql" | "postgresql" | "sqlite";
+
+function createMockEm(dbType: DbType = "postgresql") {
+  const resolver = new RelationMetadataResolver();
+  function wrap(col: string) {
+    if (dbType === "mysql") return `\`${col.replace(/`/g, "``")}\``;
+    return `"${col.replace(/"/g, '""')}"`;
+  }
+  return {
+    wrap,
+    wrapTable: (t: string) => wrap(t),
+    resolver,
+    _ctx: {
+      isMySqlFamily: () => dbType === "mysql",
+      isPostgres: () => dbType === "postgresql",
+      isSqlite: () => dbType === "sqlite",
+      getDialect: () =>
+        dbType === "mysql" ? "mysql" : dbType === "sqlite" ? "sqlite" : "postgresql",
+    },
+  } as unknown as EntityManager;
+}
+
+function createQb(dbType: DbType = "postgresql") {
+  const em = createMockEm(dbType);
+  const qb = new SelectQueryBuilder<Item>(Item, "i", em);
+  const resolver = (em as any).resolver as RelationMetadataResolver;
+  const meta = resolver.resolveEntityMetadata(Item);
+  if (meta) {
+    const map = new Map<string, string>();
+    for (const c of meta.columns) {
+      map.set((c as any).propertyKey ?? c.name!, c.name!);
+    }
+    qb.setPropertyToColumnMap(map);
+  }
+  const dialectName = dbType === "postgresql" ? "postgres" : dbType;
+  qb.setDialectExpression(createDialectExpression(dialectName));
+  return qb;
+}
+
+describe("CAST expressions (QueryDSL Tier 2)", () => {
+  describe("ColumnExpression cast methods", () => {
+    it("stringValue() renders CAST(col AS TEXT) on PostgreSQL", () => {
+      const i = qAlias(Item, "i");
+      const qb = createQb("postgresql");
+      qb.select([i.quantity.stringValue().as("qty_str")]);
+      expect(qb.getSql().text).toContain(
+        `CAST("i"."quantity" AS TEXT) AS "qty_str"`,
+      );
+    });
+
+    it("stringValue() renders CAST(col AS CHAR) on MySQL", () => {
+      const i = qAlias(Item, "i");
+      const qb = createQb("mysql");
+      qb.select([i.quantity.stringValue().as("qty_str")]);
+      expect(qb.getSql().text).toContain(
+        "CAST(`i`.`quantity` AS CHAR) AS `qty_str`",
+      );
+    });
+
+    it("stringValue() renders CAST(col AS TEXT) on SQLite", () => {
+      const i = qAlias(Item, "i");
+      const qb = createQb("sqlite");
+      qb.select([i.quantity.stringValue().as("qty_str")]);
+      expect(qb.getSql().text).toContain(
+        `CAST("i"."quantity" AS TEXT) AS "qty_str"`,
+      );
+    });
+
+    it("intValue() renders INTEGER on PG and SIGNED on MySQL", () => {
+      const i = qAlias(Item, "i");
+      expect(
+        createQb("postgresql")
+          .select([i.price.intValue().as("p")])
+          .getSql().text,
+      ).toContain(`CAST("i"."price" AS INTEGER)`);
+      expect(
+        createQb("mysql").select([i.price.intValue().as("p")]).getSql().text,
+      ).toContain("CAST(`i`.`price` AS SIGNED)");
+    });
+
+    it("longValue() renders BIGINT on PG and SIGNED on MySQL", () => {
+      const i = qAlias(Item, "i");
+      expect(
+        createQb("postgresql")
+          .select([i.price.longValue().as("p")])
+          .getSql().text,
+      ).toContain(`CAST("i"."price" AS BIGINT)`);
+      expect(
+        createQb("mysql").select([i.price.longValue().as("p")]).getSql().text,
+      ).toContain("CAST(`i`.`price` AS SIGNED)");
+    });
+
+    it("floatValue() renders REAL on PG and DECIMAL on MySQL", () => {
+      const i = qAlias(Item, "i");
+      expect(
+        createQb("postgresql")
+          .select([i.quantity.floatValue().as("q")])
+          .getSql().text,
+      ).toContain(`CAST("i"."quantity" AS REAL)`);
+      expect(
+        createQb("mysql").select([i.quantity.floatValue().as("q")]).getSql().text,
+      ).toContain("CAST(`i`.`quantity` AS DECIMAL)");
+    });
+
+    it("booleanValue() renders BOOLEAN on PG, UNSIGNED on MySQL, INTEGER on SQLite", () => {
+      const i = qAlias(Item, "i");
+      expect(
+        createQb("postgresql")
+          .select([i.quantity.booleanValue().as("b")])
+          .getSql().text,
+      ).toContain(`CAST("i"."quantity" AS BOOLEAN)`);
+      expect(
+        createQb("mysql").select([i.quantity.booleanValue().as("b")]).getSql().text,
+      ).toContain("CAST(`i`.`quantity` AS UNSIGNED)");
+      expect(
+        createQb("sqlite").select([i.quantity.booleanValue().as("b")]).getSql().text,
+      ).toContain(`CAST("i"."quantity" AS INTEGER)`);
+    });
+  });
+
+  describe("ScalarExpression cast chaining", () => {
+    it("chains CAST onto a coalesce() result", () => {
+      const i = qAlias(Item, "i");
+      const qb = createQb("postgresql");
+      qb.select([coalesce(i.price, 0).floatValue().as("safe_price")]);
+      const { text, values } = qb.getSql();
+      expect(text).toContain(
+        `CAST(COALESCE("i"."price", ?) AS REAL) AS "safe_price"`,
+      );
+      expect(values).toContain(0);
+    });
+
+    it("supports a cast of a cast (uncommon but valid)", () => {
+      const i = qAlias(Item, "i");
+      const qb = createQb("postgresql");
+      qb.select([i.quantity.intValue().stringValue().as("qty_text")]);
+      expect(qb.getSql().text).toContain(
+        `CAST(CAST("i"."quantity" AS INTEGER) AS TEXT) AS "qty_text"`,
+      );
+    });
+  });
+
+  describe("WHERE / HAVING usage", () => {
+    it("cast expressions compare cleanly in WHERE", () => {
+      const i = qAlias(Item, "i");
+      const qb = createQb("postgresql");
+      qb.where(i.sku.intValue().gt(1000));
+      const { text, values } = qb.getSql();
+      expect(text).toContain(`CAST("i"."sku" AS INTEGER) > ?`);
+      expect(values).toContain(1000);
+    });
+
+    it("cast is composable with Expressions.and", () => {
+      const i = qAlias(Item, "i");
+      const qb = createQb("postgresql");
+      qb.where(
+        i.sku
+          .intValue()
+          .gt(1000)
+          .and(i.quantity.stringValue().eq("100")),
+      );
+      const { text } = qb.getSql();
+      expect(text).toContain(`CAST("i"."sku" AS INTEGER) >`);
+      expect(text).toContain(`CAST("i"."quantity" AS TEXT) =`);
+      expect(text).toContain(" AND ");
+    });
+  });
+
+  describe("Error paths", () => {
+    it("throws on missing dialect when the expression is detached", () => {
+      const i = qAlias(Item, "i");
+      const expr = i.quantity.intValue();
+      expect(() => expr.renderer((ref) => ref)).toThrow(
+        /require.* DialectExpression/,
+      );
+    });
+  });
+});

--- a/__tests__/unit/qdsl-tier2-date-component.test.ts
+++ b/__tests__/unit/qdsl-tier2-date-component.test.ts
@@ -1,0 +1,244 @@
+import "reflect-metadata";
+import { SelectQueryBuilder, qAlias } from "../../src/core/SelectQueryBuilder";
+import { Entity, PrimaryGeneratedColumn, Column } from "../../src/decorators";
+import { EntityManager } from "../../src/core/EntityManager";
+import { RelationMetadataResolver } from "../../src/core/RelationMetadataResolver";
+import { createDialectExpression } from "../../src/dialects/DialectExpression";
+import { Expressions } from "../../src/core/expressions/LogicalCondition";
+
+@Entity()
+class Event {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @Column({ type: "datetime" })
+  startsAt!: Date;
+
+  @Column({ type: "datetime" })
+  endsAt!: Date;
+}
+
+type DbType = "mysql" | "postgresql" | "sqlite";
+
+function createMockEm(dbType: DbType = "postgresql") {
+  const resolver = new RelationMetadataResolver();
+  function wrap(col: string) {
+    if (dbType === "mysql") return `\`${col.replace(/`/g, "``")}\``;
+    return `"${col.replace(/"/g, '""')}"`;
+  }
+  return {
+    wrap,
+    wrapTable: (t: string) => wrap(t),
+    resolver,
+    _ctx: {
+      isMySqlFamily: () => dbType === "mysql",
+      isPostgres: () => dbType === "postgresql",
+      isSqlite: () => dbType === "sqlite",
+      getDialect: () =>
+        dbType === "mysql" ? "mysql" : dbType === "sqlite" ? "sqlite" : "postgresql",
+    },
+  } as unknown as EntityManager;
+}
+
+function createQb(dbType: DbType = "postgresql") {
+  const em = createMockEm(dbType);
+  const qb = new SelectQueryBuilder<Event>(Event, "e", em);
+  const resolver = (em as any).resolver as RelationMetadataResolver;
+  const meta = resolver.resolveEntityMetadata(Event);
+  if (meta) {
+    const map = new Map<string, string>();
+    for (const c of meta.columns) {
+      map.set((c as any).propertyKey ?? c.name!, c.name!);
+    }
+    qb.setPropertyToColumnMap(map);
+  }
+  const dialectName = dbType === "postgresql" ? "postgres" : dbType;
+  qb.setDialectExpression(createDialectExpression(dialectName));
+  return qb;
+}
+
+describe("Date component expressions (QueryDSL Tier 2)", () => {
+  describe("PostgreSQL dialect — EXTRACT(... FROM ...)", () => {
+    const e = qAlias(Event, "e");
+
+    it("year() emits EXTRACT(YEAR FROM col)", () => {
+      const qb = createQb("postgresql").select([e.startsAt.year().as("y")]);
+      expect(qb.getSql().text).toContain(
+        `CAST(EXTRACT(YEAR FROM "e"."startsAt") AS INTEGER) AS "y"`,
+      );
+    });
+    it("month() emits EXTRACT(MONTH FROM col)", () => {
+      const qb = createQb("postgresql").select([e.startsAt.month().as("m")]);
+      expect(qb.getSql().text).toContain("EXTRACT(MONTH FROM ");
+    });
+    it("day() emits EXTRACT(DAY FROM col)", () => {
+      const qb = createQb("postgresql").select([e.startsAt.day().as("d")]);
+      expect(qb.getSql().text).toContain("EXTRACT(DAY FROM ");
+    });
+    it("hour/minute/second", () => {
+      const qb = createQb("postgresql").select([
+        e.startsAt.hour().as("h"),
+        e.startsAt.minute().as("mi"),
+        e.startsAt.second().as("s"),
+      ]);
+      const text = qb.getSql().text;
+      expect(text).toContain("EXTRACT(HOUR FROM ");
+      expect(text).toContain("EXTRACT(MINUTE FROM ");
+      expect(text).toContain("EXTRACT(SECOND FROM ");
+    });
+    it("dayOfWeek → DOW, dayOfYear → DOY, week → WEEK", () => {
+      const qb = createQb("postgresql").select([
+        e.startsAt.dayOfWeek().as("dow"),
+        e.startsAt.dayOfYear().as("doy"),
+        e.startsAt.week().as("w"),
+      ]);
+      const text = qb.getSql().text;
+      expect(text).toContain("EXTRACT(DOW FROM ");
+      expect(text).toContain("EXTRACT(DOY FROM ");
+      expect(text).toContain("EXTRACT(WEEK FROM ");
+    });
+  });
+
+  describe("MySQL dialect — component functions", () => {
+    const e = qAlias(Event, "e");
+
+    it("year/month/dayOfMonth", () => {
+      const qb = createQb("mysql").select([
+        e.startsAt.year().as("y"),
+        e.startsAt.month().as("m"),
+        e.startsAt.dayOfMonth().as("d"),
+      ]);
+      const text = qb.getSql().text;
+      expect(text).toContain("YEAR(`e`.`startsAt`) AS `y`");
+      expect(text).toContain("MONTH(`e`.`startsAt`) AS `m`");
+      expect(text).toContain("DAYOFMONTH(`e`.`startsAt`) AS `d`");
+    });
+
+    it("dayOfWeek → DAYOFWEEK, dayOfYear → DAYOFYEAR, week → WEEK", () => {
+      const qb = createQb("mysql").select([
+        e.startsAt.dayOfWeek().as("dw"),
+        e.startsAt.dayOfYear().as("dy"),
+        e.startsAt.week().as("w"),
+      ]);
+      const text = qb.getSql().text;
+      expect(text).toContain("DAYOFWEEK(`e`.`startsAt`)");
+      expect(text).toContain("DAYOFYEAR(`e`.`startsAt`)");
+      expect(text).toContain("WEEK(`e`.`startsAt`)");
+    });
+
+    it("hour/minute/second", () => {
+      const qb = createQb("mysql").select([
+        e.startsAt.hour().as("h"),
+        e.startsAt.minute().as("mi"),
+        e.startsAt.second().as("s"),
+      ]);
+      const text = qb.getSql().text;
+      expect(text).toContain("HOUR(`e`.`startsAt`)");
+      expect(text).toContain("MINUTE(`e`.`startsAt`)");
+      expect(text).toContain("SECOND(`e`.`startsAt`)");
+    });
+
+    it("day() maps to DAYOFMONTH", () => {
+      const qb = createQb("mysql").select([e.startsAt.day().as("d")]);
+      expect(qb.getSql().text).toContain("DAYOFMONTH(`e`.`startsAt`)");
+    });
+  });
+
+  describe("SQLite dialect — strftime + CAST", () => {
+    const e = qAlias(Event, "e");
+
+    it("year → strftime('%Y', col)", () => {
+      const qb = createQb("sqlite").select([e.startsAt.year().as("y")]);
+      const { text, values } = qb.getSql();
+      expect(text).toContain(
+        `CAST(strftime(?, "e"."startsAt") AS INTEGER) AS "y"`,
+      );
+      expect(values).toContain("%Y");
+    });
+
+    it("month, day, hour, minute, second — each uses a distinct strftime format", () => {
+      const qb = createQb("sqlite").select([
+        e.startsAt.month().as("m"),
+        e.startsAt.day().as("d"),
+        e.startsAt.hour().as("h"),
+        e.startsAt.minute().as("mi"),
+        e.startsAt.second().as("s"),
+      ]);
+      const { values } = qb.getSql();
+      expect(values).toEqual(
+        expect.arrayContaining(["%m", "%d", "%H", "%M", "%S"]),
+      );
+    });
+
+    it("dayOfWeek → %w, dayOfYear → %j, week → %W", () => {
+      const qb = createQb("sqlite").select([
+        e.startsAt.dayOfWeek().as("dw"),
+        e.startsAt.dayOfYear().as("dy"),
+        e.startsAt.week().as("w"),
+      ]);
+      const { values } = qb.getSql();
+      expect(values).toEqual(
+        expect.arrayContaining(["%w", "%j", "%W"]),
+      );
+    });
+  });
+
+  describe("WHERE / HAVING usage", () => {
+    it("year().eq(2026) becomes a WHERE condition", () => {
+      const e = qAlias(Event, "e");
+      const qb = createQb("postgresql");
+      qb.where(e.startsAt.year().eq(2026));
+      const { text, values } = qb.getSql();
+      expect(text).toContain(`CAST(EXTRACT(YEAR FROM "e"."startsAt") AS INTEGER) = ?`);
+      expect(values).toContain(2026);
+    });
+
+    it("composes with Expressions.and", () => {
+      const e = qAlias(Event, "e");
+      const qb = createQb("mysql");
+      qb.where(
+        Expressions.and(
+          e.startsAt.year().eq(2026),
+          e.startsAt.month().gte(3),
+        ),
+      );
+      const { text } = qb.getSql();
+      expect(text).toContain("YEAR(`e`.`startsAt`) =");
+      expect(text).toContain("MONTH(`e`.`startsAt`) >=");
+      expect(text).toContain(" AND ");
+    });
+
+    it("ORDER BY on a date component via .asc() through a CAST layer", () => {
+      const e = qAlias(Event, "e");
+      // Verify that chaining .year() in SELECT works; ordering requires
+      // addOrderBy on a ref — outside Phase 2.5 scope, but confirm the
+      // scalar composes at least in HAVING position.
+      const qb = createQb("postgresql");
+      qb.groupBy([e.col("startsAt")]).having(e.startsAt.year().gte(2026));
+      const { text } = qb.getSql();
+      expect(text).toContain(`HAVING CAST(EXTRACT(YEAR`);
+    });
+  });
+
+  describe("Chaining CAST after date component", () => {
+    it("year().stringValue() nests correctly on PostgreSQL", () => {
+      const e = qAlias(Event, "e");
+      const qb = createQb("postgresql").select([
+        e.startsAt.year().stringValue().as("y"),
+      ]);
+      expect(qb.getSql().text).toContain(
+        `CAST(CAST(EXTRACT(YEAR FROM "e"."startsAt") AS INTEGER) AS TEXT) AS "y"`,
+      );
+    });
+  });
+
+  describe("Error paths", () => {
+    it("throws on missing dialect when detached", () => {
+      const e = qAlias(Event, "e");
+      const expr = e.startsAt.year();
+      expect(() => expr.renderer((ref) => ref)).toThrow(
+        /require.* DialectExpression/,
+      );
+    });
+  });
+});

--- a/__tests__/unit/qdsl-tier2-nullish.test.ts
+++ b/__tests__/unit/qdsl-tier2-nullish.test.ts
@@ -1,0 +1,274 @@
+import "reflect-metadata";
+import { SelectQueryBuilder, qAlias } from "../../src/core/SelectQueryBuilder";
+import { Entity, PrimaryGeneratedColumn, Column } from "../../src/decorators";
+import { EntityManager } from "../../src/core/EntityManager";
+import { RelationMetadataResolver } from "../../src/core/RelationMetadataResolver";
+import { createDialectExpression } from "../../src/dialects/DialectExpression";
+import {
+  coalesce,
+  nullif,
+} from "../../src/core/expressions/NullishExpression";
+import {
+  ScalarExpression,
+  isScalarExpression,
+  isScalarCondition,
+} from "../../src/core/expressions/ScalarExpression";
+import { Expressions } from "../../src/core/expressions/LogicalCondition";
+
+@Entity()
+class User {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @Column({ type: "varchar", length: 255, nullable: true })
+  nickname!: string;
+
+  @Column({ type: "varchar", length: 255 })
+  name!: string;
+
+  @Column({ type: "varchar", length: 255, nullable: true })
+  email!: string;
+
+  @Column({ type: "int", nullable: true })
+  score!: number;
+
+  @Column({ type: "json" })
+  metadata!: { profile?: { tier?: string } };
+}
+
+type DbType = "mysql" | "postgresql" | "sqlite";
+
+function createMockEm(dbType: DbType = "postgresql") {
+  const resolver = new RelationMetadataResolver();
+  function wrap(col: string) {
+    if (dbType === "mysql") return `\`${col.replace(/`/g, "``")}\``;
+    return `"${col.replace(/"/g, '""')}"`;
+  }
+  return {
+    wrap,
+    wrapTable: (t: string) => wrap(t),
+    resolver,
+    _ctx: {
+      isMySqlFamily: () => dbType === "mysql",
+      isPostgres: () => dbType === "postgresql",
+      isSqlite: () => dbType === "sqlite",
+      getDialect: () =>
+        dbType === "mysql" ? "mysql" : dbType === "sqlite" ? "sqlite" : "postgresql",
+    },
+  } as unknown as EntityManager;
+}
+
+function createQb(dbType: DbType = "postgresql") {
+  const em = createMockEm(dbType);
+  const qb = new SelectQueryBuilder<User>(User, "u", em);
+  const resolver = (em as any).resolver as RelationMetadataResolver;
+  const meta = resolver.resolveEntityMetadata(User);
+  if (meta) {
+    const map = new Map<string, string>();
+    for (const c of meta.columns) {
+      map.set((c as any).propertyKey ?? c.name!, c.name!);
+    }
+    qb.setPropertyToColumnMap(map);
+  }
+  const dialectName = dbType === "postgresql" ? "postgres" : dbType;
+  qb.setDialectExpression(createDialectExpression(dialectName));
+  return qb;
+}
+
+describe("NullishExpression — coalesce / nullif (QueryDSL Tier 2)", () => {
+  describe("coalesce()", () => {
+    it("throws on fewer than 2 arguments", () => {
+      expect(() => coalesce(42)).toThrow(/at least 2/);
+    });
+
+    it("returns a ScalarExpression instance", () => {
+      const u = qAlias(User, "u");
+      const result = coalesce(u.nickname, u.name);
+      expect(isScalarExpression(result)).toBe(true);
+      expect(result).toBeInstanceOf(ScalarExpression);
+    });
+
+    it("renders COALESCE with multiple column refs", () => {
+      const u = qAlias(User, "u");
+      const qb = createQb();
+      qb.select([coalesce(u.nickname, u.name).as("display")]);
+      const { text } = qb.getSql();
+      expect(text).toContain(
+        `COALESCE("u"."nickname", "u"."name") AS "display"`,
+      );
+    });
+
+    it("binds plain values as parameters", () => {
+      const u = qAlias(User, "u");
+      const qb = createQb();
+      qb.select([coalesce(u.nickname, "anon").as("display")]);
+      const { text, values } = qb.getSql();
+      expect(text).toContain(`COALESCE("u"."nickname", ?)`);
+      expect(values).toContain("anon");
+    });
+
+    it("nests inside another coalesce", () => {
+      const u = qAlias(User, "u");
+      const qb = createQb();
+      const inner = coalesce(u.nickname, u.name);
+      qb.select([coalesce(inner, "fallback").as("display")]);
+      const { text, values } = qb.getSql();
+      expect(text).toContain(
+        `COALESCE(COALESCE("u"."nickname", "u"."name"), ?)`,
+      );
+      expect(values).toContain("fallback");
+    });
+
+    it("supports JSON path extract as an argument (PostgreSQL)", () => {
+      const u = qAlias(User, "u");
+      const qb = createQb("postgresql");
+      qb.select([
+        coalesce(u.metadata.profile.tier, "free").as("tier"),
+      ]);
+      const { text } = qb.getSql();
+      expect(text).toContain("#>>");
+      expect(text).toContain("COALESCE(");
+      expect(text).toContain(`AS "tier"`);
+    });
+
+    it("accepts an aggregate as an argument", () => {
+      const u = qAlias(User, "u");
+      const qb = createQb();
+      qb.select([coalesce(u.score.sum(), 0).as("total")]);
+      const { text, values } = qb.getSql();
+      expect(text).toContain(`COALESCE(SUM("u"."score"), ?)`);
+      expect(values).toContain(0);
+    });
+  });
+
+  describe("nullif()", () => {
+    it("returns a ScalarExpression", () => {
+      const u = qAlias(User, "u");
+      expect(isScalarExpression(nullif(u.email, ""))).toBe(true);
+    });
+
+    it("renders NULLIF(col, value)", () => {
+      const u = qAlias(User, "u");
+      const qb = createQb();
+      qb.select([nullif(u.email, "").as("email_or_null")]);
+      const { text, values } = qb.getSql();
+      expect(text).toContain(`NULLIF("u"."email", ?) AS "email_or_null"`);
+      expect(values).toContain("");
+    });
+
+    it("renders NULLIF(col, col)", () => {
+      const u = qAlias(User, "u");
+      const qb = createQb();
+      qb.select([nullif(u.nickname, u.name).as("override")]);
+      const { text } = qb.getSql();
+      expect(text).toContain(
+        `NULLIF("u"."nickname", "u"."name") AS "override"`,
+      );
+    });
+  });
+
+  describe("ColumnExpression.coalesce()", () => {
+    it("is shorthand for the free-standing coalesce()", () => {
+      const u = qAlias(User, "u");
+      const qb = createQb();
+      qb.select([u.nickname.coalesce(u.name, "anon").as("display")]);
+      const { text } = qb.getSql();
+      expect(text).toContain(
+        `COALESCE("u"."nickname", "u"."name", ?) AS "display"`,
+      );
+    });
+
+    it("throws without any fallback", () => {
+      const u = qAlias(User, "u");
+      expect(() => (u.nickname as any).coalesce()).toThrow(
+        /at least one fallback/,
+      );
+    });
+  });
+
+  describe("ScalarCondition — WHERE / HAVING usage", () => {
+    it("eq() produces a WHERE condition from a coalesce expression", () => {
+      const u = qAlias(User, "u");
+      const qb = createQb();
+      qb.where(coalesce(u.nickname, u.name).eq("admin"));
+      const { text, values } = qb.getSql();
+      expect(text).toContain(`COALESCE("u"."nickname", "u"."name") = ?`);
+      expect(values).toContain("admin");
+    });
+
+    it("gt() works on a numeric coalesce", () => {
+      const u = qAlias(User, "u");
+      const qb = createQb();
+      qb.where(coalesce(u.score, 0).gt(100));
+      const { text } = qb.getSql();
+      expect(text).toContain(`COALESCE("u"."score", ?) > ?`);
+    });
+
+    it("between() produces BETWEEN clause", () => {
+      const u = qAlias(User, "u");
+      const qb = createQb();
+      qb.where(coalesce(u.score, 0).between(10, 20));
+      const { text } = qb.getSql();
+      expect(text).toMatch(/COALESCE\([^)]+\) BETWEEN \? AND \?/);
+    });
+
+    it("isNull() works", () => {
+      const u = qAlias(User, "u");
+      const qb = createQb();
+      qb.where(nullif(u.email, "").isNull());
+      const { text } = qb.getSql();
+      expect(text).toMatch(/NULLIF\([^)]+\) IS NULL/);
+    });
+
+    it("composes with .and() / .or()", () => {
+      const u = qAlias(User, "u");
+      const qb = createQb();
+      qb.where(
+        coalesce(u.nickname, u.name)
+          .eq("admin")
+          .or(u.score.gt(90)),
+      );
+      const { text } = qb.getSql();
+      expect(text).toContain("COALESCE");
+      expect(text).toContain(" OR ");
+    });
+
+    it("works inside Expressions.and()", () => {
+      const u = qAlias(User, "u");
+      const qb = createQb();
+      const cond = Expressions.and(
+        coalesce(u.score, 0).gte(50),
+        u.name.eq("Alice"),
+      );
+      qb.where(cond);
+      const { text } = qb.getSql();
+      expect(text).toContain(
+        `(COALESCE("u"."score", ?) >= ? AND "u"."name" = ?)`,
+      );
+    });
+
+    it("isScalarCondition guard identifies the condition type", () => {
+      const u = qAlias(User, "u");
+      const cond = coalesce(u.nickname, u.name).eq("admin");
+      expect(isScalarCondition(cond)).toBe(true);
+    });
+  });
+
+  describe("Expressions.coalesce / Expressions.nullif — static surface", () => {
+    it("Expressions.coalesce delegates to coalesce()", () => {
+      const u = qAlias(User, "u");
+      const qb = createQb();
+      qb.select([Expressions.coalesce(u.nickname, "anon").as("d")]);
+      const { text } = qb.getSql();
+      expect(text).toContain(`COALESCE("u"."nickname", ?) AS "d"`);
+    });
+
+    it("Expressions.nullif delegates to nullif()", () => {
+      const u = qAlias(User, "u");
+      const qb = createQb();
+      qb.select([Expressions.nullif(u.email, "").as("x")]);
+      const { text } = qb.getSql();
+      expect(text).toContain(`NULLIF("u"."email", ?) AS "x"`);
+    });
+  });
+});

--- a/__tests__/unit/qdsl-tier2-subquery.test.ts
+++ b/__tests__/unit/qdsl-tier2-subquery.test.ts
@@ -1,0 +1,236 @@
+import "reflect-metadata";
+import { SelectQueryBuilder, qAlias } from "../../src/core/SelectQueryBuilder";
+import { Entity, PrimaryGeneratedColumn, Column } from "../../src/decorators";
+import { EntityManager } from "../../src/core/EntityManager";
+import { RelationMetadataResolver } from "../../src/core/RelationMetadataResolver";
+import { createDialectExpression } from "../../src/dialects/DialectExpression";
+import {
+  exists,
+  notExists,
+  isSubqueryLike,
+  isExistsCondition,
+  ExistsCondition,
+} from "../../src/core/expressions/SubqueryExpression";
+import { Expressions } from "../../src/core/expressions/LogicalCondition";
+
+@Entity()
+class User {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @Column({ type: "varchar", length: 50 })
+  status!: string;
+
+  @Column({ type: "int" })
+  departmentId!: number;
+}
+
+@Entity()
+class Post {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @Column({ type: "int" })
+  authorId!: number;
+
+  @Column({ type: "varchar", length: 50 })
+  status!: string;
+
+  @Column({ type: "int" })
+  views!: number;
+}
+
+type DbType = "mysql" | "postgresql" | "sqlite";
+
+function createMockEm(dbType: DbType = "postgresql") {
+  const resolver = new RelationMetadataResolver();
+  function wrap(col: string) {
+    if (dbType === "mysql") return `\`${col.replace(/`/g, "``")}\``;
+    return `"${col.replace(/"/g, '""')}"`;
+  }
+  return {
+    wrap,
+    wrapTable: (t: string) => wrap(t),
+    resolver,
+    _ctx: {
+      isMySqlFamily: () => dbType === "mysql",
+      isPostgres: () => dbType === "postgresql",
+      isSqlite: () => dbType === "sqlite",
+      getDialect: () =>
+        dbType === "mysql" ? "mysql" : dbType === "sqlite" ? "sqlite" : "postgresql",
+    },
+  } as unknown as EntityManager;
+}
+
+function setupQb<E extends object>(
+  entity: new () => E,
+  alias: string,
+  dbType: DbType = "postgresql",
+): SelectQueryBuilder<E> {
+  const em = createMockEm(dbType);
+  const qb = new SelectQueryBuilder<E>(entity as any, alias, em);
+  const resolver = (em as any).resolver as RelationMetadataResolver;
+  const meta = resolver.resolveEntityMetadata(entity as any);
+  if (meta) {
+    const map = new Map<string, string>();
+    for (const c of meta.columns) {
+      map.set((c as any).propertyKey ?? c.name!, c.name!);
+    }
+    qb.setPropertyToColumnMap(map);
+  }
+  const dialectName = dbType === "postgresql" ? "postgres" : dbType;
+  qb.setDialectExpression(createDialectExpression(dialectName));
+  return qb;
+}
+
+describe("Subquery expressions (QueryDSL Tier 2)", () => {
+  describe("isSubqueryLike guard", () => {
+    it("returns true for a SelectQueryBuilder", () => {
+      const sub = setupQb(Post, "p").select(["id"]);
+      expect(isSubqueryLike(sub)).toBe(true);
+    });
+
+    it("returns false for plain objects", () => {
+      expect(isSubqueryLike({})).toBe(false);
+      expect(isSubqueryLike(42)).toBe(false);
+      expect(isSubqueryLike(null)).toBe(false);
+      expect(isSubqueryLike({ toSql: () => null })).toBe(false); // missing getSql
+    });
+  });
+
+  describe("ColumnExpression.in / notIn with subquery", () => {
+    it("col.in(subquery) renders col IN (SELECT ...)", () => {
+      const p = qAlias(Post, "p");
+      const u = qAlias(User, "u");
+      const outer = setupQb(User, "u");
+      const activeAuthors = setupQb(Post, "p")
+        .select(["authorId"])
+        .where(p.status.eq("published"));
+
+      outer.where(u.id.in(activeAuthors));
+      const { text } = outer.getSql();
+      expect(text).toContain(`"u"."id" IN (`);
+      expect(text).toContain(`SELECT "p"."authorId"`);
+      expect(text).toContain(`WHERE "p"."status" = ?`);
+    });
+
+    it("col.notIn(subquery) renders col NOT IN (SELECT ...)", () => {
+      const u = qAlias(User, "u");
+      const outer = setupQb(User, "u");
+      const inactive = setupQb(Post, "p")
+        .select(["authorId"])
+        .where(qAlias(Post, "p").status.eq("archived"));
+
+      outer.where(u.id.notIn(inactive));
+      const { text } = outer.getSql();
+      expect(text).toContain(`"u"."id" NOT IN (`);
+    });
+
+    it("col.in() still works with value list (backward compatible)", () => {
+      const u = qAlias(User, "u");
+      const qb = setupQb(User, "u");
+      qb.where(u.status.in(["active", "pending"]));
+      const { text, values } = qb.getSql();
+      expect(text).toContain(`"u"."status" IN (?, ?)`);
+      expect(values).toEqual(expect.arrayContaining(["active", "pending"]));
+    });
+  });
+
+  describe("ColumnExpression scalar comparison with subquery", () => {
+    it("col.eq(subquery) renders col = (SELECT ...)", () => {
+      const u = qAlias(User, "u");
+      const outer = setupQb(User, "u");
+      const maxId = setupQb(User, "u2").selectRaw(["MAX(u2.id)"]);
+
+      outer.where(u.id.eq(maxId));
+      const { text } = outer.getSql();
+      expect(text).toMatch(/"u"\."id" = \(SELECT/);
+    });
+
+    it("col.gt(subquery) renders col > (SELECT ...)", () => {
+      const p = qAlias(Post, "p");
+      const outer = setupQb(Post, "p");
+      const avgViews = setupQb(Post, "p2").selectRaw(["AVG(p2.views)"]);
+
+      outer.where(p.views.gt(avgViews));
+      const { text } = outer.getSql();
+      expect(text).toMatch(/"p"\."views" > \(SELECT/);
+    });
+  });
+
+  describe("Expressions.exists / notExists", () => {
+    it("exists() returns an ExistsCondition", () => {
+      const sub = setupQb(Post, "p").select(["id"]);
+      const cond = exists(sub);
+      expect(isExistsCondition(cond)).toBe(true);
+      expect(cond).toBeInstanceOf(ExistsCondition);
+      expect(cond.negated).toBe(false);
+    });
+
+    it("notExists() returns a negated ExistsCondition", () => {
+      const sub = setupQb(Post, "p").select(["id"]);
+      const cond = notExists(sub);
+      expect(cond.negated).toBe(true);
+    });
+
+    it("EXISTS subquery renders in WHERE", () => {
+      const outer = setupQb(User, "u");
+      const subAuthors = setupQb(Post, "p").select(["id"]);
+      outer.where(Expressions.exists(subAuthors));
+      const { text } = outer.getSql();
+      expect(text).toMatch(/WHERE EXISTS \(/);
+    });
+
+    it("NOT EXISTS subquery renders in WHERE", () => {
+      const outer = setupQb(User, "u");
+      const subAuthors = setupQb(Post, "p").select(["id"]);
+      outer.where(Expressions.notExists(subAuthors));
+      const { text } = outer.getSql();
+      expect(text).toMatch(/WHERE NOT EXISTS \(/);
+    });
+
+    it(".not() on ExistsCondition toggles negation (no double wrap)", () => {
+      const sub = setupQb(Post, "p").select(["id"]);
+      const c1 = exists(sub);
+      const c2 = c1.not();
+      expect(c2).toBeInstanceOf(ExistsCondition);
+      expect((c2 as ExistsCondition).negated).toBe(true);
+      // Second negation flips back.
+      const c3 = (c2 as ExistsCondition).not();
+      expect((c3 as ExistsCondition).negated).toBe(false);
+    });
+
+    it("exists condition composes with Expressions.and", () => {
+      const u = qAlias(User, "u");
+      const outer = setupQb(User, "u");
+      const sub = setupQb(Post, "p").select(["id"]);
+      outer.where(
+        Expressions.and(u.status.eq("active"), Expressions.exists(sub)),
+      );
+      const { text } = outer.getSql();
+      expect(text).toContain(`"u"."status" =`);
+      expect(text).toContain("EXISTS (");
+      expect(text).toContain(" AND ");
+    });
+
+    it("exists() throws on non-subquery argument", () => {
+      expect(() => exists({} as any)).toThrow(
+        /SelectQueryBuilder-like/,
+      );
+    });
+
+    it("preserves subquery parameter bindings", () => {
+      const outer = setupQb(User, "u");
+      const p = qAlias(Post, "p");
+      const sub = setupQb(Post, "p")
+        .select(["id"])
+        .where(p.status.eq("published"))
+        .where(p.views.gte(100));
+
+      outer.where(Expressions.exists(sub));
+      const { values } = outer.getSql();
+      expect(values).toContain("published");
+      expect(values).toContain(100);
+    });
+  });
+});

--- a/__tests__/unit/qdsl-tier2-temporal.test.ts
+++ b/__tests__/unit/qdsl-tier2-temporal.test.ts
@@ -1,0 +1,174 @@
+import "reflect-metadata";
+import { SelectQueryBuilder, qAlias } from "../../src/core/SelectQueryBuilder";
+import { Entity, PrimaryGeneratedColumn, Column } from "../../src/decorators";
+import { EntityManager } from "../../src/core/EntityManager";
+import { RelationMetadataResolver } from "../../src/core/RelationMetadataResolver";
+import { createDialectExpression } from "../../src/dialects/DialectExpression";
+import {
+  currentDate,
+  currentTime,
+  currentTimestamp,
+} from "../../src/core/expressions/TemporalExpression";
+import {
+  ScalarExpression,
+  isScalarExpression,
+} from "../../src/core/expressions/ScalarExpression";
+import { Expressions } from "../../src/core/expressions/LogicalCondition";
+
+@Entity()
+class Session {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @Column({ type: "datetime" })
+  createdAt!: Date;
+
+  @Column({ type: "datetime" })
+  expiresAt!: Date;
+}
+
+type DbType = "mysql" | "postgresql" | "sqlite";
+
+function createMockEm(dbType: DbType = "postgresql") {
+  const resolver = new RelationMetadataResolver();
+  function wrap(col: string) {
+    if (dbType === "mysql") return `\`${col.replace(/`/g, "``")}\``;
+    return `"${col.replace(/"/g, '""')}"`;
+  }
+  return {
+    wrap,
+    wrapTable: (t: string) => wrap(t),
+    resolver,
+    _ctx: {
+      isMySqlFamily: () => dbType === "mysql",
+      isPostgres: () => dbType === "postgresql",
+      isSqlite: () => dbType === "sqlite",
+      getDialect: () =>
+        dbType === "mysql" ? "mysql" : dbType === "sqlite" ? "sqlite" : "postgresql",
+    },
+  } as unknown as EntityManager;
+}
+
+function createQb(dbType: DbType = "postgresql") {
+  const em = createMockEm(dbType);
+  const qb = new SelectQueryBuilder<Session>(Session, "s", em);
+  const resolver = (em as any).resolver as RelationMetadataResolver;
+  const meta = resolver.resolveEntityMetadata(Session);
+  if (meta) {
+    const map = new Map<string, string>();
+    for (const c of meta.columns) {
+      map.set((c as any).propertyKey ?? c.name!, c.name!);
+    }
+    qb.setPropertyToColumnMap(map);
+  }
+  const dialectName = dbType === "postgresql" ? "postgres" : dbType;
+  qb.setDialectExpression(createDialectExpression(dialectName));
+  return qb;
+}
+
+describe("Temporal helpers — currentDate / currentTime / currentTimestamp (QueryDSL Tier 2)", () => {
+  describe("factories", () => {
+    it("currentDate() returns a ScalarExpression", () => {
+      const expr = currentDate();
+      expect(isScalarExpression(expr)).toBe(true);
+      expect(expr).toBeInstanceOf(ScalarExpression);
+    });
+
+    it("currentTime() returns a ScalarExpression", () => {
+      expect(isScalarExpression(currentTime())).toBe(true);
+    });
+
+    it("currentTimestamp() returns a ScalarExpression", () => {
+      expect(isScalarExpression(currentTimestamp())).toBe(true);
+    });
+  });
+
+  describe("SQL rendering — dialect-independent", () => {
+    const check = (dbType: DbType) => {
+      const qb = createQb(dbType);
+      qb.select([
+        currentDate().as("today"),
+        currentTime().as("now_t"),
+        currentTimestamp().as("now_ts"),
+      ]);
+      return qb.getSql().text;
+    };
+
+    it("emits CURRENT_DATE / CURRENT_TIME / CURRENT_TIMESTAMP on PostgreSQL", () => {
+      const text = check("postgresql");
+      expect(text).toContain("CURRENT_DATE");
+      expect(text).toContain("CURRENT_TIME");
+      expect(text).toContain("CURRENT_TIMESTAMP");
+    });
+
+    it("emits the same literals on MySQL", () => {
+      const text = check("mysql");
+      expect(text).toContain("CURRENT_DATE");
+      expect(text).toContain("CURRENT_TIME");
+      expect(text).toContain("CURRENT_TIMESTAMP");
+    });
+
+    it("emits the same literals on SQLite", () => {
+      const text = check("sqlite");
+      expect(text).toContain("CURRENT_DATE");
+      expect(text).toContain("CURRENT_TIME");
+      expect(text).toContain("CURRENT_TIMESTAMP");
+    });
+  });
+
+  describe("WHERE / HAVING usage", () => {
+    it("supports currentTimestamp() as a comparison operand via ColumnExpression", () => {
+      const s = qAlias(Session, "s");
+      const qb = createQb();
+      qb.where(s.expiresAt.gte(currentTimestamp()));
+      const { text } = qb.getSql();
+      // Current-value operand is sent inline (no binding for CURRENT_TIMESTAMP itself);
+      // the column reference qualifies through the alias registry.
+      expect(text).toContain(`"s"."expiresAt" >= `);
+      // CURRENT_TIMESTAMP literal may end up serialized through a
+      // placeholder if the dialect treats ScalarExpression as a value —
+      // assert its presence either in SQL text or in the bound values
+      // array.
+      const { values } = qb.getSql();
+      const hasLiteral =
+        text.includes("CURRENT_TIMESTAMP") ||
+        (values as unknown[]).some(
+          (v) =>
+            typeof v === "object" &&
+            v !== null &&
+            (v as { sql?: unknown }).sql === "CURRENT_TIMESTAMP",
+        );
+      expect(hasLiteral).toBe(true);
+    });
+  });
+
+  describe("composition with ScalarCondition", () => {
+    it("currentDate().eq(x) builds a ScalarCondition", () => {
+      const qb = createQb();
+      qb.where(currentDate().eq("2026-04-18"));
+      const { text, values } = qb.getSql();
+      expect(text).toContain("CURRENT_DATE = ");
+      expect(values).toContain("2026-04-18");
+    });
+  });
+
+  describe("Expressions namespace", () => {
+    it("Expressions.currentDate() delegates to currentDate()", () => {
+      const qb = createQb();
+      qb.select([Expressions.currentDate().as("d")]);
+      expect(qb.getSql().text).toContain(`CURRENT_DATE AS "d"`);
+    });
+
+    it("Expressions.currentTime() delegates", () => {
+      const qb = createQb();
+      qb.select([Expressions.currentTime().as("t")]);
+      expect(qb.getSql().text).toContain(`CURRENT_TIME AS "t"`);
+    });
+
+    it("Expressions.currentTimestamp() delegates", () => {
+      const qb = createQb();
+      qb.select([Expressions.currentTimestamp().as("ts")]);
+      expect(qb.getSql().text).toContain(`CURRENT_TIMESTAMP AS "ts"`);
+    });
+  });
+});

--- a/docs/ko/query-builder.md
+++ b/docs/ko/query-builder.md
@@ -518,6 +518,33 @@ JSON 경로 별칭은 드라이버의 텍스트 추출 연산자(`#>>` / `JSON_U
 
 `addSelect(u.age.as("years"))`로 기존 SELECT 목록 뒤에 덧붙일 수도 있고, 한 번의 `select([...])`에 별칭 컬럼과 집계를 섞어 넣어도 돼요.
 
+##### null 처리 — `coalesce()` / `nullif()`
+
+`coalesce(a, b, c, …)`는 왼쪽에서 오른쪽으로 처음 non-null인 값을 반환해요. `nullif(a, b)`는 `a`가 `b`와 같으면 `NULL`, 아니면 `a`를 돌려주죠. 빈 문자열이나 `-1` 같은 센티넬 값을 진짜 NULL로 바꾸고 싶을 때 쓰세요. 둘 다 표준 SQL이어서 드라이버 구분 없이 그대로 써요.
+
+```typescript
+import { coalesce, nullif, Expressions, qAlias } from "@stingerloom/orm";
+
+const u = qAlias(User, "u");
+
+// 닉네임 → 이름 → 기본값 순으로 fallback
+qb.select([
+  u.nickname.coalesce(u.name, "anonymous").as("display_name"),
+]);
+// SELECT COALESCE("u"."nickname", "u"."name", ?) AS "display_name"
+
+// 빈 이메일은 NULL로
+qb.select([nullif(u.email, "").as("email_or_null")]);
+
+// WHERE / HAVING에서도 그대로 사용
+qb.where(coalesce(u.score, 0).gte(50));
+// WHERE COALESCE("u"."score", ?) >= ?
+```
+
+인자 자리에는 컬럼, JSON 경로 추출(`u.metadata.profile.tier`), 집계(`u.id.count()`), 중첩된 다른 `coalesce`, 원시 값 무엇이든 섞어 쓸 수 있어요. 값은 자동으로 바인딩돼서 안전하고요. 결과는 `ScalarExpression`이어서 `.eq()` / `.gt()` / `.as()`를 바로 이어 붙일 수 있어요.
+
+정적 헬퍼로는 `Expressions.coalesce` / `Expressions.nullif`를 제공해요. Java QueryDSL의 `Expressions.*` 스타일을 선호하면 이쪽을 쓰면 돼요.
+
 ##### 조건 묶기 — `.and()` / `.or()` / `.not()`
 
 조건 두 개를 AND로 묶거나, OR로 풀거나, 부정할 수 있어요.
@@ -617,6 +644,7 @@ qb.where(u.name.likeIgnoreCase("%Al%"));          // 와일드카드를 직접 �
 | 값 집계                   | `.count()`, `.countDistinct()`, `.sum()`, `.avg()`, `.min()`, `.max()`        |
 | 집계 결과로 필터          | 집계 뒤에 `.gt(10)`, `.eq(0)`, `.between(1, 100)` 등 평소대로                 |
 | SELECT 별칭               | `.as("name")` — 컬럼 / JSON 경로 / 집계 어디에든 붙여서 `AliasedExpression` 반환 |
+| null fallback             | `coalesce(...)`, `col.coalesce(...)`, `nullif(a, b)` — 첫 non-null 값 / 일치 시 NULL 변환 |
 | 조건 묶기                 | `.and(other)`, `.or(other)`, `.not()`                                         |
 | 그룹을 직접 짜고 싶을 때  | `Expressions.and(...)`, `Expressions.or(...)`, `Expressions.not(cond)`        |
 | 안전한 prefix / suffix / 포함 | `.startsWith`, `.endsWith`, `.contains` (LIKE 특수문자 자동 이스케이프)   |

--- a/docs/ko/query-builder.md
+++ b/docs/ko/query-builder.md
@@ -563,6 +563,32 @@ qb.select([Expressions.currentDate().as("today")]);
 
 `ColumnExpression`의 비교 메서드는 인자가 `ScalarExpression`이면 자동으로 풀어서 인라인으로 넣어요. 그래서 `u.createdAt.lte(currentTimestamp())`처럼 써도 파라미터 바인딩이 아니라 `CURRENT_TIMESTAMP`가 그대로 SQL에 박혀요.
 
+##### 타입 변환 — `.stringValue()` / `.intValue()` / `.longValue()` / `.floatValue()` / `.booleanValue()`
+
+컬럼이나 스칼라 표현식을 다른 SQL 타입으로 CAST해요. 드라이버별로 받는 타입명이 다르기 때문에(MySQL은 `INTEGER` 대신 `SIGNED`, SQLite는 `BOOLEAN` 대신 `INTEGER`) 메서드 이름만 기억하면 나머지는 자동으로 처리돼요.
+
+```typescript
+const i = qAlias(Item, "i");
+
+qb.select([i.quantity.stringValue().as("qty_str")]);
+// PG/SQLite:  CAST("i"."quantity" AS TEXT) AS "qty_str"
+// MySQL:      CAST(`i`.`quantity` AS CHAR)  AS `qty_str`
+
+qb.where(i.sku.intValue().gt(1000));
+// PG/SQLite:  CAST("i"."sku" AS INTEGER) > ?
+// MySQL:      CAST(`i`.`sku` AS SIGNED)  > ?
+```
+
+CAST 헬퍼는 `ColumnExpression`과 `ScalarExpression` 양쪽에 다 달려 있어요. `coalesce(u.price, 0).floatValue()`처럼 이미 파생된 스칼라에도 이어 붙일 수 있고, 결과도 `ScalarExpression`이라 `.as()` / `.eq()` / 중첩된 `coalesce`에 그대로 쓸 수 있어요.
+
+| Kind     | MySQL      | PostgreSQL | SQLite    |
+|----------|------------|------------|-----------|
+| string   | `CHAR`     | `TEXT`     | `TEXT`    |
+| int      | `SIGNED`   | `INTEGER`  | `INTEGER` |
+| long     | `SIGNED`   | `BIGINT`   | `INTEGER` |
+| float    | `DECIMAL`  | `REAL`     | `REAL`    |
+| boolean  | `UNSIGNED` | `BOOLEAN`  | `INTEGER` |
+
 ##### 조건 묶기 — `.and()` / `.or()` / `.not()`
 
 조건 두 개를 AND로 묶거나, OR로 풀거나, 부정할 수 있어요.
@@ -664,6 +690,7 @@ qb.where(u.name.likeIgnoreCase("%Al%"));          // 와일드카드를 직접 �
 | SELECT 별칭               | `.as("name")` — 컬럼 / JSON 경로 / 집계 어디에든 붙여서 `AliasedExpression` 반환 |
 | null fallback             | `coalesce(...)`, `col.coalesce(...)`, `nullif(a, b)` — 첫 non-null 값 / 일치 시 NULL 변환 |
 | 현재 날짜 / 시각          | `currentDate()`, `currentTime()`, `currentTimestamp()` — `Expressions`에도 있음                 |
+| 타입 변환                 | `.stringValue()`, `.intValue()`, `.longValue()`, `.floatValue()`, `.booleanValue()`             |
 | 조건 묶기                 | `.and(other)`, `.or(other)`, `.not()`                                         |
 | 그룹을 직접 짜고 싶을 때  | `Expressions.and(...)`, `Expressions.or(...)`, `Expressions.not(cond)`        |
 | 안전한 prefix / suffix / 포함 | `.startsWith`, `.endsWith`, `.contains` (LIKE 특수문자 자동 이스케이프)   |

--- a/docs/ko/query-builder.md
+++ b/docs/ko/query-builder.md
@@ -545,6 +545,24 @@ qb.where(coalesce(u.score, 0).gte(50));
 
 정적 헬퍼로는 `Expressions.coalesce` / `Expressions.nullif`를 제공해요. Java QueryDSL의 `Expressions.*` 스타일을 선호하면 이쪽을 쓰면 돼요.
 
+##### 현재 시각 — `currentDate()` / `currentTime()` / `currentTimestamp()`
+
+DB 서버의 시계를 어느 자리에든 넣을 수 있는 세 개의 표준 SQL 헬퍼예요. 결과는 `ScalarExpression`이라 `.as()` / `.eq()` / `coalesce`에 중첩 등 지금까지 본 합성이 전부 그대로 돼요. 드라이버 차이 없이 동일한 리터럴(`CURRENT_DATE` / `CURRENT_TIME` / `CURRENT_TIMESTAMP`)로 나가요.
+
+```typescript
+import { Expressions, qAlias } from "@stingerloom/orm";
+
+const s = qAlias(Session, "s");
+
+qb.where(s.expiresAt.gte(Expressions.currentTimestamp()));
+// WHERE "s"."expires_at" >= CURRENT_TIMESTAMP
+
+qb.select([Expressions.currentDate().as("today")]);
+// SELECT CURRENT_DATE AS "today"
+```
+
+`ColumnExpression`의 비교 메서드는 인자가 `ScalarExpression`이면 자동으로 풀어서 인라인으로 넣어요. 그래서 `u.createdAt.lte(currentTimestamp())`처럼 써도 파라미터 바인딩이 아니라 `CURRENT_TIMESTAMP`가 그대로 SQL에 박혀요.
+
 ##### 조건 묶기 — `.and()` / `.or()` / `.not()`
 
 조건 두 개를 AND로 묶거나, OR로 풀거나, 부정할 수 있어요.
@@ -645,6 +663,7 @@ qb.where(u.name.likeIgnoreCase("%Al%"));          // 와일드카드를 직접 �
 | 집계 결과로 필터          | 집계 뒤에 `.gt(10)`, `.eq(0)`, `.between(1, 100)` 등 평소대로                 |
 | SELECT 별칭               | `.as("name")` — 컬럼 / JSON 경로 / 집계 어디에든 붙여서 `AliasedExpression` 반환 |
 | null fallback             | `coalesce(...)`, `col.coalesce(...)`, `nullif(a, b)` — 첫 non-null 값 / 일치 시 NULL 변환 |
+| 현재 날짜 / 시각          | `currentDate()`, `currentTime()`, `currentTimestamp()` — `Expressions`에도 있음                 |
 | 조건 묶기                 | `.and(other)`, `.or(other)`, `.not()`                                         |
 | 그룹을 직접 짜고 싶을 때  | `Expressions.and(...)`, `Expressions.or(...)`, `Expressions.not(cond)`        |
 | 안전한 prefix / suffix / 포함 | `.startsWith`, `.endsWith`, `.contains` (LIKE 특수문자 자동 이스케이프)   |

--- a/docs/ko/query-builder.md
+++ b/docs/ko/query-builder.md
@@ -620,6 +620,44 @@ qb.select([e.startsAt.year().as("yr"), e.id.count().as("total")])
 
 `dayOfWeek`와 `week`는 드라이버마다 인코딩이 살짝 달라요 — MySQL의 `DAYOFWEEK`은 1=일…7=토, PostgreSQL의 `DOW`는 0=일…6=토, SQLite의 `%w`는 PG와 같아요. 리포트 이식성이 중요하면 애플리케이션 계층에서 정규화하거나, 드라이버별 raw SQL을 쓰는 편이 안전해요.
 
+##### 서브쿼리 비교 — `.in(subquery)` / `.eq(subquery)` / `exists` / `notExists`
+
+`ColumnExpression.in()` / `.notIn()`은 값 배열뿐 아니라 `SelectQueryBuilder`도 받아요. 서브쿼리를 넘기면 `col IN (SELECT …)` 형태로 내려가고, 안쪽 파라미터 바인딩까지 그대로 보존돼요. `.eq` / `.neq` / `.gt` / `.gte` / `.lt` / `.lte`도 마찬가지로 (단일 값 반환) 서브쿼리를 받아 `col <op> (SELECT …)` 로 만들어요.
+
+```typescript
+const u = qAlias(User, "u");
+const p = qAlias(Post, "p");
+
+const activeAuthors = em
+  .createQueryBuilder(Post, "p")
+  .select(["authorId"])
+  .where(p.status.eq("published"));
+
+qb.where(u.id.in(activeAuthors));
+// WHERE "u"."id" IN (SELECT "p"."authorId" FROM "post" AS "p"
+//                     WHERE "p"."status" = ?)
+
+// 스칼라 서브쿼리 — 집계와 비교
+const avgViews = em
+  .createQueryBuilder(Post, "p2")
+  .selectRaw(["AVG(p2.views)"]);
+
+qb.where(p.views.gt(avgViews));
+// WHERE "p"."views" > (SELECT AVG(p2.views) FROM …)
+```
+
+`Expressions.exists(subQb)` / `Expressions.notExists(subQb)`는 상관 서브쿼리 조건을 만들어요.
+
+```typescript
+qb.where(Expressions.exists(em.createQueryBuilder(Post, "p")
+  .select(["id"])
+  .where(sql`"p"."author_id" = "u"."id"`)));
+// WHERE EXISTS (SELECT "id" FROM "post" AS "p"
+//                WHERE "p"."author_id" = "u"."id")
+```
+
+`ExistsCondition.not()`은 `NOT (…)`으로 감싸지 않고 내부의 `EXISTS` ↔ `NOT EXISTS` 플래그만 뒤집어요. SQL이 깔끔하게 나와요.
+
 ##### 조건 묶기 — `.and()` / `.or()` / `.not()`
 
 조건 두 개를 AND로 묶거나, OR로 풀거나, 부정할 수 있어요.
@@ -723,6 +761,7 @@ qb.where(u.name.likeIgnoreCase("%Al%"));          // 와일드카드를 직접 �
 | 현재 날짜 / 시각          | `currentDate()`, `currentTime()`, `currentTimestamp()` — `Expressions`에도 있음                 |
 | 타입 변환                 | `.stringValue()`, `.intValue()`, `.longValue()`, `.floatValue()`, `.booleanValue()`             |
 | 날짜 컴포넌트             | `.year()`, `.month()`, `.day()`, `.hour()`, `.minute()`, `.second()`, `.dayOfWeek()`, `.dayOfYear()`, `.week()` |
+| 서브쿼리 비교             | `.in(subQb)`, `.notIn(subQb)`, `.eq/.neq/.gt/.gte/.lt/.lte(subQb)`, `Expressions.exists`, `Expressions.notExists` |
 | 조건 묶기                 | `.and(other)`, `.or(other)`, `.not()`                                         |
 | 그룹을 직접 짜고 싶을 때  | `Expressions.and(...)`, `Expressions.or(...)`, `Expressions.not(cond)`        |
 | 안전한 prefix / suffix / 포함 | `.startsWith`, `.endsWith`, `.contains` (LIKE 특수문자 자동 이스케이프)   |

--- a/docs/ko/query-builder.md
+++ b/docs/ko/query-builder.md
@@ -497,6 +497,27 @@ SELECT에 넣을 때 `.as("total")`을 권장해요. 생략하면 `agg_count_id`
 
 중복을 빼고 세고 싶으면 `.countDistinct()`를 쓰세요. `COUNT(DISTINCT u.role)`이 나와요.
 
+##### SELECT 별칭 — `.as("name")`
+
+일반 컬럼, JSON 경로, 집계 어느 것에든 `.as("name")`을 붙일 수 있어요. 결과는 `AliasedExpression`이고 SELECT 자리에서만 의미가 있어요. `where()`나 `having()`에는 넘길 수 없도록 타입으로 막혀 있어요.
+
+```typescript
+const u = qAlias(User, "u");
+
+await em.createQueryBuilder(User, "u")
+  .select([
+    u.name.as("display_name"),                 // 그냥 컬럼 별칭
+    u.metadata.profile.email.as("contact"),    // JSON 추출 + 별칭
+    u.id.count().as("total"),                  // 집계 + 별칭
+  ])
+  .groupBy(["u.name", "u.metadata"])
+  .getRawMany();
+```
+
+JSON 경로 별칭은 드라이버의 텍스트 추출 연산자(`#>>` / `JSON_UNQUOTE(JSON_EXTRACT(...))` / `json_extract()`)로 컴파일되고, 경로 문자열은 바인딩 파라미터로 붙어서 `getRawMany()` 직렬화 과정에서도 안전하게 보존돼요.
+
+`addSelect(u.age.as("years"))`로 기존 SELECT 목록 뒤에 덧붙일 수도 있고, 한 번의 `select([...])`에 별칭 컬럼과 집계를 섞어 넣어도 돼요.
+
 ##### 조건 묶기 — `.and()` / `.or()` / `.not()`
 
 조건 두 개를 AND로 묶거나, OR로 풀거나, 부정할 수 있어요.
@@ -595,6 +616,7 @@ qb.where(u.name.likeIgnoreCase("%Al%"));          // 와일드카드를 직접 �
 | null 위치 지정            | 위 두 개에 이어서 `.nullsFirst()` / `.nullsLast()`                            |
 | 값 집계                   | `.count()`, `.countDistinct()`, `.sum()`, `.avg()`, `.min()`, `.max()`        |
 | 집계 결과로 필터          | 집계 뒤에 `.gt(10)`, `.eq(0)`, `.between(1, 100)` 등 평소대로                 |
+| SELECT 별칭               | `.as("name")` — 컬럼 / JSON 경로 / 집계 어디에든 붙여서 `AliasedExpression` 반환 |
 | 조건 묶기                 | `.and(other)`, `.or(other)`, `.not()`                                         |
 | 그룹을 직접 짜고 싶을 때  | `Expressions.and(...)`, `Expressions.or(...)`, `Expressions.not(cond)`        |
 | 안전한 prefix / suffix / 포함 | `.startsWith`, `.endsWith`, `.contains` (LIKE 특수문자 자동 이스케이프)   |

--- a/docs/ko/query-builder.md
+++ b/docs/ko/query-builder.md
@@ -658,6 +658,46 @@ qb.where(Expressions.exists(em.createQueryBuilder(Post, "p")
 
 `ExistsCondition.not()`은 `NOT (…)`으로 감싸지 않고 내부의 `EXISTS` ↔ `NOT EXISTS` 플래그만 뒤집어요. SQL이 깔끔하게 나와요.
 
+##### `CASE WHEN …` — `Expressions.caseBuilder()` / `Expressions.cases(...)`
+
+SQL이 지원하는 두 종류의 CASE를 각각 전용 빌더로 제공해요.
+
+**Searched CASE** — `caseBuilder()`. 조건 체인 형태로 쓰면 돼요. 각 분기는 `ConditionLike` + 결과값 쌍이고, 마지막에 `otherwise(default)`를 선택적으로 달고 `.end()`로 마무리해요.
+
+```typescript
+const u = qAlias(User, "u");
+
+const tier = Expressions.caseBuilder()
+  .when(u.score.gte(90)).then("gold")
+  .when(u.score.gte(70)).then("silver")
+  .otherwise("bronze")
+  .end();
+
+qb.select([tier.as("tier")]);
+// SELECT CASE WHEN "u"."score" >= ? THEN ?
+//             WHEN "u"."score" >= ? THEN ?
+//             ELSE ? END AS "tier"
+```
+
+**Simple CASE** — `cases(subject)`. 값 매칭 스위치 스타일이에요.
+
+```typescript
+const weight = Expressions.cases(u.status)
+  .when("active",  1)
+  .when("pending", 0)
+  .otherwise(-1)
+  .end();
+
+qb.select([weight.as("w")]);
+// SELECT CASE "u"."status" WHEN ? THEN ?
+//                           WHEN ? THEN ?
+//                           ELSE ? END AS "w"
+```
+
+`end()`은 `ScalarExpression`을 돌려주니까 지금까지 본 모든 연산(cast / alias / 비교 / coalesce 등)에 그대로 이어 붙일 수 있어요.
+
+오용 방어도 들어가 있어요. `.otherwise()` 뒤의 `.when()`, 중복 `.otherwise()`, WHEN 없이 `.end()` — 이 세 경우는 명확한 에러 메시지로 막히니까, 잘못된 SQL이 쿼리 실행까지 가지 않아요.
+
 ##### 조건 묶기 — `.and()` / `.or()` / `.not()`
 
 조건 두 개를 AND로 묶거나, OR로 풀거나, 부정할 수 있어요.
@@ -762,6 +802,7 @@ qb.where(u.name.likeIgnoreCase("%Al%"));          // 와일드카드를 직접 �
 | 타입 변환                 | `.stringValue()`, `.intValue()`, `.longValue()`, `.floatValue()`, `.booleanValue()`             |
 | 날짜 컴포넌트             | `.year()`, `.month()`, `.day()`, `.hour()`, `.minute()`, `.second()`, `.dayOfWeek()`, `.dayOfYear()`, `.week()` |
 | 서브쿼리 비교             | `.in(subQb)`, `.notIn(subQb)`, `.eq/.neq/.gt/.gte/.lt/.lte(subQb)`, `Expressions.exists`, `Expressions.notExists` |
+| CASE 표현식               | `Expressions.caseBuilder().when(...).then(...).otherwise(...).end()`; `Expressions.cases(subject)...end()`     |
 | 조건 묶기                 | `.and(other)`, `.or(other)`, `.not()`                                         |
 | 그룹을 직접 짜고 싶을 때  | `Expressions.and(...)`, `Expressions.or(...)`, `Expressions.not(cond)`        |
 | 안전한 prefix / suffix / 포함 | `.startsWith`, `.endsWith`, `.contains` (LIKE 특수문자 자동 이스케이프)   |

--- a/docs/ko/query-builder.md
+++ b/docs/ko/query-builder.md
@@ -589,6 +589,37 @@ CAST 헬퍼는 `ColumnExpression`과 `ScalarExpression` 양쪽에 다 달려 있
 | float    | `DECIMAL`  | `REAL`     | `REAL`    |
 | boolean  | `UNSIGNED` | `BOOLEAN`  | `INTEGER` |
 
+##### 날짜 / 시각 컴포넌트 — `.year()` / `.month()` / `.day()` / `.hour()` / …
+
+날짜나 타임스탬프 컬럼에서 일부 성분만 뽑아낼 수 있어요. 10개 메서드가 있어요: `year`, `month`, `day`(= `dayOfMonth`), `hour`, `minute`, `second`, `dayOfWeek`, `dayOfMonth`, `dayOfYear`, `week`. 결과는 `ScalarExpression`이라 SELECT / WHERE / HAVING에 모두 쓸 수 있고, `.as()` / cast / coalesce와 바로 이어 붙일 수 있어요.
+
+```typescript
+const e = qAlias(Event, "e");
+
+qb.select([e.startsAt.year().as("yr"), e.id.count().as("total")])
+  .groupBy(["e.startsAt"])
+  .having(e.startsAt.year().gte(2026));
+// PG:     CAST(EXTRACT(YEAR FROM "e"."starts_at") AS INTEGER) = ?
+// MySQL:  YEAR(`e`.`starts_at`) = ?
+// SQLite: CAST(strftime(?, "e"."starts_at") AS INTEGER) = ?   -- '%Y'
+```
+
+드라이버별 SQL 생성:
+
+| 헬퍼 | MySQL | PostgreSQL | SQLite |
+|------|-------|------------|--------|
+| `year()` | `YEAR(col)` | `EXTRACT(YEAR FROM col)` | `strftime('%Y', col)` |
+| `month()` | `MONTH(col)` | `EXTRACT(MONTH FROM col)` | `strftime('%m', col)` |
+| `day()` / `dayOfMonth()` | `DAYOFMONTH(col)` | `EXTRACT(DAY FROM col)` | `strftime('%d', col)` |
+| `hour()` | `HOUR(col)` | `EXTRACT(HOUR FROM col)` | `strftime('%H', col)` |
+| `minute()` | `MINUTE(col)` | `EXTRACT(MINUTE FROM col)` | `strftime('%M', col)` |
+| `second()` | `SECOND(col)` | `EXTRACT(SECOND FROM col)` | `strftime('%S', col)` |
+| `dayOfWeek()` | `DAYOFWEEK(col)` | `EXTRACT(DOW FROM col)` | `strftime('%w', col)` |
+| `dayOfYear()` | `DAYOFYEAR(col)` | `EXTRACT(DOY FROM col)` | `strftime('%j', col)` |
+| `week()` | `WEEK(col)` | `EXTRACT(WEEK FROM col)` | `strftime('%W', col)` |
+
+`dayOfWeek`와 `week`는 드라이버마다 인코딩이 살짝 달라요 — MySQL의 `DAYOFWEEK`은 1=일…7=토, PostgreSQL의 `DOW`는 0=일…6=토, SQLite의 `%w`는 PG와 같아요. 리포트 이식성이 중요하면 애플리케이션 계층에서 정규화하거나, 드라이버별 raw SQL을 쓰는 편이 안전해요.
+
 ##### 조건 묶기 — `.and()` / `.or()` / `.not()`
 
 조건 두 개를 AND로 묶거나, OR로 풀거나, 부정할 수 있어요.
@@ -691,6 +722,7 @@ qb.where(u.name.likeIgnoreCase("%Al%"));          // 와일드카드를 직접 �
 | null fallback             | `coalesce(...)`, `col.coalesce(...)`, `nullif(a, b)` — 첫 non-null 값 / 일치 시 NULL 변환 |
 | 현재 날짜 / 시각          | `currentDate()`, `currentTime()`, `currentTimestamp()` — `Expressions`에도 있음                 |
 | 타입 변환                 | `.stringValue()`, `.intValue()`, `.longValue()`, `.floatValue()`, `.booleanValue()`             |
+| 날짜 컴포넌트             | `.year()`, `.month()`, `.day()`, `.hour()`, `.minute()`, `.second()`, `.dayOfWeek()`, `.dayOfYear()`, `.week()` |
 | 조건 묶기                 | `.and(other)`, `.or(other)`, `.not()`                                         |
 | 그룹을 직접 짜고 싶을 때  | `Expressions.and(...)`, `Expressions.or(...)`, `Expressions.not(cond)`        |
 | 안전한 prefix / suffix / 포함 | `.startsWith`, `.endsWith`, `.contains` (LIKE 특수문자 자동 이스케이프)   |

--- a/docs/query-builder.md
+++ b/docs/query-builder.md
@@ -693,6 +693,46 @@ without anything special.
 | float    | `DECIMAL`  | `REAL`     | `REAL`    |
 | boolean  | `UNSIGNED` | `BOOLEAN`  | `INTEGER` |
 
+##### Date / time components — `.year()` / `.month()` / `.day()` / `.hour()` / …
+
+Extract a component from a date or timestamp column. Ten helpers
+cover the common shapes — year, month, day (alias of `dayOfMonth`),
+hour, minute, second, `dayOfWeek`, `dayOfMonth`, `dayOfYear`, `week`.
+Each returns a `ScalarExpression`, so they drop into SELECT, WHERE,
+HAVING, chain into `.as()`, and compose with cast/coalesce.
+
+```typescript
+const e = qAlias(Event, "e");
+
+// Count events per year
+qb.select([e.startsAt.year().as("yr"), e.id.count().as("total")])
+  .groupBy(["e.startsAt"])
+  .having(e.startsAt.year().gte(2026));
+// PG:     CAST(EXTRACT(YEAR FROM "e"."starts_at") AS INTEGER) = ?
+// MySQL:  YEAR(`e`.`starts_at`) = ?
+// SQLite: CAST(strftime(?, "e"."starts_at") AS INTEGER) = ?   -- '%Y'
+```
+
+Dialect-specific emission (the caller never sees the difference):
+
+| Helper | MySQL | PostgreSQL | SQLite |
+|--------|-------|------------|--------|
+| `year()` | `YEAR(col)` | `EXTRACT(YEAR FROM col)` | `strftime('%Y', col)` |
+| `month()` | `MONTH(col)` | `EXTRACT(MONTH FROM col)` | `strftime('%m', col)` |
+| `day()` / `dayOfMonth()` | `DAYOFMONTH(col)` | `EXTRACT(DAY FROM col)` | `strftime('%d', col)` |
+| `hour()` | `HOUR(col)` | `EXTRACT(HOUR FROM col)` | `strftime('%H', col)` |
+| `minute()` | `MINUTE(col)` | `EXTRACT(MINUTE FROM col)` | `strftime('%M', col)` |
+| `second()` | `SECOND(col)` | `EXTRACT(SECOND FROM col)` | `strftime('%S', col)` |
+| `dayOfWeek()` | `DAYOFWEEK(col)` | `EXTRACT(DOW FROM col)` | `strftime('%w', col)` |
+| `dayOfYear()` | `DAYOFYEAR(col)` | `EXTRACT(DOY FROM col)` | `strftime('%j', col)` |
+| `week()` | `WEEK(col)` | `EXTRACT(WEEK FROM col)` | `strftime('%W', col)` |
+
+`dayOfWeek` and `week` encodings differ slightly between engines —
+MySQL uses `1=Sun…7=Sat` for `DAYOFWEEK`, PostgreSQL `0=Sun…6=Sat`
+for `DOW`, and SQLite matches PostgreSQL via `%w`. If portability
+within your reports matters, normalize in the application layer or
+use dialect-specific raw SQL.
+
 ##### Logical composition — `.and()` / `.or()` / `.not()` + `Expressions`
 
 ```typescript
@@ -790,6 +830,7 @@ Method summary:
 | Null handling         | `coalesce(…)`, `nullif(a, b)`, `col.coalesce(…)`, `Expressions.coalesce`, `Expressions.nullif` |
 | Current date / time   | `currentDate()`, `currentTime()`, `currentTimestamp()` — also on `Expressions`                 |
 | Type casts            | `.stringValue()`, `.intValue()`, `.longValue()`, `.floatValue()`, `.booleanValue()` — dialect-specific type names |
+| Date components       | `.year()`, `.month()`, `.day()`, `.hour()`, `.minute()`, `.second()`, `.dayOfWeek()`, `.dayOfMonth()`, `.dayOfYear()`, `.week()` |
 | Logical composition   | `ColumnCondition.and/.or/.not`, `Expressions.and`, `Expressions.or`, `Expressions.not`          |
 
 ### JOIN — Combining Tables

--- a/docs/query-builder.md
+++ b/docs/query-builder.md
@@ -563,6 +563,41 @@ that plays two roles:
 Aggregates also participate in ORDER BY via `.asc()` / `.desc()`, mirroring
 the ColumnExpression surface.
 
+##### SELECT aliases — `.as("name")` on any projectable expression
+
+`.as("alias")` works on every expression that can appear in SELECT —
+plain columns, JSON path extractions, and aggregates. The result is an
+`AliasedExpression` destined for `select()` or `addSelect()`; it is not
+a condition, so it will not compile when handed to `where()` or
+`having()`.
+
+```typescript
+const u = qAlias(User, "u");
+
+await em.createQueryBuilder(User, "u")
+  .select([
+    u.name.as("display_name"),
+    u.metadata.profile.email.as("contact"),
+    u.id.count().as("total"),
+  ])
+  .groupBy(["u.name", "u.metadata"])
+  .getRawMany();
+// SELECT "u"."name" AS "display_name",
+//        ("u"."metadata" #>> $1) AS "contact",
+//        COUNT("u"."id") AS "total"
+// …
+```
+
+JSON path aliases compile to the dialect's preferred text-extraction
+operator (`#>>` on PostgreSQL, `JSON_UNQUOTE(JSON_EXTRACT(...))` on
+MySQL, `json_extract()` on SQLite) with the path supplied as a bound
+parameter — so it survives `getRawMany()` serialization and is free of
+injection risk.
+
+`addSelect(u.age.as("years"))` appends to an existing projection; mixing
+aliased columns with aggregates in the same `select([...])` call is also
+supported.
+
 ##### Logical composition — `.and()` / `.or()` / `.not()` + `Expressions`
 
 ```typescript
@@ -656,6 +691,7 @@ Method summary:
 | String (case-insens.) | `.equalsIgnoreCase`, `.likeIgnoreCase`, `.startsWithIgnoreCase`, `.endsWithIgnoreCase`, `.containsIgnoreCase` |
 | Ordering              | `.asc()`, `.desc()`, `.nullsFirst()`, `.nullsLast()`                                            |
 | Aggregates            | `.count()`, `.countDistinct()`, `.sum()`, `.avg()`, `.min()`, `.max()` — each with `.as(alias)` and `.eq/.neq/.gt/.gte/.lt/.lte/.between` |
+| SELECT alias          | `.as("name")` on columns, JSON path extracts, and aggregates — produces `AliasedExpression` |
 | Logical composition   | `ColumnCondition.and/.or/.not`, `Expressions.and`, `Expressions.or`, `Expressions.not`          |
 
 ### JOIN — Combining Tables

--- a/docs/query-builder.md
+++ b/docs/query-builder.md
@@ -733,6 +733,53 @@ for `DOW`, and SQLite matches PostgreSQL via `%w`. If portability
 within your reports matters, normalize in the application layer or
 use dialect-specific raw SQL.
 
+##### Subquery comparisons — `.in(subquery)` / `.eq(subquery)` / `exists` / `notExists`
+
+`ColumnExpression.in()` / `.notIn()` accept either a value list
+(existing behavior) or a `SelectQueryBuilder` — the latter embeds as
+`col IN (SELECT ...)` with all inner bindings preserved. All scalar
+comparison methods (`.eq` / `.neq` / `.gt` / `.gte` / `.lt` / `.lte`)
+likewise accept a subquery and emit `col <op> (SELECT ...)` for
+one-row-one-column scalar subqueries.
+
+```typescript
+const u = qAlias(User, "u");
+const p = qAlias(Post, "p");
+
+// Users whose id appears in the authorId column of published posts
+const activeAuthors = em
+  .createQueryBuilder(Post, "p")
+  .select(["authorId"])
+  .where(p.status.eq("published"));
+
+qb.where(u.id.in(activeAuthors));
+// WHERE "u"."id" IN (SELECT "p"."authorId" FROM "post" AS "p"
+//                     WHERE "p"."status" = $1)
+
+// Scalar subquery — compare against a single aggregate
+const avgViews = em
+  .createQueryBuilder(Post, "p2")
+  .selectRaw(["AVG(p2.views)"]);
+
+qb.where(p.views.gt(avgViews));
+// WHERE "p"."views" > (SELECT AVG(p2.views) FROM …)
+```
+
+`Expressions.exists(subQb)` and `Expressions.notExists(subQb)` build
+correlated-subquery conditions:
+
+```typescript
+qb.where(Expressions.exists(em.createQueryBuilder(Post, "p")
+  .select(["id"])
+  .where(sql`"p"."author_id" = "u"."id"`)));
+// WHERE EXISTS (SELECT "id" FROM "post" AS "p"
+//                WHERE "p"."author_id" = "u"."id")
+```
+
+`ExistsCondition.not()` toggles the `EXISTS` / `NOT EXISTS` flag
+rather than wrapping in a redundant `NOT (…)`, keeping output SQL
+clean.
+
 ##### Logical composition — `.and()` / `.or()` / `.not()` + `Expressions`
 
 ```typescript
@@ -831,6 +878,7 @@ Method summary:
 | Current date / time   | `currentDate()`, `currentTime()`, `currentTimestamp()` — also on `Expressions`                 |
 | Type casts            | `.stringValue()`, `.intValue()`, `.longValue()`, `.floatValue()`, `.booleanValue()` — dialect-specific type names |
 | Date components       | `.year()`, `.month()`, `.day()`, `.hour()`, `.minute()`, `.second()`, `.dayOfWeek()`, `.dayOfMonth()`, `.dayOfYear()`, `.week()` |
+| Subquery compare      | `.in(subQb)`, `.notIn(subQb)`, `.eq/.neq/.gt/.gte/.lt/.lte(subQb)`, `Expressions.exists`, `Expressions.notExists` |
 | Logical composition   | `ColumnCondition.and/.or/.not`, `Expressions.and`, `Expressions.or`, `Expressions.not`          |
 
 ### JOIN — Combining Tables

--- a/docs/query-builder.md
+++ b/docs/query-builder.md
@@ -660,6 +660,39 @@ qb.select([Expressions.currentDate().as("today")]);
 emits an inline `CURRENT_TIMESTAMP` rather than binding the expression
 as a parameter.
 
+##### Type casts — `.stringValue()` / `.intValue()` / `.longValue()` / `.floatValue()` / `.booleanValue()`
+
+Cast any column or scalar expression to a portable SQL type. The type
+name is resolved per dialect so you don't have to remember whether
+MySQL accepts `INTEGER` (it doesn't) or `SIGNED`, or whether SQLite
+has a `BOOLEAN` (it doesn't — it uses `INTEGER`).
+
+```typescript
+const i = qAlias(Item, "i");
+
+qb.select([i.quantity.stringValue().as("qty_str")]);
+// PG/SQLite:  CAST("i"."quantity" AS TEXT) AS "qty_str"
+// MySQL:      CAST(`i`.`quantity` AS CHAR)  AS `qty_str`
+
+qb.where(i.sku.intValue().gt(1000));
+// PG/SQLite:  CAST("i"."sku" AS INTEGER) > $1
+// MySQL:      CAST(`i`.`sku` AS SIGNED)  > ?
+```
+
+The cast helpers are on both `ColumnExpression` and `ScalarExpression`
+— so you can chain them onto `coalesce(u.price, 0).floatValue()` or
+any other derived scalar. The result is a `ScalarExpression` itself,
+so it plugs into `.as()`, `.eq()`, `.gt()`, and nested `coalesce`
+without anything special.
+
+| Kind     | MySQL      | PostgreSQL | SQLite    |
+|----------|------------|------------|-----------|
+| string   | `CHAR`     | `TEXT`     | `TEXT`    |
+| int      | `SIGNED`   | `INTEGER`  | `INTEGER` |
+| long     | `SIGNED`   | `BIGINT`   | `INTEGER` |
+| float    | `DECIMAL`  | `REAL`     | `REAL`    |
+| boolean  | `UNSIGNED` | `BOOLEAN`  | `INTEGER` |
+
 ##### Logical composition — `.and()` / `.or()` / `.not()` + `Expressions`
 
 ```typescript
@@ -756,6 +789,7 @@ Method summary:
 | SELECT alias          | `.as("name")` on columns, JSON path extracts, and aggregates — produces `AliasedExpression` |
 | Null handling         | `coalesce(…)`, `nullif(a, b)`, `col.coalesce(…)`, `Expressions.coalesce`, `Expressions.nullif` |
 | Current date / time   | `currentDate()`, `currentTime()`, `currentTimestamp()` — also on `Expressions`                 |
+| Type casts            | `.stringValue()`, `.intValue()`, `.longValue()`, `.floatValue()`, `.booleanValue()` — dialect-specific type names |
 | Logical composition   | `ColumnCondition.and/.or/.not`, `Expressions.and`, `Expressions.or`, `Expressions.not`          |
 
 ### JOIN — Combining Tables

--- a/docs/query-builder.md
+++ b/docs/query-builder.md
@@ -780,6 +780,55 @@ qb.where(Expressions.exists(em.createQueryBuilder(Post, "p")
 rather than wrapping in a redundant `NOT (…)`, keeping output SQL
 clean.
 
+##### `CASE WHEN … THEN …` — `Expressions.caseBuilder()` / `Expressions.cases(...)`
+
+Two fluent builders cover the two forms SQL supports:
+
+**Searched CASE** — `caseBuilder()` reads like a guard chain. Each
+branch is a `ConditionLike` paired with a result value; end with an
+optional `otherwise(default)` and call `.end()` to finalize.
+
+```typescript
+const u = qAlias(User, "u");
+
+const tier = Expressions.caseBuilder()
+  .when(u.score.gte(90)).then("gold")
+  .when(u.score.gte(70)).then("silver")
+  .otherwise("bronze")
+  .end();
+
+qb.select([tier.as("tier")]);
+// SELECT CASE WHEN "u"."score" >= $1 THEN $2
+//             WHEN "u"."score" >= $3 THEN $4
+//             ELSE $5 END AS "tier"
+```
+
+**Simple CASE** — `cases(subject)` is the switch-style form, matching
+the subject against each candidate value:
+
+```typescript
+const weight = Expressions.cases(u.status)
+  .when("active",  1)
+  .when("pending", 0)
+  .otherwise(-1)
+  .end();
+
+qb.select([weight.as("w")]);
+// SELECT CASE "u"."status" WHEN $1 THEN $2
+//                           WHEN $3 THEN $4
+//                           ELSE $5 END AS "w"
+```
+
+`end()` returns a `ScalarExpression`, so the result feeds every
+downstream builder you've already seen — cast it (`.stringValue()`),
+alias it (`.as("tier")`), compare it in a condition (`.eq("gold")`),
+nest it in `coalesce(...)`, or pass it to another `CASE` branch as a
+result.
+
+Misuse-guard: `.when()` after `.otherwise()`, duplicate `.otherwise()`,
+or `.end()` with no branches each throw an explanatory error early,
+rather than producing malformed SQL.
+
 ##### Logical composition — `.and()` / `.or()` / `.not()` + `Expressions`
 
 ```typescript
@@ -879,6 +928,7 @@ Method summary:
 | Type casts            | `.stringValue()`, `.intValue()`, `.longValue()`, `.floatValue()`, `.booleanValue()` — dialect-specific type names |
 | Date components       | `.year()`, `.month()`, `.day()`, `.hour()`, `.minute()`, `.second()`, `.dayOfWeek()`, `.dayOfMonth()`, `.dayOfYear()`, `.week()` |
 | Subquery compare      | `.in(subQb)`, `.notIn(subQb)`, `.eq/.neq/.gt/.gte/.lt/.lte(subQb)`, `Expressions.exists`, `Expressions.notExists` |
+| CASE expressions      | `Expressions.caseBuilder().when(...).then(...).otherwise(...).end()`; `Expressions.cases(subject).when(val, result)...end()` |
 | Logical composition   | `ColumnCondition.and/.or/.not`, `Expressions.and`, `Expressions.or`, `Expressions.not`          |
 
 ### JOIN — Combining Tables

--- a/docs/query-builder.md
+++ b/docs/query-builder.md
@@ -636,6 +636,30 @@ Static helpers live on the `Expressions` namespace — `Expressions.coalesce`
 and `Expressions.nullif` — mirroring Java QueryDSL for callers who
 prefer the static entry point.
 
+##### Current date/time — `currentDate()` / `currentTime()` / `currentTimestamp()`
+
+Three small standard-SQL helpers that insert the server's clock into
+any expression position. They are scalar expressions, so they compose
+with everything already shown (`.as()`, `.eq()`, nested inside
+`coalesce`, etc.) and emit the same literal on every dialect.
+
+```typescript
+import { Expressions, qAlias } from "@stingerloom/orm";
+
+const s = qAlias(Session, "s");
+
+qb.where(s.expiresAt.gte(Expressions.currentTimestamp()));
+// WHERE "s"."expires_at" >= CURRENT_TIMESTAMP
+
+qb.select([Expressions.currentDate().as("today")]);
+// SELECT CURRENT_DATE AS "today"
+```
+
+`ColumnExpression` comparison methods now transparently unwrap a
+`ScalarExpression` operand — so `u.createdAt.lte(currentTimestamp())`
+emits an inline `CURRENT_TIMESTAMP` rather than binding the expression
+as a parameter.
+
 ##### Logical composition — `.and()` / `.or()` / `.not()` + `Expressions`
 
 ```typescript
@@ -731,6 +755,7 @@ Method summary:
 | Aggregates            | `.count()`, `.countDistinct()`, `.sum()`, `.avg()`, `.min()`, `.max()` — each with `.as(alias)` and `.eq/.neq/.gt/.gte/.lt/.lte/.between` |
 | SELECT alias          | `.as("name")` on columns, JSON path extracts, and aggregates — produces `AliasedExpression` |
 | Null handling         | `coalesce(…)`, `nullif(a, b)`, `col.coalesce(…)`, `Expressions.coalesce`, `Expressions.nullif` |
+| Current date / time   | `currentDate()`, `currentTime()`, `currentTimestamp()` — also on `Expressions`                 |
 | Logical composition   | `ColumnCondition.and/.or/.not`, `Expressions.and`, `Expressions.or`, `Expressions.not`          |
 
 ### JOIN — Combining Tables

--- a/docs/query-builder.md
+++ b/docs/query-builder.md
@@ -598,6 +598,44 @@ injection risk.
 aliased columns with aggregates in the same `select([...])` call is also
 supported.
 
+##### Null handling — `coalesce()` / `nullif()`
+
+`coalesce(a, b, c, …)` returns the first non-null argument. `nullif(a,
+b)` returns `NULL` when `a === b`, otherwise `a` — useful for turning a
+sentinel value (empty string, `-1`, etc.) into a real `NULL`. Both are
+standard SQL, so they compile identically on every dialect.
+
+```typescript
+import { coalesce, nullif, Expressions, qAlias } from "@stingerloom/orm";
+
+const u = qAlias(User, "u");
+
+// Display name with graceful fallback — column → column → literal
+qb.select([
+  u.nickname.coalesce(u.name, "anonymous").as("display_name"),
+]);
+// SELECT COALESCE("u"."nickname", "u"."name", $1) AS "display_name"
+
+// Turn an empty email into NULL
+qb.select([nullif(u.email, "").as("email_or_null")]);
+// SELECT NULLIF("u"."email", $1) AS "email_or_null"
+
+// Both also work in WHERE / HAVING
+qb.where(coalesce(u.score, 0).gte(50));
+// WHERE COALESCE("u"."score", $1) >= $2
+```
+
+Arguments accept any expression the query builder understands: column
+references, JSON path extractions (`u.metadata.profile.tier`),
+aggregates (`u.id.count()`), other scalar expressions (nested
+`coalesce`), and plain values — bound as parameters. The result is a
+`ScalarExpression`, which exposes the same `.eq()` / `.gt()` / `.as()`
+surface you've already seen, so every derived expression composes.
+
+Static helpers live on the `Expressions` namespace — `Expressions.coalesce`
+and `Expressions.nullif` — mirroring Java QueryDSL for callers who
+prefer the static entry point.
+
 ##### Logical composition — `.and()` / `.or()` / `.not()` + `Expressions`
 
 ```typescript
@@ -692,6 +730,7 @@ Method summary:
 | Ordering              | `.asc()`, `.desc()`, `.nullsFirst()`, `.nullsLast()`                                            |
 | Aggregates            | `.count()`, `.countDistinct()`, `.sum()`, `.avg()`, `.min()`, `.max()` — each with `.as(alias)` and `.eq/.neq/.gt/.gte/.lt/.lte/.between` |
 | SELECT alias          | `.as("name")` on columns, JSON path extracts, and aggregates — produces `AliasedExpression` |
+| Null handling         | `coalesce(…)`, `nullif(a, b)`, `col.coalesce(…)`, `Expressions.coalesce`, `Expressions.nullif` |
 | Logical composition   | `ColumnCondition.and/.or/.not`, `Expressions.and`, `Expressions.or`, `Expressions.not`          |
 
 ### JOIN — Combining Tables

--- a/src/core/RawQueryBuilder.ts
+++ b/src/core/RawQueryBuilder.ts
@@ -83,6 +83,34 @@ export class RawQueryBuilder implements BaseRawQueryBuilder {
   }
 
   /**
+   * Specifies the SELECT clause as a list of parameterized SQL fragments.
+   *
+   * Unlike {@link select}, each fragment is a `Sql` object (from
+   * `sql-template-tag`) so bound parameter values — e.g. JSON path
+   * literals from a `JSON_EXTRACT(col, ?)` call — are preserved when
+   * the query is executed.
+   *
+   * @param fragments - SELECT-list expressions (already containing any
+   *                    `AS alias` suffix).
+   * @param distinct  - When true, emits `SELECT DISTINCT` instead of
+   *                    `SELECT`.
+   * @returns The current instance of the query builder.
+   */
+  selectFragments(fragments: Sql[], distinct = false): RawQueryBuilder {
+    if (fragments.length === 0) {
+      throw new OrmError(
+        OrmErrorCode.INVALID_QUERY,
+        "selectFragments() requires at least one fragment.",
+      );
+    }
+    const keyword = distinct ? "SELECT DISTINCT" : "SELECT";
+    this.sqlQuerySegments.push(
+      sql`${raw(keyword)} ${join(fragments, ", ")}`,
+    );
+    return this;
+  }
+
+  /**
    * Specifies the table to select from.
    * @param table - The name of the table.
    * @param alias - An optional alias for the table.

--- a/src/core/SelectQueryBuilder.ts
+++ b/src/core/SelectQueryBuilder.ts
@@ -210,6 +210,32 @@ export class ColumnCondition implements ConditionLike {
     ) => Sql,
   ) {}
 
+  /**
+   * @internal Unwrap a value that may be a {@link ScalarExpression} (e.g.
+   * `Expressions.currentTimestamp()`) into a rendered `Sql` fragment.
+   * Plain values pass through unchanged so `sql-template-tag` binds them
+   * as parameters.
+   */
+  private resolveValue(
+    value: unknown,
+    resolveColumn: (ref: string) => string,
+    dialect: DialectExpression | undefined,
+  ): unknown {
+    if (
+      value !== null &&
+      typeof value === "object" &&
+      (value as { __isScalarExpression?: unknown }).__isScalarExpression === true
+    ) {
+      return (value as {
+        renderer: (
+          r: (ref: string) => string,
+          d?: DialectExpression,
+        ) => Sql;
+      }).renderer(resolveColumn, dialect);
+    }
+    return value;
+  }
+
   /** @internal Resolve the column reference and produce final SQL. */
   resolve(
     resolveColumn: (ref: string) => string,
@@ -219,38 +245,43 @@ export class ColumnCondition implements ConditionLike {
     if (this.dialectRenderer) {
       return this.dialectRenderer(qualified, dialect);
     }
+    const value = this.resolveValue(this.value, resolveColumn, dialect);
     switch (this.operator) {
       case "=":
-        if (this.value === null) return Conditions.isNull(qualified);
-        if (Array.isArray(this.value)) return Conditions.in(qualified, this.value);
-        return Conditions.equals(qualified, this.value);
+        if (value === null) return Conditions.isNull(qualified);
+        if (Array.isArray(value)) return Conditions.in(qualified, value);
+        return Conditions.equals(qualified, value);
       case "!=":
       case "<>":
-        return Conditions.notEquals(qualified, this.value);
+        return Conditions.notEquals(qualified, value);
       case ">":
-        return Conditions.gt(qualified, this.value);
+        return Conditions.gt(qualified, value);
       case ">=":
-        return Conditions.gte(qualified, this.value);
+        return Conditions.gte(qualified, value);
       case "<":
-        return Conditions.lt(qualified, this.value);
+        return Conditions.lt(qualified, value);
       case "<=":
-        return Conditions.lte(qualified, this.value);
+        return Conditions.lte(qualified, value);
       case "LIKE":
-        return Conditions.like(qualified, this.value);
+        return Conditions.like(qualified, value as string);
       case "NOT LIKE":
-        return Conditions.notLike(qualified, this.value);
+        return Conditions.notLike(qualified, value as string);
       case "IN":
-        return Conditions.in(qualified, this.value);
+        return Conditions.in(qualified, value as unknown[]);
       case "NOT IN":
-        return Conditions.notIn(qualified, this.value);
+        return Conditions.notIn(qualified, value as unknown[]);
       case "IS NULL":
         return Conditions.isNull(qualified);
       case "IS NOT NULL":
         return Conditions.isNotNull(qualified);
-      case "BETWEEN":
-        return Conditions.between(qualified, this.value[0], this.value[1]);
+      case "BETWEEN": {
+        const [min, max] = value as [unknown, unknown];
+        const minR = this.resolveValue(min, resolveColumn, dialect);
+        const maxR = this.resolveValue(max, resolveColumn, dialect);
+        return Conditions.between(qualified, minR, maxR);
+      }
       default:
-        return sql`${raw(qualified)} ${raw(this.operator)} ${this.value}`;
+        return sql`${raw(qualified)} ${raw(this.operator)} ${value as any}`;
     }
   }
 

--- a/src/core/SelectQueryBuilder.ts
+++ b/src/core/SelectQueryBuilder.ts
@@ -40,6 +40,8 @@ import {
 } from "./expressions/AliasedExpression";
 import { ScalarExpression } from "./expressions/ScalarExpression";
 import { coalesce as coalesceFn } from "./expressions/NullishExpression";
+import { buildCastScalar } from "./expressions/CastExpression";
+import type { CastKind } from "../dialects/DialectExpression";
 import type { InheritanceStrategy } from "../decorators/Inheritance";
 import type { ColumnMetadata } from "../scanner/ColumnScanner";
 import type { DialectExpression } from "../dialects/DialectExpression";
@@ -483,6 +485,36 @@ export class ColumnExpression {
       );
     }
     return coalesceFn(this, ...fallbacks);
+  }
+
+  // ── CAST helpers (Tier 2) ──────────────────────────────
+
+  /** `CAST(column AS <dialect-string-type>)` — TEXT / CHAR. */
+  stringValue(): ScalarExpression {
+    return this.buildCast("string");
+  }
+  /** `CAST(column AS <dialect-int-type>)` — INTEGER / SIGNED. */
+  intValue(): ScalarExpression {
+    return this.buildCast("int");
+  }
+  /** `CAST(column AS <dialect-long-type>)` — BIGINT / SIGNED. */
+  longValue(): ScalarExpression {
+    return this.buildCast("long");
+  }
+  /** `CAST(column AS <dialect-float-type>)` — REAL / DECIMAL. */
+  floatValue(): ScalarExpression {
+    return this.buildCast("float");
+  }
+  /** `CAST(column AS <dialect-boolean-type>)` — BOOLEAN / UNSIGNED / INTEGER. */
+  booleanValue(): ScalarExpression {
+    return this.buildCast("boolean");
+  }
+
+  private buildCast(kind: CastKind): ScalarExpression {
+    const ref = this.ref;
+    return buildCastScalar(kind, (resolveColumn) =>
+      sql`${raw(resolveColumn(ref))}`,
+    );
   }
 
   // ── Aggregate helpers (Tier 1) ─────────────────────────

--- a/src/core/SelectQueryBuilder.ts
+++ b/src/core/SelectQueryBuilder.ts
@@ -41,7 +41,8 @@ import {
 import { ScalarExpression } from "./expressions/ScalarExpression";
 import { coalesce as coalesceFn } from "./expressions/NullishExpression";
 import { buildCastScalar } from "./expressions/CastExpression";
-import type { CastKind } from "../dialects/DialectExpression";
+import { buildDateComponentFromRef } from "./expressions/DateComponentExpression";
+import type { CastKind, DateComponent } from "../dialects/DialectExpression";
 import type { InheritanceStrategy } from "../decorators/Inheritance";
 import type { ColumnMetadata } from "../scanner/ColumnScanner";
 import type { DialectExpression } from "../dialects/DialectExpression";
@@ -515,6 +516,53 @@ export class ColumnExpression {
     return buildCastScalar(kind, (resolveColumn) =>
       sql`${raw(resolveColumn(ref))}`,
     );
+  }
+
+  // ── Date / time component helpers (Tier 2) ─────────────
+
+  /** `EXTRACT(YEAR …)` / `YEAR(col)` / `strftime('%Y', col)`. */
+  year(): ScalarExpression {
+    return this.buildDateComponent("year");
+  }
+  /** `EXTRACT(MONTH …)` / `MONTH(col)` / `strftime('%m', col)`. */
+  month(): ScalarExpression {
+    return this.buildDateComponent("month");
+  }
+  /** Alias of `.dayOfMonth()` — 1–31. */
+  day(): ScalarExpression {
+    return this.buildDateComponent("day");
+  }
+  /** `EXTRACT(HOUR …)` / `HOUR(col)` / `strftime('%H', col)`. */
+  hour(): ScalarExpression {
+    return this.buildDateComponent("hour");
+  }
+  /** Minute of hour, 0–59. */
+  minute(): ScalarExpression {
+    return this.buildDateComponent("minute");
+  }
+  /** Second of minute, 0–59. */
+  second(): ScalarExpression {
+    return this.buildDateComponent("second");
+  }
+  /** Day of week — engine-specific encoding (see DialectExpression doc). */
+  dayOfWeek(): ScalarExpression {
+    return this.buildDateComponent("dayOfWeek");
+  }
+  /** Day of month, 1–31. */
+  dayOfMonth(): ScalarExpression {
+    return this.buildDateComponent("dayOfMonth");
+  }
+  /** Day of year, 1–366. */
+  dayOfYear(): ScalarExpression {
+    return this.buildDateComponent("dayOfYear");
+  }
+  /** Week of year — engine-specific encoding (see DialectExpression doc). */
+  week(): ScalarExpression {
+    return this.buildDateComponent("week");
+  }
+
+  private buildDateComponent(component: DateComponent): ScalarExpression {
+    return buildDateComponentFromRef(component, this.ref);
   }
 
   // ── Aggregate helpers (Tier 1) ─────────────────────────

--- a/src/core/SelectQueryBuilder.ts
+++ b/src/core/SelectQueryBuilder.ts
@@ -214,10 +214,24 @@ export class ColumnCondition implements ConditionLike {
   ) {}
 
   /**
+   * @internal Duck-type guard for `SelectQueryBuilder`-like subqueries.
+   * Kept inline to avoid importing the concrete class (which lives in
+   * the same file but cycles through compilation).
+   */
+  private isSubqueryLike(value: unknown): value is { toSql(): Sql } {
+    return (
+      value !== null &&
+      typeof value === "object" &&
+      typeof (value as { toSql?: unknown }).toSql === "function" &&
+      typeof (value as { getSql?: unknown }).getSql === "function"
+    );
+  }
+
+  /**
    * @internal Unwrap a value that may be a {@link ScalarExpression} (e.g.
-   * `Expressions.currentTimestamp()`) into a rendered `Sql` fragment.
-   * Plain values pass through unchanged so `sql-template-tag` binds them
-   * as parameters.
+   * `Expressions.currentTimestamp()`) or a subquery-like `SelectQueryBuilder`
+   * into a rendered `Sql` fragment. Plain values pass through unchanged
+   * so `sql-template-tag` binds them as parameters.
    */
   private resolveValue(
     value: unknown,
@@ -235,6 +249,18 @@ export class ColumnCondition implements ConditionLike {
           d?: DialectExpression,
         ) => Sql;
       }).renderer(resolveColumn, dialect);
+    }
+    if (
+      value !== null &&
+      typeof value === "object" &&
+      typeof (value as { toSql?: unknown }).toSql === "function" &&
+      typeof (value as { getSql?: unknown }).getSql === "function"
+    ) {
+      // SelectQueryBuilder-like — embed as a parenthesized subquery so
+      // `col = (SELECT ...)` / `col IN (SELECT ...)` etc. work through
+      // the same code path as scalar / primitive comparisons.
+      const inner = (value as { toSql(): Sql }).toSql();
+      return sql`(${inner})`;
     }
     return value;
   }
@@ -270,8 +296,16 @@ export class ColumnCondition implements ConditionLike {
       case "NOT LIKE":
         return Conditions.notLike(qualified, value as string);
       case "IN":
+        if (this.value !== null && this.isSubqueryLike(this.value)) {
+          const sub = (this.value as { toSql(): Sql }).toSql();
+          return sql`${raw(qualified)} IN (${sub})`;
+        }
         return Conditions.in(qualified, value as unknown[]);
       case "NOT IN":
+        if (this.value !== null && this.isSubqueryLike(this.value)) {
+          const sub = (this.value as { toSql(): Sql }).toSql();
+          return sql`${raw(qualified)} NOT IN (${sub})`;
+        }
         return Conditions.notIn(qualified, value as unknown[]);
       case "IS NULL":
         return Conditions.isNull(qualified);
@@ -338,10 +372,18 @@ export class ColumnExpression {
   like(pattern: string): ColumnCondition { return new ColumnCondition(this.ref, "LIKE", pattern); }
   /** `column NOT LIKE pattern` (pattern passed through verbatim). */
   notLike(pattern: string): ColumnCondition { return new ColumnCondition(this.ref, "NOT LIKE", pattern); }
-  /** `column IN (values)` */
-  in(values: any[]): ColumnCondition { return new ColumnCondition(this.ref, "IN", values); }
-  /** `column NOT IN (values)` */
-  notIn(values: any[]): ColumnCondition { return new ColumnCondition(this.ref, "NOT IN", values); }
+  /** `column IN (values)` — accepts either a value list or a subquery. */
+  in(values: any[]): ColumnCondition;
+  in(subquery: { toSql(): Sql }): ColumnCondition;
+  in(valuesOrSubquery: any[] | { toSql(): Sql }): ColumnCondition {
+    return new ColumnCondition(this.ref, "IN", valuesOrSubquery);
+  }
+  /** `column NOT IN (values)` — accepts either a value list or a subquery. */
+  notIn(values: any[]): ColumnCondition;
+  notIn(subquery: { toSql(): Sql }): ColumnCondition;
+  notIn(valuesOrSubquery: any[] | { toSql(): Sql }): ColumnCondition {
+    return new ColumnCondition(this.ref, "NOT IN", valuesOrSubquery);
+  }
   /** `column IS NULL` */
   isNull(): ColumnCondition { return new ColumnCondition(this.ref, "IS NULL", undefined); }
   /** `column IS NOT NULL` */

--- a/src/core/SelectQueryBuilder.ts
+++ b/src/core/SelectQueryBuilder.ts
@@ -34,6 +34,10 @@ import {
   isLogicalCondition,
 } from "./expressions/LogicalCondition";
 import { escapeLikeValue } from "./expressions/likeEscape";
+import {
+  AliasedExpression,
+  isAliasedExpression,
+} from "./expressions/AliasedExpression";
 import type { InheritanceStrategy } from "../decorators/Inheritance";
 import type { ColumnMetadata } from "../scanner/ColumnScanner";
 import type { DialectExpression } from "../dialects/DialectExpression";
@@ -399,6 +403,28 @@ export class ColumnExpression {
   asc(): OrderExpression { return new OrderExpression(this.ref, "ASC"); }
   /** Descending ORDER BY on this column. */
   desc(): OrderExpression { return new OrderExpression(this.ref, "DESC"); }
+
+  // ── SELECT alias (Tier 2) ──────────────────────────────
+
+  /**
+   * Tag this column for SELECT with an explicit result alias.
+   *
+   * Produces `<qualified_col> AS <alias>` in the SELECT list. Only
+   * meaningful when passed to `select()` / `addSelect()` — the result
+   * is an {@link AliasedExpression}, not a condition, so it cannot
+   * appear in `where()` / `having()`.
+   *
+   * @example
+   * ```ts
+   * qb.select([u.firstName.as("name"), u.age.as("years")]).getRawMany();
+   * ```
+   */
+  as(alias: string): AliasedExpression {
+    const ref = this.ref;
+    return new AliasedExpression(alias, (resolveColumn) =>
+      sql`${raw(resolveColumn(ref))}`,
+    );
+  }
 
   // ── Aggregate helpers (Tier 1) ─────────────────────────
 
@@ -824,6 +850,15 @@ export class SelectQueryBuilder<T, TResult = T> {
   protected rowValidator: RowValidator<any> | undefined;
   protected arrayValidatorFn: ArrayValidator<any> | undefined;
   protected selectedPropertyKeys: string[] | null = null;
+  /**
+   * Parameterized SELECT list built from {@link AliasedExpression}s.
+   *
+   * When non-null, this takes precedence over both {@link selectColumns}
+   * and {@link selectExpressions} in the build path — the SELECT segment
+   * is emitted via `RawQueryBuilder.selectFragments()` so bound values
+   * (e.g. JSON path literals on MySQL) are preserved through execution.
+   */
+  protected aliasedSelectList: Sql[] | null = null;
   protected indexHints: Array<{
     type: "USE" | "FORCE" | "IGNORE";
     indexName: string;
@@ -1187,21 +1222,60 @@ export class SelectQueryBuilder<T, TResult = T> {
    */
   select(aggregate: AggregateExpression): SelectQueryBuilder<T, any>;
   select(aggregates: AggregateExpression[]): SelectQueryBuilder<T, any>;
+  /**
+   * Seed the SELECT clause with one or more {@link AliasedExpression}s
+   * — columns or JSON-path extractions tagged with an explicit result
+   * alias via `.as("name")`. Mix of {@link AliasedExpression} and
+   * {@link AggregateExpression} is supported; the list is rendered as a
+   * parameterized SELECT fragment so JSON path literals survive
+   * execution.
+   */
+  select(aliased: AliasedExpression): SelectQueryBuilder<T, any>;
+  select(aliased: AliasedExpression[]): SelectQueryBuilder<T, any>;
+  select(
+    projections: Array<AliasedExpression | AggregateExpression>,
+  ): SelectQueryBuilder<T, any>;
   select<K extends ColumnOf<T>>(
-    columns: K[] | "*" | AggregateExpression | AggregateExpression[],
+    columns:
+      | K[]
+      | "*"
+      | AggregateExpression
+      | AggregateExpression[]
+      | AliasedExpression
+      | AliasedExpression[]
+      | Array<AliasedExpression | AggregateExpression>,
   ): SelectQueryBuilder<T, any> {
+    if (isAliasedExpression(columns)) {
+      return this.selectAliased([columns]);
+    }
     if (isAggregateExpression(columns)) {
       return this.selectAggregates([columns]);
     }
-    if (Array.isArray(columns) && columns.length > 0 && isAggregateExpression(columns[0])) {
-      return this.selectAggregates(columns as AggregateExpression[]);
+    if (Array.isArray(columns) && columns.length > 0) {
+      const first = columns[0];
+      if (isAliasedExpression(first) || isAggregateExpression(first)) {
+        // Any aliased entry forces the parameterized-fragment path so
+        // JSON extract bindings survive; a homogeneous aggregate array
+        // keeps the cheaper string path.
+        const hasAliased = (columns as unknown[]).some((c) =>
+          isAliasedExpression(c),
+        );
+        if (hasAliased) {
+          return this.selectAliased(
+            columns as Array<AliasedExpression | AggregateExpression>,
+          );
+        }
+        return this.selectAggregates(columns as AggregateExpression[]);
+      }
     }
     if (columns === "*") {
       this.selectColumns = "*";
       this.selectedPropertyKeys = null;
+      this.aliasedSelectList = null;
     } else {
       this.selectColumns = (columns as string[]).map((c) => this.col(c));
       this.selectedPropertyKeys = columns as string[];
+      this.aliasedSelectList = null;
     }
     return this as any;
   }
@@ -1223,6 +1297,39 @@ export class SelectQueryBuilder<T, TResult = T> {
       fragments.push(`${fn.sql} AS ${this.em.wrap(resolvedAlias)}`);
     }
     this.selectColumns = fragments;
+    this.selectedPropertyKeys = null;
+    this.aliasedSelectList = null;
+    return this;
+  }
+
+  /**
+   * @internal Replace the SELECT clause with parameterized alias
+   * fragments.
+   *
+   * Used when the projection contains an {@link AliasedExpression} —
+   * JSON path extractions encode path literals as bound parameters, so
+   * the list is rendered as a `Sql[]` (preserving those values) and
+   * handed to {@link RawQueryBuilder.selectFragments} at build time.
+   * Aggregates mixed in are rendered alongside so callers can freely
+   * combine `count().as()` with `col.as()`.
+   */
+  private selectAliased(
+    projections: Array<AliasedExpression | AggregateExpression>,
+  ): this {
+    const fragments: Sql[] = [];
+    const resolver: ColumnResolver = (ref) => this.resolveColumn(ref);
+    for (const p of projections) {
+      if (isAliasedExpression(p)) {
+        const inner = p.renderer(resolver, this.dialectExpression);
+        fragments.push(sql`${inner} AS ${raw(this.em.wrap(p.alias))}`);
+      } else if (isAggregateExpression(p)) {
+        const resolvedAlias = p.alias ?? p.getAlias();
+        const fn = p.renderFunction(resolver);
+        fragments.push(sql`${fn} AS ${raw(this.em.wrap(resolvedAlias))}`);
+      }
+    }
+    this.aliasedSelectList = fragments;
+    this.selectColumns = "*";
     this.selectedPropertyKeys = null;
     return this;
   }
@@ -1254,8 +1361,25 @@ export class SelectQueryBuilder<T, TResult = T> {
   }
 
   addSelect(expr: AggregateExpression): this;
+  addSelect(expr: AliasedExpression): this;
   addSelect(expr: Sql | string, alias?: string): this;
-  addSelect(expr: Sql | string | AggregateExpression, alias?: string): this {
+  addSelect(
+    expr: Sql | string | AggregateExpression | AliasedExpression,
+    alias?: string,
+  ): this {
+    if (isAliasedExpression(expr)) {
+      // Route through `selectExpressions` so JSON path bindings survive;
+      // these fragments are appended to the existing SELECT list at
+      // build time.
+      const inner = expr.renderer(
+        (ref) => this.resolveColumn(ref),
+        this.dialectExpression,
+      );
+      this.selectExpressions.push(
+        sql`${inner} AS ${raw(this.em.wrap(expr.alias))}`,
+      );
+      return this;
+    }
     if (isAggregateExpression(expr)) {
       // Aggregate SQL has no bound parameters (func name + qualified col),
       // so funneling through selectColumns as a plain string is safe and
@@ -2802,7 +2926,12 @@ export class SelectQueryBuilder<T, TResult = T> {
     else qb.setDatabaseType("postgresql");
 
     // SELECT — inheritance-aware
-    if (this.selectColumns === "*") {
+    if (this.aliasedSelectList !== null) {
+      // Aliased-expression projection (may carry bound params for JSON
+      // extract); bypass the string-based select() path to keep values
+      // attached to their placeholders.
+      qb.selectFragments(this.aliasedSelectList, this.distinct);
+    } else if (this.selectColumns === "*") {
       // TPT child: use explicit column list from both tables
       if (this.tptSelectColumns) {
         const cols = [...this.tptSelectColumns];
@@ -3318,6 +3447,9 @@ export class SelectQueryBuilder<T, TResult = T> {
     cloned.dialectExpression = this.dialectExpression;
     cloned.aliasRegistry = new Map(this.aliasRegistry);
     cloned.selectExpressions = [...this.selectExpressions];
+    cloned.aliasedSelectList = this.aliasedSelectList
+      ? [...this.aliasedSelectList]
+      : null;
     // Inheritance state
     cloned.inheritanceStrategy = this.inheritanceStrategy;
     cloned.isInheritanceChild = this.isInheritanceChild;

--- a/src/core/SelectQueryBuilder.ts
+++ b/src/core/SelectQueryBuilder.ts
@@ -38,6 +38,8 @@ import {
   AliasedExpression,
   isAliasedExpression,
 } from "./expressions/AliasedExpression";
+import { ScalarExpression } from "./expressions/ScalarExpression";
+import { coalesce as coalesceFn } from "./expressions/NullishExpression";
 import type { InheritanceStrategy } from "../decorators/Inheritance";
 import type { ColumnMetadata } from "../scanner/ColumnScanner";
 import type { DialectExpression } from "../dialects/DialectExpression";
@@ -283,6 +285,7 @@ export class ColumnCondition implements ConditionLike {
  * ```
  */
 export class ColumnExpression {
+  readonly __isColumnExpression = true as const;
   constructor(private readonly ref: string) {}
 
   /** `column = value` */
@@ -424,6 +427,31 @@ export class ColumnExpression {
     return new AliasedExpression(alias, (resolveColumn) =>
       sql`${raw(resolveColumn(ref))}`,
     );
+  }
+
+  // ── Null handling (Tier 2) ─────────────────────────────
+
+  /**
+   * `COALESCE(this, fallback1, fallback2, …)` — returns the first
+   * non-null value from left to right. Useful for picking a display
+   * name with graceful fallback.
+   *
+   * Requires at least one fallback. Fallbacks may be other column
+   * expressions, scalar expressions, aggregates, JSON path extracts,
+   * or plain values (which become bound parameters).
+   *
+   * @example
+   * ```ts
+   * qb.select([u.nickname.coalesce(u.name, "anonymous").as("display")]);
+   * ```
+   */
+  coalesce(...fallbacks: unknown[]): ScalarExpression {
+    if (fallbacks.length === 0) {
+      throw new Error(
+        "coalesce() requires at least one fallback argument.",
+      );
+    }
+    return coalesceFn(this, ...fallbacks);
   }
 
   // ── Aggregate helpers (Tier 1) ─────────────────────────

--- a/src/core/expressions/AliasedExpression.ts
+++ b/src/core/expressions/AliasedExpression.ts
@@ -1,0 +1,62 @@
+import type { Sql } from "sql-template-tag";
+import type { ColumnResolver } from "./ConditionLike";
+import type { DialectExpression } from "../../dialects/DialectExpression";
+
+/**
+ * Produces the inner SQL fragment for a SELECT-position expression
+ * (without the trailing `AS alias` clause).
+ *
+ * @internal Implemented by {@link ColumnExpression.as} and
+ * {@link JsonPathExpression.as}; the query builder supplies the column
+ * resolver and (when available) the target dialect at build time.
+ */
+export type AliasedRenderer = (
+  resolveColumn: ColumnResolver,
+  dialect?: DialectExpression,
+) => Sql;
+
+/**
+ * A SELECT-position expression tagged with a result alias.
+ *
+ * Produced by calling `.as("name")` on a column- or JSON-path
+ * expression. Pass it to `select()` / `addSelect()` to render as
+ * `<expression> AS <alias>`.
+ *
+ * ⚠ Only meaningful in SELECT — an `AliasedExpression` is not a
+ * {@link ConditionLike} and cannot be passed to `where()` / `having()`.
+ *
+ * @example
+ * ```ts
+ * const u = qAlias(User, "u");
+ *
+ * // Column aliasing
+ * qb.select([u.firstName.as("name"), u.age.as("years")]);
+ *
+ * // JSON path aliasing (dialect-specific extract)
+ * qb.select([u.metadata.profile.email.as("contact_email")]);
+ * ```
+ */
+export class AliasedExpression {
+  readonly __isAliasedExpression = true as const;
+
+  constructor(
+    /** User-provided alias from `.as("name")`. */
+    readonly alias: string,
+    /** Renderer that produces the inner SQL fragment (no AS clause). */
+    readonly renderer: AliasedRenderer,
+  ) {}
+}
+
+/**
+ * Type guard — true if `value` is an {@link AliasedExpression}.
+ */
+export function isAliasedExpression(
+  value: unknown,
+): value is AliasedExpression {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    (value as { __isAliasedExpression?: unknown }).__isAliasedExpression ===
+      true
+  );
+}

--- a/src/core/expressions/CaseExpression.ts
+++ b/src/core/expressions/CaseExpression.ts
@@ -1,0 +1,215 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import sql, { Sql, raw, join } from "sql-template-tag";
+import type { ConditionLike, ColumnResolver } from "./ConditionLike";
+import type { DialectExpression } from "../../dialects/DialectExpression";
+import { ScalarExpression } from "./ScalarExpression";
+
+/**
+ * @internal Shared helper — render any value usable as a CASE result:
+ * a column/scalar expression unwraps to its inner SQL, everything else
+ * is bound as a parameter.
+ */
+function renderResultValue(
+  value: unknown,
+  resolveColumn: ColumnResolver,
+  dialect?: DialectExpression,
+): Sql {
+  if (
+    value !== null &&
+    typeof value === "object" &&
+    (value as { __isScalarExpression?: unknown }).__isScalarExpression === true
+  ) {
+    return (value as {
+      renderer: (r: ColumnResolver, d?: DialectExpression) => Sql;
+    }).renderer(resolveColumn, dialect);
+  }
+  if (
+    value !== null &&
+    typeof value === "object" &&
+    (value as { __isColumnExpression?: unknown }).__isColumnExpression === true
+  ) {
+    return sql`${raw(resolveColumn((value as { toString(): string }).toString()))}`;
+  }
+  return sql`${value as any}`;
+}
+
+interface CaseBranch {
+  condition: ConditionLike;
+  result: unknown;
+}
+
+/**
+ * Fluent builder for a **searched** `CASE WHEN cond THEN result …
+ * ELSE default END` expression.
+ *
+ * Start via `Expressions.caseBuilder()`. Chain `.when(cond).then(val)`
+ * for each branch, optionally finish with `.otherwise(val)`, then call
+ * `.end()` to get a {@link ScalarExpression}.
+ *
+ * @example
+ * ```ts
+ * const u = qAlias(User, "u");
+ * const tier = Expressions.caseBuilder()
+ *   .when(u.score.gte(90)).then("gold")
+ *   .when(u.score.gte(70)).then("silver")
+ *   .otherwise("bronze")
+ *   .end();
+ *
+ * qb.select([tier.as("tier")]);
+ * ```
+ */
+export class CaseBuilder {
+  private readonly branches: CaseBranch[] = [];
+  private elseValue: { present: true; value: unknown } | undefined;
+
+  /** Start a new branch — takes a condition. Must be followed by `.then()`. */
+  when(condition: ConditionLike): CaseWhenBuilder {
+    if (this.elseValue) {
+      throw new Error(
+        "CaseBuilder: cannot add .when() after .otherwise() has been set.",
+      );
+    }
+    if (!condition || (condition as { __isCondition?: unknown }).__isCondition !== true) {
+      throw new Error(
+        "CaseBuilder.when() expects a ConditionLike argument.",
+      );
+    }
+    return new CaseWhenBuilder(this, condition);
+  }
+
+  /** @internal Append a completed branch. */
+  _appendBranch(branch: CaseBranch): this {
+    if (this.elseValue) {
+      throw new Error(
+        "CaseBuilder: cannot add .when() after .otherwise() has been set.",
+      );
+    }
+    this.branches.push(branch);
+    return this;
+  }
+
+  /** Attach the `ELSE default` branch. After this, only `.end()` is valid. */
+  otherwise(value: unknown): CaseBuilder {
+    if (this.elseValue) {
+      throw new Error("CaseBuilder: .otherwise() already set.");
+    }
+    this.elseValue = { present: true, value };
+    return this;
+  }
+
+  /** Finalize — produce a {@link ScalarExpression} ready for SELECT/WHERE/etc. */
+  end(): ScalarExpression {
+    if (this.branches.length === 0) {
+      throw new Error(
+        "CaseBuilder.end(): CASE expression needs at least one WHEN/THEN pair.",
+      );
+    }
+    const branches = this.branches;
+    const elseValue = this.elseValue;
+    return new ScalarExpression((resolveColumn, dialect) => {
+      const whenParts = branches.map((b) => {
+        const cond = b.condition.resolve(resolveColumn, dialect);
+        const result = renderResultValue(b.result, resolveColumn, dialect);
+        return sql`WHEN ${cond} THEN ${result}`;
+      });
+      if (elseValue) {
+        const def = renderResultValue(elseValue.value, resolveColumn, dialect);
+        return sql`CASE ${join(whenParts, " ")} ELSE ${def} END`;
+      }
+      return sql`CASE ${join(whenParts, " ")} END`;
+    });
+  }
+}
+
+/**
+ * @internal Intermediate builder state — the condition has been given,
+ * awaiting its `.then(result)` call before the chain can continue.
+ */
+export class CaseWhenBuilder {
+  constructor(
+    private readonly parent: CaseBuilder,
+    private readonly condition: ConditionLike,
+  ) {}
+
+  then(result: unknown): CaseBuilder {
+    return this.parent._appendBranch({
+      condition: this.condition,
+      result,
+    });
+  }
+}
+
+/**
+ * Fluent builder for a **simple** `CASE value WHEN v1 THEN r1 …` expression.
+ *
+ * Start via `Expressions.cases(valueExpr)`. Each `.when(value, result)`
+ * adds a branch; `.otherwise(result)` sets the default; `.end()` finalizes.
+ *
+ * @example
+ * ```ts
+ * const u = qAlias(User, "u");
+ * const weight = Expressions.cases(u.status)
+ *   .when("active", 1)
+ *   .when("pending", 0)
+ *   .otherwise(-1)
+ *   .end();
+ * ```
+ */
+export class CaseValueBuilder {
+  private readonly branches: Array<{ value: unknown; result: unknown }> = [];
+  private elseValue: { present: true; value: unknown } | undefined;
+
+  constructor(private readonly subject: unknown) {}
+
+  when(value: unknown, result: unknown): this {
+    if (this.elseValue) {
+      throw new Error(
+        "CaseValueBuilder: cannot add .when() after .otherwise() has been set.",
+      );
+    }
+    this.branches.push({ value, result });
+    return this;
+  }
+
+  otherwise(result: unknown): this {
+    if (this.elseValue) {
+      throw new Error("CaseValueBuilder: .otherwise() already set.");
+    }
+    this.elseValue = { present: true, value: result };
+    return this;
+  }
+
+  end(): ScalarExpression {
+    if (this.branches.length === 0) {
+      throw new Error(
+        "CaseValueBuilder.end(): simple CASE needs at least one WHEN/THEN pair.",
+      );
+    }
+    const subject = this.subject;
+    const branches = this.branches;
+    const elseValue = this.elseValue;
+    return new ScalarExpression((resolveColumn, dialect) => {
+      const subj = renderResultValue(subject, resolveColumn, dialect);
+      const whenParts = branches.map((b) => {
+        const val = renderResultValue(b.value, resolveColumn, dialect);
+        const res = renderResultValue(b.result, resolveColumn, dialect);
+        return sql`WHEN ${val} THEN ${res}`;
+      });
+      if (elseValue) {
+        const def = renderResultValue(elseValue.value, resolveColumn, dialect);
+        return sql`CASE ${subj} ${join(whenParts, " ")} ELSE ${def} END`;
+      }
+      return sql`CASE ${subj} ${join(whenParts, " ")} END`;
+    });
+  }
+}
+
+/** Factory for a searched-CASE builder. Entry point for `Expressions.caseBuilder()`. */
+export function caseBuilder(): CaseBuilder {
+  return new CaseBuilder();
+}
+
+/** Factory for a simple-CASE builder. Entry point for `Expressions.cases(subject)`. */
+export function cases(subject: unknown): CaseValueBuilder {
+  return new CaseValueBuilder(subject);
+}

--- a/src/core/expressions/CastExpression.ts
+++ b/src/core/expressions/CastExpression.ts
@@ -1,0 +1,27 @@
+import sql, { Sql, raw } from "sql-template-tag";
+import type { CastKind, DialectExpression } from "../../dialects/DialectExpression";
+import type { ColumnResolver } from "./ConditionLike";
+import { ScalarExpression } from "./ScalarExpression";
+
+/**
+ * @internal Build a `CAST(<inner> AS <type>)` scalar expression around
+ * a pre-rendered inner SQL fragment. Used by `.stringValue()` /
+ * `.intValue()` / etc. helpers on both {@link ColumnExpression} and
+ * {@link ScalarExpression}.
+ */
+export function buildCastScalar(
+  kind: CastKind,
+  inner: (resolveColumn: ColumnResolver, dialect?: DialectExpression) => Sql,
+): ScalarExpression {
+  return new ScalarExpression((resolveColumn, dialect) => {
+    if (!dialect) {
+      throw new Error(
+        "CAST expressions require a DialectExpression. Ensure the query " +
+          "builder was created via EntityManager.createQueryBuilder().",
+      );
+    }
+    const value = inner(resolveColumn, dialect);
+    const typeName = dialect.castTypeName(kind);
+    return sql`CAST(${value} AS ${raw(typeName)})`;
+  });
+}

--- a/src/core/expressions/DateComponentExpression.ts
+++ b/src/core/expressions/DateComponentExpression.ts
@@ -1,0 +1,39 @@
+import sql, { raw } from "sql-template-tag";
+import type {
+  DateComponent,
+  DialectExpression,
+} from "../../dialects/DialectExpression";
+import type { Sql } from "sql-template-tag";
+import type { ColumnResolver } from "./ConditionLike";
+import { ScalarExpression } from "./ScalarExpression";
+
+/**
+ * @internal Build a date-component scalar expression around a
+ * pre-rendered inner value. Used by `.year()` / `.month()` / etc.
+ * helpers on both {@link ColumnExpression} and {@link ScalarExpression}.
+ */
+export function buildDateComponent(
+  component: DateComponent,
+  inner: (resolveColumn: ColumnResolver, dialect?: DialectExpression) => Sql,
+): ScalarExpression {
+  return new ScalarExpression((resolveColumn, dialect) => {
+    if (!dialect) {
+      throw new Error(
+        "Date component expressions require a DialectExpression. " +
+          "Ensure the query builder was created via EntityManager.createQueryBuilder().",
+      );
+    }
+    const value = inner(resolveColumn, dialect);
+    return dialect.dateComponent(value, component);
+  });
+}
+
+/** @internal shared for column-ref based date component helpers. */
+export function buildDateComponentFromRef(
+  component: DateComponent,
+  ref: string,
+): ScalarExpression {
+  return buildDateComponent(component, (resolveColumn) =>
+    sql`${raw(resolveColumn(ref))}`,
+  );
+}

--- a/src/core/expressions/JsonPathExpression.ts
+++ b/src/core/expressions/JsonPathExpression.ts
@@ -5,6 +5,7 @@ import type {
   DialectExpression,
 } from "../../dialects/DialectExpression";
 import type { ConditionLike, ColumnResolver } from "./ConditionLike";
+import { AliasedExpression } from "./AliasedExpression";
 
 /**
  * A segment of a JSON navigation path.
@@ -203,6 +204,7 @@ const JSON_EXPR_METHODS = new Set<string>([
   "hasKey",
   "arrayLength",
   "typeOf",
+  "as",
   "toString",
   "valueOf",
   "constructor",
@@ -327,6 +329,34 @@ class JsonPathExpressionBase {
   /** JSON type at this path (`'object'`, `'array'`, `'string'`, …), as a comparable scalar. */
   typeOf(): JsonScalarExpression {
     return new JsonScalarExpression(this._ref, this._path, "typeOf", this._meta);
+  }
+
+  /**
+   * Tag this JSON extraction for SELECT with a result alias.
+   *
+   * Emits a dialect-specific extraction (`JSON_UNQUOTE(JSON_EXTRACT(…))`
+   * on MySQL, `#>>` on PostgreSQL, `json_extract()` on SQLite) returned
+   * as text, followed by `AS <alias>`. Only meaningful when passed to
+   * `select()` / `addSelect()`.
+   *
+   * @example
+   * ```ts
+   * qb.select([u.metadata.profile.email.as("contact")]).getRawMany();
+   * ```
+   */
+  as(alias: string): AliasedExpression {
+    const ref = this._ref;
+    const path = this._path;
+    const meta = this._meta;
+    return new AliasedExpression(alias, (resolveColumn, dialect) => {
+      if (!dialect) {
+        throw new Error(
+          "JsonPathExpression.as() requires a DialectExpression. " +
+            "Ensure the query builder was created via EntityManager.createQueryBuilder().",
+        );
+      }
+      return dialect.jsonExtract(resolveColumn(ref), path, true, meta);
+    });
   }
 
   toString(): string {

--- a/src/core/expressions/LogicalCondition.ts
+++ b/src/core/expressions/LogicalCondition.ts
@@ -17,6 +17,12 @@ import {
   registerExistsLogicalComposer,
   ExistsCondition,
 } from "./SubqueryExpression";
+import {
+  caseBuilder as caseBuilderFactory,
+  cases as casesFactory,
+  CaseBuilder,
+  CaseValueBuilder,
+} from "./CaseExpression";
 
 export type LogicalOperator = "AND" | "OR" | "NOT";
 
@@ -192,6 +198,24 @@ export const Expressions = {
     subquery: { toSql(): import("sql-template-tag").Sql },
   ): ExistsCondition {
     return notExistsFactory(subquery);
+  },
+
+  /**
+   * Start a **searched** `CASE WHEN cond THEN val … ELSE val END`
+   * builder. Chain `.when(cond).then(val)` for each branch, optionally
+   * finish with `.otherwise(val)`, then call `.end()` to finalize.
+   */
+  caseBuilder(): CaseBuilder {
+    return caseBuilderFactory();
+  },
+
+  /**
+   * Start a **simple** `CASE value WHEN v1 THEN r1 …` builder. Useful
+   * for value-switching — e.g. converting a status column into a
+   * priority number.
+   */
+  cases(subject: unknown): CaseValueBuilder {
+    return casesFactory(subject);
   },
 } as const;
 

--- a/src/core/expressions/LogicalCondition.ts
+++ b/src/core/expressions/LogicalCondition.ts
@@ -11,6 +11,12 @@ import {
   currentTimestamp,
 } from "./TemporalExpression";
 import type { ScalarExpression } from "./ScalarExpression";
+import {
+  exists as existsFactory,
+  notExists as notExistsFactory,
+  registerExistsLogicalComposer,
+  ExistsCondition,
+} from "./SubqueryExpression";
 
 export type LogicalOperator = "AND" | "OR" | "NOT";
 
@@ -172,6 +178,21 @@ export const Expressions = {
   currentTimestamp(): ScalarExpression {
     return currentTimestamp();
   },
+
+  /**
+   * `EXISTS (subquery)`. Pass a `SelectQueryBuilder`; the subquery is
+   * rendered (with bindings preserved) at condition-resolution time.
+   */
+  exists(subquery: { toSql(): import("sql-template-tag").Sql }): ExistsCondition {
+    return existsFactory(subquery);
+  },
+
+  /** `NOT EXISTS (subquery)`. Mirror of {@link exists}. */
+  notExists(
+    subquery: { toSql(): import("sql-template-tag").Sql },
+  ): ExistsCondition {
+    return notExistsFactory(subquery);
+  },
 } as const;
 
 // Register the composer so AggregateCondition.and/.or/.not (and any other
@@ -184,6 +205,12 @@ registerLogicalComposer({
 });
 
 registerScalarLogicalComposer({
+  and: (a, b) => new LogicalCondition("AND", [a, b]),
+  or: (a, b) => new LogicalCondition("OR", [a, b]),
+  not: (a) => new LogicalCondition("NOT", [a]),
+});
+
+registerExistsLogicalComposer({
   and: (a, b) => new LogicalCondition("AND", [a, b]),
   or: (a, b) => new LogicalCondition("OR", [a, b]),
   not: (a) => new LogicalCondition("NOT", [a]),

--- a/src/core/expressions/LogicalCondition.ts
+++ b/src/core/expressions/LogicalCondition.ts
@@ -5,6 +5,11 @@ import type { DialectExpression } from "../../dialects/DialectExpression";
 import { registerLogicalComposer } from "./AggregateExpression";
 import { registerScalarLogicalComposer } from "./ScalarExpression";
 import { coalesce, nullif } from "./NullishExpression";
+import {
+  currentDate,
+  currentTime,
+  currentTimestamp,
+} from "./TemporalExpression";
 import type { ScalarExpression } from "./ScalarExpression";
 
 export type LogicalOperator = "AND" | "OR" | "NOT";
@@ -151,6 +156,21 @@ export const Expressions = {
    */
   nullif(a: unknown, b: unknown): ScalarExpression {
     return nullif(a, b);
+  },
+
+  /** `CURRENT_DATE` — the database server's current date. */
+  currentDate(): ScalarExpression {
+    return currentDate();
+  },
+
+  /** `CURRENT_TIME` — the database server's current time of day. */
+  currentTime(): ScalarExpression {
+    return currentTime();
+  },
+
+  /** `CURRENT_TIMESTAMP` — the database server's current date+time. */
+  currentTimestamp(): ScalarExpression {
+    return currentTimestamp();
   },
 } as const;
 

--- a/src/core/expressions/LogicalCondition.ts
+++ b/src/core/expressions/LogicalCondition.ts
@@ -3,6 +3,9 @@ import sql, { Sql, join } from "sql-template-tag";
 import type { ConditionLike, ColumnResolver } from "./ConditionLike";
 import type { DialectExpression } from "../../dialects/DialectExpression";
 import { registerLogicalComposer } from "./AggregateExpression";
+import { registerScalarLogicalComposer } from "./ScalarExpression";
+import { coalesce, nullif } from "./NullishExpression";
+import type { ScalarExpression } from "./ScalarExpression";
 
 export type LogicalOperator = "AND" | "OR" | "NOT";
 
@@ -121,12 +124,46 @@ export const Expressions = {
   not(cond: ConditionLike): LogicalCondition {
     return new LogicalCondition("NOT", [cond]);
   },
+
+  /**
+   * `COALESCE(a, b, c, …)` — first non-null argument.
+   *
+   * Accepts any mix of {@link ColumnExpression}, {@link ScalarExpression},
+   * {@link AggregateExpression}, JSON path extractions, and plain
+   * values. Requires at least 2 arguments.
+   *
+   * @example
+   * ```ts
+   * Expressions.coalesce(u.nickname, u.name, "anonymous")
+   * ```
+   */
+  coalesce(first: unknown, second: unknown, ...rest: unknown[]): ScalarExpression {
+    return coalesce(first, second, ...rest);
+  },
+
+  /**
+   * `NULLIF(a, b)` — returns `NULL` when `a === b`, otherwise `a`.
+   *
+   * @example
+   * ```ts
+   * Expressions.nullif(u.email, "")  // turn empty string into NULL
+   * ```
+   */
+  nullif(a: unknown, b: unknown): ScalarExpression {
+    return nullif(a, b);
+  },
 } as const;
 
 // Register the composer so AggregateCondition.and/.or/.not (and any other
 // condition type that wants to delegate) can resolve the LogicalCondition
 // factory without forming an import cycle.
 registerLogicalComposer({
+  and: (a, b) => new LogicalCondition("AND", [a, b]),
+  or: (a, b) => new LogicalCondition("OR", [a, b]),
+  not: (a) => new LogicalCondition("NOT", [a]),
+});
+
+registerScalarLogicalComposer({
   and: (a, b) => new LogicalCondition("AND", [a, b]),
   or: (a, b) => new LogicalCondition("OR", [a, b]),
   not: (a) => new LogicalCondition("NOT", [a]),

--- a/src/core/expressions/NullishExpression.ts
+++ b/src/core/expressions/NullishExpression.ts
@@ -1,0 +1,123 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import sql, { Sql, raw, join } from "sql-template-tag";
+import type { ColumnResolver } from "./ConditionLike";
+import type { DialectExpression } from "../../dialects/DialectExpression";
+import { ScalarExpression } from "./ScalarExpression";
+import {
+  AggregateExpression,
+  isAggregateExpression,
+} from "./AggregateExpression";
+import { isJsonPathExpression } from "./JsonPathExpression";
+import { isScalarExpression } from "./ScalarExpression";
+
+/**
+ * Duck-type guard for `ColumnExpression` — defined inline here to avoid
+ * an import cycle with `SelectQueryBuilder.ts`. `ColumnExpression`
+ * carries an `__isColumnExpression` marker for exactly this purpose.
+ */
+function isColumnExpr(value: unknown): boolean {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    (value as { __isColumnExpression?: unknown }).__isColumnExpression === true
+  );
+}
+
+/**
+ * Inputs accepted by `coalesce()` / `nullif()`. Column and path
+ * expressions resolve against the query builder's alias registry;
+ * plain values are sent as bound parameters.
+ */
+export type NullishArg = ScalarExpression | AggregateExpression | unknown;
+
+/**
+ * @internal Render any accepted argument into a parameter-safe `Sql`
+ * fragment. Keeps the coalesce/nullif builders small and aligns their
+ * argument semantics: entity-aware references become qualified column
+ * references, JSON paths delegate to the dialect's text extract, and
+ * scalars go through standard placeholder binding.
+ */
+export function renderNullishArg(
+  arg: NullishArg,
+  resolveColumn: ColumnResolver,
+  dialect?: DialectExpression,
+): Sql {
+  if (isColumnExpr(arg)) {
+    return sql`${raw(resolveColumn((arg as { toString(): string }).toString()))}`;
+  }
+  if (isAggregateExpression(arg)) {
+    return (arg as AggregateExpression).renderFunction(resolveColumn);
+  }
+  if (isScalarExpression(arg)) {
+    return (arg as ScalarExpression).renderer(resolveColumn, dialect);
+  }
+  if (isJsonPathExpression(arg)) {
+    if (!dialect) {
+      throw new Error(
+        "JsonPathExpression inside coalesce()/nullif() requires a DialectExpression. " +
+          "Ensure the query builder was created via EntityManager.createQueryBuilder().",
+      );
+    }
+    const jp = arg as {
+      _ref: string;
+      _path: ReadonlyArray<string | number>;
+      _meta?: import("../../dialects/DialectExpression").ColumnJsonMeta;
+    };
+    return dialect.jsonExtract(resolveColumn(jp._ref), jp._path, true, jp._meta);
+  }
+  return sql`${arg as any}`;
+}
+
+/**
+ * Build a `COALESCE(a, b, c, …)` scalar expression.
+ *
+ * Accepts any mix of column references, scalar expressions, aggregates,
+ * JSON path extractions, and plain values. The returned
+ * {@link ScalarExpression} can be projected with `.as("alias")`,
+ * compared with `.eq()` / `.gt()` / etc., and nested inside other
+ * scalar expressions.
+ *
+ * Requires at least two arguments — a single-argument COALESCE is a
+ * no-op that SQL engines typically reject.
+ *
+ * @example
+ * ```ts
+ * const u = qAlias(User, "u");
+ * const display = coalesce(u.nickname, u.name, "anonymous");
+ * qb.select([display.as("display_name")]);
+ * ```
+ */
+export function coalesce(...args: NullishArg[]): ScalarExpression {
+  if (args.length < 2) {
+    throw new Error("coalesce() requires at least 2 arguments.");
+  }
+  const captured = args;
+  return new ScalarExpression((resolveColumn, dialect) => {
+    const parts = captured.map((a) =>
+      renderNullishArg(a, resolveColumn, dialect),
+    );
+    return sql`COALESCE(${join(parts, ", ")})`;
+  });
+}
+
+/**
+ * Build a `NULLIF(a, b)` scalar expression — returns `NULL` when `a`
+ * equals `b`, otherwise `a`. Useful for turning a sentinel value into
+ * a real `NULL` (e.g. empty string → missing email).
+ *
+ * Both arguments accept column references, scalar expressions,
+ * aggregates, JSON path extractions, and plain values.
+ *
+ * @example
+ * ```ts
+ * const u = qAlias(User, "u");
+ * qb.select([nullif(u.email, "").as("email_or_null")]);
+ * ```
+ */
+export function nullif(a: NullishArg, b: NullishArg): ScalarExpression {
+  return new ScalarExpression((resolveColumn, dialect) => {
+    const left = renderNullishArg(a, resolveColumn, dialect);
+    const right = renderNullishArg(b, resolveColumn, dialect);
+    return sql`NULLIF(${left}, ${right})`;
+  });
+}

--- a/src/core/expressions/ScalarExpression.ts
+++ b/src/core/expressions/ScalarExpression.ts
@@ -1,7 +1,10 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import sql, { Sql, raw, join } from "sql-template-tag";
 import type { ConditionLike, ColumnResolver } from "./ConditionLike";
-import type { DialectExpression } from "../../dialects/DialectExpression";
+import type {
+  CastKind,
+  DialectExpression,
+} from "../../dialects/DialectExpression";
 import { AliasedExpression } from "./AliasedExpression";
 
 /**
@@ -85,6 +88,43 @@ export class ScalarExpression {
   }
   notLike(pattern: string): ScalarCondition {
     return new ScalarCondition(this, "NOT LIKE", pattern);
+  }
+
+  // ── CAST helpers — chain a CAST onto any scalar result ──
+  /** Wrap in `CAST(... AS TEXT/CHAR)`. */
+  stringValue(): ScalarExpression {
+    return this.buildCast("string");
+  }
+  /** Wrap in `CAST(... AS INTEGER/SIGNED)`. */
+  intValue(): ScalarExpression {
+    return this.buildCast("int");
+  }
+  /** Wrap in `CAST(... AS BIGINT/SIGNED)`. */
+  longValue(): ScalarExpression {
+    return this.buildCast("long");
+  }
+  /** Wrap in `CAST(... AS REAL/DECIMAL)`. */
+  floatValue(): ScalarExpression {
+    return this.buildCast("float");
+  }
+  /** Wrap in `CAST(... AS BOOLEAN/UNSIGNED/INTEGER)`. */
+  booleanValue(): ScalarExpression {
+    return this.buildCast("boolean");
+  }
+
+  private buildCast(kind: CastKind): ScalarExpression {
+    const innerRenderer = this.renderer;
+    return new ScalarExpression((resolveColumn, dialect) => {
+      if (!dialect) {
+        throw new Error(
+          "CAST expressions require a DialectExpression. Ensure the query " +
+            "builder was created via EntityManager.createQueryBuilder().",
+        );
+      }
+      const value = innerRenderer(resolveColumn, dialect);
+      const typeName = dialect.castTypeName(kind);
+      return sql`CAST(${value} AS ${raw(typeName)})`;
+    });
   }
 }
 

--- a/src/core/expressions/ScalarExpression.ts
+++ b/src/core/expressions/ScalarExpression.ts
@@ -1,0 +1,203 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import sql, { Sql, raw, join } from "sql-template-tag";
+import type { ConditionLike, ColumnResolver } from "./ConditionLike";
+import type { DialectExpression } from "../../dialects/DialectExpression";
+import { AliasedExpression } from "./AliasedExpression";
+
+/**
+ * Renderer contract for a scalar SQL expression — produces one `Sql`
+ * value per call. Used by {@link ScalarExpression} to defer rendering
+ * until the query builder has an alias resolver and dialect handle.
+ */
+export type ScalarRenderer = (
+  resolveColumn: ColumnResolver,
+  dialect?: DialectExpression,
+) => Sql;
+
+/**
+ * A deferred scalar SQL expression — the output of functions that
+ * compute a value (`COALESCE(a, b)`, `NULLIF(a, b)`, `CAST(col AS
+ * TYPE)`, `EXTRACT(YEAR FROM col)` …).
+ *
+ * Plays the same dual role as a {@link ColumnExpression}: it can be
+ * projected in SELECT via `.as("alias")`, compared with `.eq()` /
+ * `.gt()` / `.between()` to produce a {@link ScalarCondition}, and used
+ * as an argument to other scalar expressions (so `coalesce(col,
+ * nullif(x, y))` composes naturally).
+ *
+ * @example
+ * ```ts
+ * const u = qAlias(User, "u");
+ * const display = u.nickname.coalesce(u.name, "anonymous");
+ *
+ * qb.select([display.as("display_name")])
+ *   .where(display.eq("admin"));
+ * ```
+ */
+export class ScalarExpression {
+  readonly __isScalarExpression = true as const;
+
+  constructor(readonly renderer: ScalarRenderer) {}
+
+  /** Tag this expression for SELECT with a result alias. */
+  as(alias: string): AliasedExpression {
+    const renderer = this.renderer;
+    return new AliasedExpression(alias, (resolveColumn, dialect) =>
+      renderer(resolveColumn, dialect),
+    );
+  }
+
+  eq(value: any): ScalarCondition {
+    return new ScalarCondition(this, "=", value);
+  }
+  neq(value: any): ScalarCondition {
+    return new ScalarCondition(this, "!=", value);
+  }
+  gt(value: any): ScalarCondition {
+    return new ScalarCondition(this, ">", value);
+  }
+  gte(value: any): ScalarCondition {
+    return new ScalarCondition(this, ">=", value);
+  }
+  lt(value: any): ScalarCondition {
+    return new ScalarCondition(this, "<", value);
+  }
+  lte(value: any): ScalarCondition {
+    return new ScalarCondition(this, "<=", value);
+  }
+  between(min: any, max: any): ScalarCondition {
+    return new ScalarCondition(this, "BETWEEN", [min, max]);
+  }
+  in(values: any[]): ScalarCondition {
+    return new ScalarCondition(this, "IN", values);
+  }
+  notIn(values: any[]): ScalarCondition {
+    return new ScalarCondition(this, "NOT IN", values);
+  }
+  isNull(): ScalarCondition {
+    return new ScalarCondition(this, "IS NULL", undefined);
+  }
+  isNotNull(): ScalarCondition {
+    return new ScalarCondition(this, "IS NOT NULL", undefined);
+  }
+  like(pattern: string): ScalarCondition {
+    return new ScalarCondition(this, "LIKE", pattern);
+  }
+  notLike(pattern: string): ScalarCondition {
+    return new ScalarCondition(this, "NOT LIKE", pattern);
+  }
+}
+
+/**
+ * Type guard — true if `value` is a {@link ScalarExpression}.
+ */
+export function isScalarExpression(
+  value: unknown,
+): value is ScalarExpression {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    (value as { __isScalarExpression?: unknown }).__isScalarExpression === true
+  );
+}
+
+/**
+ * A deferred WHERE / HAVING condition comparing a {@link ScalarExpression}
+ * to a scalar value (or BETWEEN range / IN list).
+ *
+ * Implements {@link ConditionLike}, so it can be passed to `where()`,
+ * `andWhere()`, `orWhere()`, or `having()`.
+ */
+export class ScalarCondition implements ConditionLike {
+  readonly __isCondition = true as const;
+  readonly __isScalarCondition = true as const;
+
+  constructor(
+    readonly expression: ScalarExpression,
+    readonly operator: string,
+    readonly value: unknown,
+  ) {}
+
+  resolve(resolveColumn: ColumnResolver, dialect?: DialectExpression): Sql {
+    const expr = this.expression.renderer(resolveColumn, dialect);
+    const op = this.operator;
+
+    if (op === "IS NULL") return sql`${expr} IS NULL`;
+    if (op === "IS NOT NULL") return sql`${expr} IS NOT NULL`;
+    if (op === "BETWEEN") {
+      const [min, max] = this.value as [any, any];
+      return sql`${expr} BETWEEN ${min} AND ${max}`;
+    }
+    if (op === "IN" || op === "NOT IN") {
+      const values = (this.value as any[]) ?? [];
+      if (values.length === 0) {
+        return op === "IN" ? sql`1 = 0` : sql`1 = 1`;
+      }
+      const placeholders = values.map((v) => sql`${v}`);
+      return sql`${expr} ${raw(op)} (${join(placeholders, ", ")})`;
+    }
+    return sql`${expr} ${raw(op)} ${this.value as any}`;
+  }
+
+  /** Compose with another condition using AND. */
+  and(other: ConditionLike): ConditionLike {
+    return LogicalComposer.and(this, other);
+  }
+  /** Compose with another condition using OR. */
+  or(other: ConditionLike): ConditionLike {
+    return LogicalComposer.or(this, other);
+  }
+  /** Negate this scalar condition. */
+  not(): ConditionLike {
+    return LogicalComposer.not(this);
+  }
+}
+
+/**
+ * Type guard — true if `value` is a {@link ScalarCondition}.
+ */
+export function isScalarCondition(value: unknown): value is ScalarCondition {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    (value as { __isScalarCondition?: unknown }).__isScalarCondition === true
+  );
+}
+
+/**
+ * @internal Indirection layer so this file avoids a cycle with
+ * {@link LogicalCondition}. Wired up at module load time via
+ * {@link registerScalarLogicalComposer}.
+ */
+type LogicalComposerFns = {
+  and(a: ConditionLike, b: ConditionLike): ConditionLike;
+  or(a: ConditionLike, b: ConditionLike): ConditionLike;
+  not(a: ConditionLike): ConditionLike;
+};
+
+let LogicalComposer: LogicalComposerFns = {
+  and: () => {
+    throw new Error(
+      "LogicalCondition not registered. Ensure '@stingerloom/orm' is imported via its public entrypoint.",
+    );
+  },
+  or: () => {
+    throw new Error(
+      "LogicalCondition not registered. Ensure '@stingerloom/orm' is imported via its public entrypoint.",
+    );
+  },
+  not: () => {
+    throw new Error(
+      "LogicalCondition not registered. Ensure '@stingerloom/orm' is imported via its public entrypoint.",
+    );
+  },
+};
+
+/**
+ * @internal Wire up the logical-composer functions after
+ * {@link LogicalCondition} has been loaded. Called once from
+ * `LogicalCondition.ts`.
+ */
+export function registerScalarLogicalComposer(fns: LogicalComposerFns): void {
+  LogicalComposer = fns;
+}

--- a/src/core/expressions/ScalarExpression.ts
+++ b/src/core/expressions/ScalarExpression.ts
@@ -3,6 +3,7 @@ import sql, { Sql, raw, join } from "sql-template-tag";
 import type { ConditionLike, ColumnResolver } from "./ConditionLike";
 import type {
   CastKind,
+  DateComponent,
   DialectExpression,
 } from "../../dialects/DialectExpression";
 import { AliasedExpression } from "./AliasedExpression";
@@ -124,6 +125,62 @@ export class ScalarExpression {
       const value = innerRenderer(resolveColumn, dialect);
       const typeName = dialect.castTypeName(kind);
       return sql`CAST(${value} AS ${raw(typeName)})`;
+    });
+  }
+
+  // ── Date / time component helpers (Tier 2) ─────────────
+  /** Extract year. */
+  year(): ScalarExpression {
+    return this.buildDateComponent("year");
+  }
+  /** Extract month (1–12). */
+  month(): ScalarExpression {
+    return this.buildDateComponent("month");
+  }
+  /** Alias of `.dayOfMonth()`. */
+  day(): ScalarExpression {
+    return this.buildDateComponent("day");
+  }
+  /** Extract hour (0–23). */
+  hour(): ScalarExpression {
+    return this.buildDateComponent("hour");
+  }
+  /** Extract minute of hour (0–59). */
+  minute(): ScalarExpression {
+    return this.buildDateComponent("minute");
+  }
+  /** Extract second of minute (0–59). */
+  second(): ScalarExpression {
+    return this.buildDateComponent("second");
+  }
+  /** Day of week — engine-specific encoding. */
+  dayOfWeek(): ScalarExpression {
+    return this.buildDateComponent("dayOfWeek");
+  }
+  /** Day of month (1–31). */
+  dayOfMonth(): ScalarExpression {
+    return this.buildDateComponent("dayOfMonth");
+  }
+  /** Day of year (1–366). */
+  dayOfYear(): ScalarExpression {
+    return this.buildDateComponent("dayOfYear");
+  }
+  /** Week of year — engine-specific encoding. */
+  week(): ScalarExpression {
+    return this.buildDateComponent("week");
+  }
+
+  private buildDateComponent(component: DateComponent): ScalarExpression {
+    const innerRenderer = this.renderer;
+    return new ScalarExpression((resolveColumn, dialect) => {
+      if (!dialect) {
+        throw new Error(
+          "Date component expressions require a DialectExpression. " +
+            "Ensure the query builder was created via EntityManager.createQueryBuilder().",
+        );
+      }
+      const value = innerRenderer(resolveColumn, dialect);
+      return dialect.dateComponent(value, component);
     });
   }
 }

--- a/src/core/expressions/SubqueryExpression.ts
+++ b/src/core/expressions/SubqueryExpression.ts
@@ -1,0 +1,139 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import sql, { Sql } from "sql-template-tag";
+import type { ConditionLike, ColumnResolver } from "./ConditionLike";
+import type { DialectExpression } from "../../dialects/DialectExpression";
+
+/**
+ * Duck-type guard — true if `value` looks like a `SelectQueryBuilder`
+ * (has `.toSql()` + `.getSql()` methods). Kept as duck typing to avoid
+ * an import cycle from `src/core/SelectQueryBuilder.ts`.
+ */
+export function isSubqueryLike(
+  value: unknown,
+): value is { toSql(): Sql } {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as { toSql?: unknown }).toSql === "function" &&
+    typeof (value as { getSql?: unknown }).getSql === "function"
+  );
+}
+
+/**
+ * @internal Render a subquery-like value (e.g. a `SelectQueryBuilder`)
+ * as a parenthesized `Sql` fragment suitable for embedding in an IN /
+ * EXISTS / scalar-comparison position.
+ */
+export function renderSubquery(value: { toSql(): Sql }): Sql {
+  const inner = value.toSql();
+  return sql`(${inner})`;
+}
+
+/**
+ * A deferred `EXISTS (subquery)` / `NOT EXISTS (subquery)` condition.
+ *
+ * Users normally do not construct this directly — they call
+ * `Expressions.exists(subQb)` / `Expressions.notExists(subQb)`.
+ */
+export class ExistsCondition implements ConditionLike {
+  readonly __isCondition = true as const;
+  readonly __isExistsCondition = true as const;
+
+  constructor(
+    readonly subquery: { toSql(): Sql },
+    readonly negated: boolean,
+  ) {}
+
+  resolve(_resolveColumn: ColumnResolver, _dialect?: DialectExpression): Sql {
+    const inner = this.subquery.toSql();
+    return this.negated
+      ? sql`NOT EXISTS (${inner})`
+      : sql`EXISTS (${inner})`;
+  }
+
+  and(other: ConditionLike): ConditionLike {
+    return LogicalComposer.and(this, other);
+  }
+  or(other: ConditionLike): ConditionLike {
+    return LogicalComposer.or(this, other);
+  }
+  not(): ConditionLike {
+    // Toggle the negated flag rather than nesting in NOT () for cleaner SQL.
+    return new ExistsCondition(this.subquery, !this.negated);
+  }
+}
+
+/** Type guard — true if `value` is an {@link ExistsCondition}. */
+export function isExistsCondition(value: unknown): value is ExistsCondition {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    (value as { __isExistsCondition?: unknown }).__isExistsCondition === true
+  );
+}
+
+/**
+ * @internal Indirection layer for logical composition, wired up from
+ * {@link LogicalCondition} at module load time.
+ */
+type LogicalComposerFns = {
+  and(a: ConditionLike, b: ConditionLike): ConditionLike;
+  or(a: ConditionLike, b: ConditionLike): ConditionLike;
+  not(a: ConditionLike): ConditionLike;
+};
+
+let LogicalComposer: LogicalComposerFns = {
+  and: () => {
+    throw new Error(
+      "LogicalCondition not registered. Ensure '@stingerloom/orm' is imported via its public entrypoint.",
+    );
+  },
+  or: () => {
+    throw new Error(
+      "LogicalCondition not registered. Ensure '@stingerloom/orm' is imported via its public entrypoint.",
+    );
+  },
+  not: () => {
+    throw new Error(
+      "LogicalCondition not registered. Ensure '@stingerloom/orm' is imported via its public entrypoint.",
+    );
+  },
+};
+
+/** @internal Wire up composition. Called once from LogicalCondition.ts. */
+export function registerExistsLogicalComposer(
+  fns: LogicalComposerFns,
+): void {
+  LogicalComposer = fns;
+}
+
+/**
+ * Factory — `EXISTS (subquery)`. Pass a `SelectQueryBuilder` (any
+ * entity/result type); the builder is rendered at WHERE/HAVING-build
+ * time, preserving all bound parameters.
+ *
+ * @example
+ * ```ts
+ * const active = em.createQueryBuilder(Post, "p")
+ *   .select(["id"]).where(sql`"p"."author_id" = "u"."id"`);
+ *
+ * qb.where(Expressions.exists(active));
+ * // WHERE EXISTS (SELECT "id" FROM "post" AS "p" WHERE "p"."author_id" = "u"."id")
+ * ```
+ */
+export function exists(subquery: { toSql(): Sql }): ExistsCondition {
+  if (!isSubqueryLike(subquery)) {
+    throw new Error("exists() requires a SelectQueryBuilder-like argument.");
+  }
+  return new ExistsCondition(subquery, false);
+}
+
+/** Factory — `NOT EXISTS (subquery)`. Symmetric to {@link exists}. */
+export function notExists(subquery: { toSql(): Sql }): ExistsCondition {
+  if (!isSubqueryLike(subquery)) {
+    throw new Error(
+      "notExists() requires a SelectQueryBuilder-like argument.",
+    );
+  }
+  return new ExistsCondition(subquery, true);
+}

--- a/src/core/expressions/TemporalExpression.ts
+++ b/src/core/expressions/TemporalExpression.ts
@@ -1,0 +1,40 @@
+import sql from "sql-template-tag";
+import { ScalarExpression } from "./ScalarExpression";
+
+/**
+ * `CURRENT_DATE` — the database server's current date (no time
+ * component), as a {@link ScalarExpression} that slots into SELECT,
+ * WHERE, HAVING, and ORDER BY.
+ *
+ * Standard SQL; every supported dialect emits the same literal.
+ *
+ * @example
+ * ```ts
+ * qb.where(u.createdAt.gte(Expressions.currentDate()));
+ * ```
+ */
+export function currentDate(): ScalarExpression {
+  return new ScalarExpression(() => sql`CURRENT_DATE`);
+}
+
+/**
+ * `CURRENT_TIME` — the database server's current time (no date
+ * component), as a {@link ScalarExpression}.
+ */
+export function currentTime(): ScalarExpression {
+  return new ScalarExpression(() => sql`CURRENT_TIME`);
+}
+
+/**
+ * `CURRENT_TIMESTAMP` — the database server's current date+time, as a
+ * {@link ScalarExpression}. Most common of the three; use it for
+ * "now()"-style comparisons.
+ *
+ * @example
+ * ```ts
+ * qb.where(u.expiresAt.lte(Expressions.currentTimestamp()));
+ * ```
+ */
+export function currentTimestamp(): ScalarExpression {
+  return new ScalarExpression(() => sql`CURRENT_TIMESTAMP`);
+}

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -46,4 +46,5 @@ export * from "./expressions/TemporalExpression";
 export * from "./expressions/CastExpression";
 export * from "./expressions/DateComponentExpression";
 export * from "./expressions/SubqueryExpression";
+export * from "./expressions/CaseExpression";
 export * from "./expressions/likeEscape";

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -42,4 +42,5 @@ export * from "./expressions/LogicalCondition";
 export * from "./expressions/AliasedExpression";
 export * from "./expressions/ScalarExpression";
 export * from "./expressions/NullishExpression";
+export * from "./expressions/TemporalExpression";
 export * from "./expressions/likeEscape";

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -40,4 +40,6 @@ export * from "./expressions/OrderExpression";
 export * from "./expressions/AggregateExpression";
 export * from "./expressions/LogicalCondition";
 export * from "./expressions/AliasedExpression";
+export * from "./expressions/ScalarExpression";
+export * from "./expressions/NullishExpression";
 export * from "./expressions/likeEscape";

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -44,4 +44,5 @@ export * from "./expressions/ScalarExpression";
 export * from "./expressions/NullishExpression";
 export * from "./expressions/TemporalExpression";
 export * from "./expressions/CastExpression";
+export * from "./expressions/DateComponentExpression";
 export * from "./expressions/likeEscape";

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -39,4 +39,5 @@ export * from "./expressions/ConditionLike";
 export * from "./expressions/OrderExpression";
 export * from "./expressions/AggregateExpression";
 export * from "./expressions/LogicalCondition";
+export * from "./expressions/AliasedExpression";
 export * from "./expressions/likeEscape";

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -43,4 +43,5 @@ export * from "./expressions/AliasedExpression";
 export * from "./expressions/ScalarExpression";
 export * from "./expressions/NullishExpression";
 export * from "./expressions/TemporalExpression";
+export * from "./expressions/CastExpression";
 export * from "./expressions/likeEscape";

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -45,4 +45,5 @@ export * from "./expressions/NullishExpression";
 export * from "./expressions/TemporalExpression";
 export * from "./expressions/CastExpression";
 export * from "./expressions/DateComponentExpression";
+export * from "./expressions/SubqueryExpression";
 export * from "./expressions/likeEscape";

--- a/src/dialects/DialectExpression.ts
+++ b/src/dialects/DialectExpression.ts
@@ -130,7 +130,31 @@ export interface DialectExpression {
     path: ReadonlyArray<string | number>,
     meta?: ColumnJsonMeta,
   ): Sql;
+
+  /**
+   * Dialect-specific SQL type name for a given {@link CastKind}. Used
+   * by scalar `.stringValue()` / `.intValue()` / etc. helpers to render
+   * `CAST(x AS <name>)` with the right portable type label.
+   *
+   * Mapping:
+   *
+   * | Kind      | MySQL      | PostgreSQL | SQLite  |
+   * |-----------|------------|------------|---------|
+   * | `string`  | `CHAR`     | `TEXT`     | `TEXT`  |
+   * | `int`     | `SIGNED`   | `INTEGER`  | `INTEGER` |
+   * | `long`    | `SIGNED`   | `BIGINT`   | `INTEGER` |
+   * | `float`   | `DECIMAL`  | `REAL`     | `REAL`  |
+   * | `boolean` | `UNSIGNED` | `BOOLEAN`  | `INTEGER` |
+   */
+  castTypeName(kind: CastKind): string;
 }
+
+/**
+ * Supported CAST target kinds for the `.stringValue()` /
+ * `.intValue()` family. Resolved to a dialect-specific SQL type name
+ * by {@link DialectExpression.castTypeName}.
+ */
+export type CastKind = "string" | "int" | "long" | "float" | "boolean";
 
 /** Singleton cache — implementations are stateless. */
 const cache = new Map<DialectName, DialectExpression>();

--- a/src/dialects/DialectExpression.ts
+++ b/src/dialects/DialectExpression.ts
@@ -147,6 +147,31 @@ export interface DialectExpression {
    * | `boolean` | `UNSIGNED` | `BOOLEAN`  | `INTEGER` |
    */
   castTypeName(kind: CastKind): string;
+
+  /**
+   * Render a date/time component extraction on `value` — e.g.
+   * `YEAR(col)` (MySQL), `EXTRACT(YEAR FROM col)` (PostgreSQL),
+   * `CAST(strftime('%Y', col) AS INTEGER)` (SQLite).
+   *
+   * The `value` is pre-rendered (already a `Sql` fragment) so callers
+   * can pass column references, other scalar expressions, or function
+   * calls without worrying about dialect-specific quoting.
+   *
+   * Component mapping:
+   * - `year`: 4-digit year
+   * - `month`: 1–12
+   * - `day`: alias of `dayOfMonth`, 1–31
+   * - `hour`: 0–23
+   * - `minute`: 0–59
+   * - `second`: 0–59 (or 60 for leap seconds on some engines)
+   * - `dayOfWeek`: engine-dependent encoding (MySQL 1=Sun…7=Sat,
+   *   PostgreSQL 0=Sun…6=Sat, SQLite same as PG). Prefer explicit
+   *   ISO-aware logic if portability matters.
+   * - `dayOfMonth`: 1–31
+   * - `dayOfYear`: 1–366
+   * - `week`: engine-dependent week-of-year.
+   */
+  dateComponent(value: Sql, component: DateComponent): Sql;
 }
 
 /**
@@ -155,6 +180,22 @@ export interface DialectExpression {
  * by {@link DialectExpression.castTypeName}.
  */
 export type CastKind = "string" | "int" | "long" | "float" | "boolean";
+
+/**
+ * Supported date-component extraction kinds. Resolved to dialect-
+ * specific SQL by {@link DialectExpression.dateComponent}.
+ */
+export type DateComponent =
+  | "year"
+  | "month"
+  | "day"
+  | "hour"
+  | "minute"
+  | "second"
+  | "dayOfWeek"
+  | "dayOfMonth"
+  | "dayOfYear"
+  | "week";
 
 /** Singleton cache — implementations are stateless. */
 const cache = new Map<DialectName, DialectExpression>();

--- a/src/dialects/expression/MySqlExpression.ts
+++ b/src/dialects/expression/MySqlExpression.ts
@@ -1,6 +1,10 @@
 import sql, { raw } from "sql-template-tag";
 import type { Sql } from "sql-template-tag";
-import type { ColumnJsonMeta, DialectExpression } from "../DialectExpression";
+import type {
+  CastKind,
+  ColumnJsonMeta,
+  DialectExpression,
+} from "../DialectExpression";
 
 /**
  * Serialize a JSON path into MySQL/SQLite syntax: `$.a.b[0].c`.
@@ -107,5 +111,19 @@ export class MySqlExpression implements DialectExpression {
     }
     const p = buildJsonPathString(path);
     return sql`JSON_TYPE(JSON_EXTRACT(${raw(column)}, ${p}))`;
+  }
+
+  castTypeName(kind: CastKind): string {
+    switch (kind) {
+      case "string":
+        return "CHAR";
+      case "int":
+      case "long":
+        return "SIGNED";
+      case "float":
+        return "DECIMAL";
+      case "boolean":
+        return "UNSIGNED";
+    }
   }
 }

--- a/src/dialects/expression/MySqlExpression.ts
+++ b/src/dialects/expression/MySqlExpression.ts
@@ -3,6 +3,7 @@ import type { Sql } from "sql-template-tag";
 import type {
   CastKind,
   ColumnJsonMeta,
+  DateComponent,
   DialectExpression,
 } from "../DialectExpression";
 
@@ -125,5 +126,34 @@ export class MySqlExpression implements DialectExpression {
       case "boolean":
         return "UNSIGNED";
     }
+  }
+
+  dateComponent(value: Sql, component: DateComponent): Sql {
+    const fn = mysqlDateFunction(component);
+    return sql`${raw(fn)}(${value})`;
+  }
+}
+
+function mysqlDateFunction(component: DateComponent): string {
+  switch (component) {
+    case "year":
+      return "YEAR";
+    case "month":
+      return "MONTH";
+    case "day":
+    case "dayOfMonth":
+      return "DAYOFMONTH";
+    case "hour":
+      return "HOUR";
+    case "minute":
+      return "MINUTE";
+    case "second":
+      return "SECOND";
+    case "dayOfWeek":
+      return "DAYOFWEEK";
+    case "dayOfYear":
+      return "DAYOFYEAR";
+    case "week":
+      return "WEEK";
   }
 }

--- a/src/dialects/expression/PostgresExpression.ts
+++ b/src/dialects/expression/PostgresExpression.ts
@@ -1,6 +1,10 @@
 import sql, { raw, join } from "sql-template-tag";
 import type { Sql } from "sql-template-tag";
-import type { ColumnJsonMeta, DialectExpression } from "../DialectExpression";
+import type {
+  CastKind,
+  ColumnJsonMeta,
+  DialectExpression,
+} from "../DialectExpression";
 
 export class PostgresExpression implements DialectExpression {
   readonly dialect = "postgres" as const;
@@ -209,5 +213,20 @@ export class PostgresExpression implements DialectExpression {
       return sql`jsonb_typeof(${this.navigateJsonb(column, path)})`;
     }
     return sql`jsonb_typeof(${raw(column)} #> ${this.pathArray(path)})`;
+  }
+
+  castTypeName(kind: CastKind): string {
+    switch (kind) {
+      case "string":
+        return "TEXT";
+      case "int":
+        return "INTEGER";
+      case "long":
+        return "BIGINT";
+      case "float":
+        return "REAL";
+      case "boolean":
+        return "BOOLEAN";
+    }
   }
 }

--- a/src/dialects/expression/PostgresExpression.ts
+++ b/src/dialects/expression/PostgresExpression.ts
@@ -3,6 +3,7 @@ import type { Sql } from "sql-template-tag";
 import type {
   CastKind,
   ColumnJsonMeta,
+  DateComponent,
   DialectExpression,
 } from "../DialectExpression";
 
@@ -228,5 +229,36 @@ export class PostgresExpression implements DialectExpression {
       case "boolean":
         return "BOOLEAN";
     }
+  }
+
+  dateComponent(value: Sql, component: DateComponent): Sql {
+    // PostgreSQL EXTRACT returns a numeric — cast to integer so
+    // downstream comparisons stay on integer arithmetic.
+    const field = pgExtractField(component);
+    return sql`CAST(EXTRACT(${raw(field)} FROM ${value}) AS INTEGER)`;
+  }
+}
+
+function pgExtractField(component: DateComponent): string {
+  switch (component) {
+    case "year":
+      return "YEAR";
+    case "month":
+      return "MONTH";
+    case "day":
+    case "dayOfMonth":
+      return "DAY";
+    case "hour":
+      return "HOUR";
+    case "minute":
+      return "MINUTE";
+    case "second":
+      return "SECOND";
+    case "dayOfWeek":
+      return "DOW";
+    case "dayOfYear":
+      return "DOY";
+    case "week":
+      return "WEEK";
   }
 }

--- a/src/dialects/expression/SqliteExpression.ts
+++ b/src/dialects/expression/SqliteExpression.ts
@@ -3,6 +3,7 @@ import type { Sql } from "sql-template-tag";
 import type {
   CastKind,
   ColumnJsonMeta,
+  DateComponent,
   DialectExpression,
 } from "../DialectExpression";
 import { OrmError } from "../../errors/OrmError";
@@ -120,5 +121,36 @@ export class SqliteExpression implements DialectExpression {
       case "boolean":
         return "INTEGER";
     }
+  }
+
+  dateComponent(value: Sql, component: DateComponent): Sql {
+    const format = sqliteStrftimeFormat(component);
+    return sql`CAST(strftime(${format}, ${value}) AS INTEGER)`;
+  }
+}
+
+function sqliteStrftimeFormat(component: DateComponent): string {
+  switch (component) {
+    case "year":
+      return "%Y";
+    case "month":
+      return "%m";
+    case "day":
+    case "dayOfMonth":
+      return "%d";
+    case "hour":
+      return "%H";
+    case "minute":
+      return "%M";
+    case "second":
+      return "%S";
+    case "dayOfWeek":
+      // strftime %w: 0=Sunday..6=Saturday (matches PG DOW for 0..6).
+      return "%w";
+    case "dayOfYear":
+      return "%j";
+    case "week":
+      // %W = week 0..53 (Monday as first day). Closest portable match.
+      return "%W";
   }
 }

--- a/src/dialects/expression/SqliteExpression.ts
+++ b/src/dialects/expression/SqliteExpression.ts
@@ -1,6 +1,10 @@
 import sql, { raw } from "sql-template-tag";
 import type { Sql } from "sql-template-tag";
-import type { ColumnJsonMeta, DialectExpression } from "../DialectExpression";
+import type {
+  CastKind,
+  ColumnJsonMeta,
+  DialectExpression,
+} from "../DialectExpression";
 import { OrmError } from "../../errors/OrmError";
 import { OrmErrorCode } from "../../errors/OrmErrorCode";
 import { buildJsonPathString } from "./MySqlExpression";
@@ -102,5 +106,19 @@ export class SqliteExpression implements DialectExpression {
     }
     const p = buildJsonPathString(path);
     return sql`json_type(${raw(column)}, ${p})`;
+  }
+
+  castTypeName(kind: CastKind): string {
+    switch (kind) {
+      case "string":
+        return "TEXT";
+      case "int":
+      case "long":
+        return "INTEGER";
+      case "float":
+        return "REAL";
+      case "boolean":
+        return "INTEGER";
+    }
   }
 }


### PR DESCRIPTION
## Summary

QueryDSL Tier 2 — extends `qAlias()` from ~35–40% to ~55–65% of Java QueryDSL 5.x coverage. Split into 7 phase commits so each block is reviewable in isolation.

- **Phase 2.1 — `.as()` on any projectable expression.** ColumnExpression and JsonPathExpression now emit an `AliasedExpression` for SELECT; `RawQueryBuilder.selectFragments()` preserves bindings so JSON path literals survive execution. (cd74b68)
- **Phase 2.2 — `coalesce()` / `nullif()` + `ScalarExpression`.** New `ScalarExpression` foundation (dual SELECT + comparison role) underpins every downstream phase. `ScalarCondition` plugs into AND/OR/NOT. (973bd0d)
- **Phase 2.3 — `currentDate` / `currentTime` / `currentTimestamp`.** ColumnCondition now unwraps a `ScalarExpression` operand inline so `u.expiresAt.gte(currentTimestamp())` emits the literal rather than binding it as a parameter. (2d9059d)
- **Phase 2.4 — CAST helpers.** `.stringValue()` / `.intValue()` / `.longValue()` / `.floatValue()` / `.booleanValue()` on both Column and Scalar — dialect type names via `DialectExpression.castTypeName(kind)`. (c083b9b)
- **Phase 2.5 — Date components.** `.year()`, `.month()`, `.day()`, `.hour()`, `.minute()`, `.second()`, `.dayOfWeek()`, `.dayOfMonth()`, `.dayOfYear()`, `.week()`. Dialect-specific emission (`EXTRACT` / `YEAR(col)` / `strftime`). (d392c97)
- **Phase 2.6 — Subquery comparisons + `EXISTS`.** `.in(subQb)`, `.notIn(subQb)`, scalar `.eq(subQb)` / `.gt(subQb)` / … , plus `Expressions.exists` / `notExists`. `ExistsCondition.not()` toggles the flag instead of wrapping in redundant `NOT (…)`. (26cf3f4)
- **Phase 2.7 — CaseBuilder.** Fluent builders for both searched (`caseBuilder().when(cond).then(val)…`) and simple (`cases(subject).when(val, result)…`) CASE forms. Guarded against `.when()` after `.otherwise()`, duplicate `.otherwise()`, and empty `.end()`. (fcd8cf6)

## Stats

- **Unit + integration combined:** 4,970 passed / 21 skipped / **0 failures** across 233 suites (MySQL + PostgreSQL + SQLite).
- **Tier 2 new unit tests:** 112 (16 + 21 + 11 + 12 + 17 + 15 + 20).
- **Files changed:** 26, +3,813 LOC.
- **New modules:** `AliasedExpression`, `ScalarExpression`, `NullishExpression`, `TemporalExpression`, `CastExpression`, `DateComponentExpression`, `SubqueryExpression`, `CaseExpression`.
- **DialectExpression additions:** `castTypeName(kind)`, `dateComponent(value, component)` on MySQL / PostgreSQL / SQLite.
- **RawQueryBuilder addition:** `selectFragments(fragments, distinct)` — parameter-preserving SELECT path needed for JSON-extract aliasing.
- **Docs:** `docs/query-builder.md` (EN) + `docs/ko/query-builder.md` (KO) updated with 7 new sections and summary-table rows. Dialect mapping tables included for CAST and date components.

## Release

→ **v0.18.0 "QueryDSL Tier 2 — Scalar Expressions"**

## Test plan

- [x] Unit — `npx jest --no-coverage` (3,857 passed / 19 skipped / 0 failures)
- [x] SQLite integration — `INTEGRATION_TEST=true npx jest --testPathPattern=sqlite` (409 passed)
- [x] MySQL integration — `INTEGRATION_TEST=true npx jest` (dual-driver suites hit MySQL, no regression)
- [x] PostgreSQL integration — `INTEGRATION_TEST=true npx jest` (dual-driver suites hit PostgreSQL, no regression)
- [x] Full run (unit + all integrations, 233 suites) — 4,970 passed / 21 skipped / 0 failures in 40s
- [ ] Example projects — `tsc --noEmit` on nestjs-cats / nestjs-blog / nestjs-multitenant / nestjs-todo (none touch the new surface, but confirm no type regression)
- [ ] Tag release as v0.18.0 after merge

AI-assistant: claude-opus-4-7