### PR TITLE
feat(query-builder): QueryDSL Tier 3 — TS/Node-native (string/math/date/window/raw/bigint/schema)

### DIFF
--- a/__tests__/unit/qdsl-tier3-date-window-random.test.ts
+++ b/__tests__/unit/qdsl-tier3-date-window-random.test.ts
@@ -1,0 +1,360 @@
+import "reflect-metadata";
+import { SelectQueryBuilder, qAlias } from "../../src/core/SelectQueryBuilder";
+import { Entity, PrimaryGeneratedColumn, Column } from "../../src/decorators";
+import { EntityManager } from "../../src/core/EntityManager";
+import { RelationMetadataResolver } from "../../src/core/RelationMetadataResolver";
+import { createDialectExpression } from "../../src/dialects/DialectExpression";
+import { Expressions } from "../../src/core/expressions/LogicalCondition";
+import {
+  dateDiff,
+  random,
+} from "../../src/core/expressions/DateArithmeticExpression";
+import { WindowBuilder } from "../../src/core/expressions/WindowExpression";
+import { isScalarExpression } from "../../src/core/expressions/ScalarExpression";
+
+@Entity()
+class Event {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @Column({ type: "datetime" })
+  startsAt!: Date;
+
+  @Column({ type: "datetime" })
+  endsAt!: Date;
+
+  @Column({ type: "int" })
+  score!: number;
+
+  @Column({ type: "int" })
+  teamId!: number;
+
+  @Column({ type: "datetime" })
+  createdAt!: Date;
+}
+
+type DbType = "mysql" | "postgresql" | "sqlite";
+
+function createMockEm(dbType: DbType = "postgresql") {
+  const resolver = new RelationMetadataResolver();
+  function wrap(col: string) {
+    if (dbType === "mysql") return `\`${col.replace(/`/g, "``")}\``;
+    return `"${col.replace(/"/g, '""')}"`;
+  }
+  return {
+    wrap,
+    wrapTable: (t: string) => wrap(t),
+    resolver,
+    _ctx: {
+      isMySqlFamily: () => dbType === "mysql",
+      isPostgres: () => dbType === "postgresql",
+      isSqlite: () => dbType === "sqlite",
+      getDialect: () =>
+        dbType === "mysql" ? "mysql" : dbType === "sqlite" ? "sqlite" : "postgresql",
+    },
+  } as unknown as EntityManager;
+}
+
+function createQb(dbType: DbType = "postgresql") {
+  const em = createMockEm(dbType);
+  const qb = new SelectQueryBuilder<Event>(Event, "e", em);
+  const resolver = (em as any).resolver as RelationMetadataResolver;
+  const meta = resolver.resolveEntityMetadata(Event);
+  if (meta) {
+    const map = new Map<string, string>();
+    for (const c of meta.columns) {
+      map.set((c as any).propertyKey ?? c.name!, c.name!);
+    }
+    qb.setPropertyToColumnMap(map);
+  }
+  const dialectName = dbType === "postgresql" ? "postgres" : dbType;
+  qb.setDialectExpression(createDialectExpression(dialectName));
+  return qb;
+}
+
+describe("Date arithmetic / window / random (QueryDSL Tier 3, Phase 3.2)", () => {
+  describe("addDays / addMonths / addYears — PostgreSQL", () => {
+    it("addDays(7) → (col + (7 * INTERVAL '1 day'))", () => {
+      const e = qAlias(Event, "e");
+      const { text, values } = createQb("postgresql")
+        .select([e.startsAt.addDays(7).as("future")])
+        .getSql();
+      expect(text).toContain(
+        `("e"."startsAt" + (? * INTERVAL '1 day')) AS "future"`,
+      );
+      expect(values).toContain(7);
+    });
+
+    it("addMonths + addYears", () => {
+      const e = qAlias(Event, "e");
+      const { text } = createQb("postgresql")
+        .select([
+          e.startsAt.addMonths(3).as("q"),
+          e.startsAt.addYears(1).as("next_year"),
+        ])
+        .getSql();
+      expect(text).toContain("INTERVAL '1 month'");
+      expect(text).toContain("INTERVAL '1 year'");
+    });
+
+    it("negative n subtracts", () => {
+      const e = qAlias(Event, "e");
+      const { text, values } = createQb("postgresql")
+        .select([e.startsAt.addDays(-7).as("week_ago")])
+        .getSql();
+      expect(text).toContain("INTERVAL '1 day'");
+      expect(values).toContain(-7);
+    });
+  });
+
+  describe("addDays — MySQL", () => {
+    it("addDays(7) → DATE_ADD(col, INTERVAL 7 DAY)", () => {
+      const e = qAlias(Event, "e");
+      const { text, values } = createQb("mysql")
+        .select([e.startsAt.addDays(7).as("future")])
+        .getSql();
+      expect(text).toContain("DATE_ADD(`e`.`startsAt`, INTERVAL ? DAY)");
+      expect(values).toContain(7);
+    });
+
+    it("addHours / addMinutes / addSeconds — MySQL", () => {
+      const e = qAlias(Event, "e");
+      const { text } = createQb("mysql")
+        .select([
+          e.startsAt.addHours(1).as("h"),
+          e.startsAt.addMinutes(30).as("m"),
+          e.startsAt.addSeconds(10).as("s"),
+        ])
+        .getSql();
+      expect(text).toContain("INTERVAL ? HOUR");
+      expect(text).toContain("INTERVAL ? MINUTE");
+      expect(text).toContain("INTERVAL ? SECOND");
+    });
+  });
+
+  describe("addDays — SQLite", () => {
+    it("addDays(7) → datetime(col, '+7 days')", () => {
+      const e = qAlias(Event, "e");
+      const { text, values } = createQb("sqlite")
+        .select([e.startsAt.addDays(7).as("future")])
+        .getSql();
+      expect(text).toContain(`datetime("e"."startsAt", ?) AS "future"`);
+      expect(values).toContain("+7 days");
+    });
+
+    it("negative n — SQLite uses -N days", () => {
+      const e = qAlias(Event, "e");
+      const { values } = createQb("sqlite")
+        .select([e.startsAt.addDays(-3).as("past")])
+        .getSql();
+      expect(values).toContain("-3 days");
+    });
+  });
+
+  describe("dateDiff", () => {
+    it("PostgreSQL day diff → epoch / 86400", () => {
+      const e = qAlias(Event, "e");
+      const expr = dateDiff(e.endsAt, e.startsAt, "day");
+      const { text } = createQb("postgresql").select([expr.as("d")]).getSql();
+      expect(text).toContain("EXTRACT(EPOCH FROM");
+      expect(text).toContain("/ ?");
+    });
+
+    it("PostgreSQL year diff → age()", () => {
+      const e = qAlias(Event, "e");
+      const expr = dateDiff(e.endsAt, e.startsAt, "year");
+      const { text } = createQb("postgresql").select([expr.as("y")]).getSql();
+      expect(text).toContain("age(");
+      expect(text).toContain("EXTRACT(YEAR FROM age(");
+    });
+
+    it("PostgreSQL month diff → year*12 + month", () => {
+      const e = qAlias(Event, "e");
+      const expr = dateDiff(e.endsAt, e.startsAt, "month");
+      const { text } = createQb("postgresql").select([expr.as("m")]).getSql();
+      expect(text).toContain("EXTRACT(YEAR FROM age(");
+      expect(text).toContain("* 12");
+      expect(text).toContain("EXTRACT(MONTH FROM age(");
+    });
+
+    it("MySQL → TIMESTAMPDIFF(UNIT, b, a)", () => {
+      const e = qAlias(Event, "e");
+      const expr = dateDiff(e.endsAt, e.startsAt, "day");
+      const { text } = createQb("mysql").select([expr.as("d")]).getSql();
+      expect(text).toContain(
+        "TIMESTAMPDIFF(DAY, `e`.`startsAt`, `e`.`endsAt`)",
+      );
+    });
+
+    it("SQLite → julianday difference with factor", () => {
+      const e = qAlias(Event, "e");
+      const expr = dateDiff(e.endsAt, e.startsAt, "hour");
+      const { text, values } = createQb("sqlite").select([expr.as("h")]).getSql();
+      expect(text).toContain(
+        `CAST((julianday("e"."endsAt") - julianday("e"."startsAt")) * ? AS INTEGER)`,
+      );
+      expect(values).toContain(24); // hour factor
+    });
+
+    it("SQLite year/month uses 365.25 / 30.4375 approximation", () => {
+      const e = qAlias(Event, "e");
+      const yearExpr = dateDiff(e.endsAt, e.startsAt, "year");
+      const monthExpr = dateDiff(e.endsAt, e.startsAt, "month");
+      expect(createQb("sqlite").select([yearExpr.as("y")]).getSql().text).toContain(
+        "/ 365.25",
+      );
+      expect(createQb("sqlite").select([monthExpr.as("m")]).getSql().text).toContain(
+        "/ 30.4375",
+      );
+    });
+
+    it("accepts primitive dates as operands", () => {
+      const e = qAlias(Event, "e");
+      const expr = dateDiff("2026-01-01", e.startsAt, "day");
+      const { values } = createQb("postgresql").select([expr.as("d")]).getSql();
+      expect(values).toContain("2026-01-01");
+    });
+
+    it("Expressions.dateDiff delegates", () => {
+      const e = qAlias(Event, "e");
+      const expr = Expressions.dateDiff(e.endsAt, e.startsAt, "day");
+      expect(isScalarExpression(expr)).toBe(true);
+    });
+  });
+
+  describe("Expressions.random()", () => {
+    it("PostgreSQL emits RANDOM()", () => {
+      const qb = createQb("postgresql").select([random().as("r")]);
+      expect(qb.getSql().text).toContain(`RANDOM() AS "r"`);
+    });
+
+    it("MySQL emits RAND()", () => {
+      const qb = createQb("mysql").select([random().as("r")]);
+      expect(qb.getSql().text).toContain("RAND() AS `r`");
+    });
+
+    it("SQLite emits RANDOM()", () => {
+      const qb = createQb("sqlite").select([random().as("r")]);
+      expect(qb.getSql().text).toContain(`RANDOM() AS "r"`);
+    });
+
+    it("Expressions.random() delegates", () => {
+      expect(isScalarExpression(Expressions.random())).toBe(true);
+    });
+  });
+
+  describe("WindowBuilder — aggregate.over()", () => {
+    it("empty window: COUNT(*) OVER ()", () => {
+      const e = qAlias(Event, "e");
+      const qb = createQb("postgresql");
+      const agg = e.id.count();
+      const w = agg.over().as("total");
+      qb.select([w]);
+      const { text } = qb.getSql();
+      expect(text).toContain(`COUNT("e"."id") OVER () AS "total"`);
+    });
+
+    it("partitionBy + orderBy + rowsBetween", () => {
+      const e = qAlias(Event, "e");
+      const qb = createQb("postgresql");
+      const w = e.score
+        .sum()
+        .over()
+        .partitionBy(e.teamId)
+        .orderBy(e.createdAt.desc())
+        .rowsBetween("UNBOUNDED PRECEDING", "CURRENT ROW")
+        .as("running_total");
+      qb.select([w]);
+      const { text } = qb.getSql();
+      expect(text).toContain(`SUM("e"."score") OVER (`);
+      expect(text).toContain(`PARTITION BY "e"."teamId"`);
+      expect(text).toContain(`ORDER BY "e"."createdAt" DESC`);
+      expect(text).toContain(`ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW`);
+      expect(text).toContain(`AS "running_total"`);
+    });
+
+    it("rangeBetween emits RANGE BETWEEN", () => {
+      const e = qAlias(Event, "e");
+      const qb = createQb("postgresql");
+      const w = e.score
+        .sum()
+        .over()
+        .rangeBetween("UNBOUNDED PRECEDING", "CURRENT ROW")
+        .as("running_range");
+      qb.select([w]);
+      expect(qb.getSql().text).toContain(
+        "RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW",
+      );
+    });
+
+    it("MySQL emits window with backticks", () => {
+      const e = qAlias(Event, "e");
+      const qb = createQb("mysql");
+      const w = e.score
+        .sum()
+        .over()
+        .partitionBy(e.teamId)
+        .as("running_total");
+      qb.select([w]);
+      expect(qb.getSql().text).toContain(
+        "SUM(`e`.`score`) OVER (PARTITION BY `e`.`teamId`) AS `running_total`",
+      );
+    });
+
+    it("toScalar() allows nesting as a comparison operand", () => {
+      const e = qAlias(Event, "e");
+      const avg = e.score.avg().over().partitionBy(e.teamId).toScalar();
+      const qb = createQb("postgresql");
+      qb.where(e.score.gt(avg));
+      const { text } = qb.getSql();
+      expect(text).toContain(
+        `"e"."score" > AVG("e"."score") OVER (PARTITION BY "e"."teamId")`,
+      );
+    });
+
+    it("WindowBuilder is chainable; returned instance is the same type", () => {
+      const e = qAlias(Event, "e");
+      const builder = e.score.sum().over();
+      expect(builder).toBeInstanceOf(WindowBuilder);
+      const after = builder.partitionBy(e.teamId);
+      expect(after).toBe(builder); // .partitionBy returns this
+    });
+
+    it("rank() use via e.id.count().over() partial example", () => {
+      // Tier 3 Phase 3.2 doesn't introduce RANK/DENSE_RANK explicitly,
+      // but the builder infrastructure is in place; verify it survives
+      // a chained orderBy + partitionBy for typical ranking patterns.
+      const e = qAlias(Event, "e");
+      const qb = createQb("postgresql").select([
+        e.id.count().over().partitionBy(e.teamId).orderBy(e.score.desc()).as("rnk"),
+      ]);
+      expect(qb.getSql().text).toContain(
+        `COUNT("e"."id") OVER (PARTITION BY "e"."teamId" ORDER BY "e"."score" DESC) AS "rnk"`,
+      );
+    });
+  });
+
+  describe("Error paths", () => {
+    it("addDays throws without dialect (detached)", () => {
+      const e = qAlias(Event, "e");
+      const expr = e.startsAt.addDays(1);
+      expect(() => expr.renderer((ref) => ref)).toThrow(
+        /require.* DialectExpression/,
+      );
+    });
+
+    it("dateDiff throws without dialect (detached)", () => {
+      const e = qAlias(Event, "e");
+      const expr = dateDiff(e.endsAt, e.startsAt, "day");
+      expect(() => expr.renderer((ref) => ref)).toThrow(
+        /require.* DialectExpression/,
+      );
+    });
+
+    it("random throws without dialect (detached)", () => {
+      expect(() => random().renderer((ref) => ref)).toThrow(
+        /require.* DialectExpression/,
+      );
+    });
+  });
+});

--- a/__tests__/unit/qdsl-tier3-string-numeric-math.test.ts
+++ b/__tests__/unit/qdsl-tier3-string-numeric-math.test.ts
@@ -1,0 +1,310 @@
+import "reflect-metadata";
+import { SelectQueryBuilder, qAlias } from "../../src/core/SelectQueryBuilder";
+import { Entity, PrimaryGeneratedColumn, Column } from "../../src/decorators";
+import { EntityManager } from "../../src/core/EntityManager";
+import { RelationMetadataResolver } from "../../src/core/RelationMetadataResolver";
+import { createDialectExpression } from "../../src/dialects/DialectExpression";
+import { coalesce } from "../../src/core/expressions/NullishExpression";
+import { isScalarExpression } from "../../src/core/expressions/ScalarExpression";
+
+@Entity()
+class Product {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @Column({ type: "varchar", length: 255 })
+  name!: string;
+
+  @Column({ type: "varchar", length: 100 })
+  sku!: string;
+
+  @Column({ type: "int" })
+  quantity!: number;
+
+  @Column({ type: "double" })
+  price!: number;
+
+  @Column({ type: "int" })
+  stock!: number;
+}
+
+type DbType = "mysql" | "postgresql" | "sqlite";
+
+function createMockEm(dbType: DbType = "postgresql") {
+  const resolver = new RelationMetadataResolver();
+  function wrap(col: string) {
+    if (dbType === "mysql") return `\`${col.replace(/`/g, "``")}\``;
+    return `"${col.replace(/"/g, '""')}"`;
+  }
+  return {
+    wrap,
+    wrapTable: (t: string) => wrap(t),
+    resolver,
+    _ctx: {
+      isMySqlFamily: () => dbType === "mysql",
+      isPostgres: () => dbType === "postgresql",
+      isSqlite: () => dbType === "sqlite",
+      getDialect: () =>
+        dbType === "mysql" ? "mysql" : dbType === "sqlite" ? "sqlite" : "postgresql",
+    },
+  } as unknown as EntityManager;
+}
+
+function createQb(dbType: DbType = "postgresql") {
+  const em = createMockEm(dbType);
+  const qb = new SelectQueryBuilder<Product>(Product, "p", em);
+  const resolver = (em as any).resolver as RelationMetadataResolver;
+  const meta = resolver.resolveEntityMetadata(Product);
+  if (meta) {
+    const map = new Map<string, string>();
+    for (const c of meta.columns) {
+      map.set((c as any).propertyKey ?? c.name!, c.name!);
+    }
+    qb.setPropertyToColumnMap(map);
+  }
+  const dialectName = dbType === "postgresql" ? "postgres" : dbType;
+  qb.setDialectExpression(createDialectExpression(dialectName));
+  return qb;
+}
+
+describe("String / numeric / math expressions (QueryDSL Tier 3, Phase 3.1)", () => {
+  describe("string methods — ColumnExpression", () => {
+    it("toLowerCase → LOWER(col)", () => {
+      const p = qAlias(Product, "p");
+      expect(createQb().select([p.name.toLowerCase().as("n")]).getSql().text)
+        .toContain(`LOWER("p"."name") AS "n"`);
+    });
+
+    it("toUpperCase → UPPER(col)", () => {
+      const p = qAlias(Product, "p");
+      expect(createQb().select([p.name.toUpperCase().as("n")]).getSql().text)
+        .toContain(`UPPER("p"."name") AS "n"`);
+    });
+
+    it("trim → TRIM(col)", () => {
+      const p = qAlias(Product, "p");
+      expect(createQb().select([p.name.trim().as("n")]).getSql().text)
+        .toContain(`TRIM("p"."name") AS "n"`);
+    });
+
+    it("length → CHAR_LENGTH(col)", () => {
+      const p = qAlias(Product, "p");
+      expect(createQb().select([p.name.length().as("n")]).getSql().text)
+        .toContain(`CHAR_LENGTH("p"."name") AS "n"`);
+    });
+
+    it("substring(start) → SUBSTR(col, start+1)", () => {
+      const p = qAlias(Product, "p");
+      const { text, values } = createQb()
+        .select([p.name.substring(3).as("s")])
+        .getSql();
+      expect(text).toContain(`SUBSTR("p"."name", ?)`);
+      expect(values).toContain(4);
+    });
+
+    it("substring(start, end) → SUBSTR(col, start+1, end-start)", () => {
+      const p = qAlias(Product, "p");
+      const { text, values } = createQb()
+        .select([p.name.substring(2, 5).as("s")])
+        .getSql();
+      expect(text).toContain(`SUBSTR("p"."name", ?, ?)`);
+      expect(values).toContain(3); // start+1
+      expect(values).toContain(3); // end-start (same value — length)
+    });
+
+    it("concat → CONCAT(col, ...args)", () => {
+      const p = qAlias(Product, "p");
+      const { text, values } = createQb()
+        .select([p.name.concat(" — ", p.sku).as("label")])
+        .getSql();
+      expect(text).toContain(`CONCAT("p"."name", ?, "p"."sku") AS "label"`);
+      expect(values).toContain(" — ");
+    });
+
+    it("indexOf → (STRPOS(col, needle) - 1) on PostgreSQL", () => {
+      const p = qAlias(Product, "p");
+      const { text, values } = createQb("postgresql")
+        .select([p.sku.indexOf("-").as("dash")])
+        .getSql();
+      expect(text).toContain(`(STRPOS("p"."sku", ?) - 1) AS "dash"`);
+      expect(values).toContain("-");
+    });
+
+    it("indexOf → (LOCATE(needle, col) - 1) on MySQL", () => {
+      const p = qAlias(Product, "p");
+      const { text } = createQb("mysql")
+        .select([p.sku.indexOf("-").as("dash")])
+        .getSql();
+      expect(text).toContain("(LOCATE(?, `p`.`sku`) - 1) AS `dash`");
+    });
+
+    it("indexOf → (INSTR(col, needle) - 1) on SQLite", () => {
+      const p = qAlias(Product, "p");
+      const { text } = createQb("sqlite")
+        .select([p.sku.indexOf("-").as("dash")])
+        .getSql();
+      expect(text).toContain(`(INSTR("p"."sku", ?) - 1) AS "dash"`);
+    });
+
+    it("replace → REPLACE(col, from, to)", () => {
+      const p = qAlias(Product, "p");
+      const { text, values } = createQb()
+        .select([p.name.replace("old", "new").as("n")])
+        .getSql();
+      expect(text).toContain(`REPLACE("p"."name", ?, ?) AS "n"`);
+      expect(values).toEqual(expect.arrayContaining(["old", "new"]));
+    });
+  });
+
+  describe("numeric arithmetic — ColumnExpression", () => {
+    it("add renders (col + ?)", () => {
+      const p = qAlias(Product, "p");
+      const { text, values } = createQb()
+        .select([p.price.add(10).as("adj")])
+        .getSql();
+      expect(text).toContain(`("p"."price" + ?) AS "adj"`);
+      expect(values).toContain(10);
+    });
+
+    it("sub / mul / div / mod", () => {
+      const p = qAlias(Product, "p");
+      const qb = createQb().select([
+        p.price.sub(1).as("a"),
+        p.quantity.mul(2).as("b"),
+        p.price.div(3).as("c"),
+        p.quantity.mod(4).as("d"),
+      ]);
+      const { text } = qb.getSql();
+      expect(text).toContain(`("p"."price" - ?)`);
+      expect(text).toContain(`("p"."quantity" * ?)`);
+      expect(text).toContain(`("p"."price" / ?)`);
+      expect(text).toContain(`("p"."quantity" % ?)`);
+    });
+
+    it("neg → (-col)", () => {
+      const p = qAlias(Product, "p");
+      const { text } = createQb().select([p.quantity.neg().as("n")]).getSql();
+      expect(text).toContain(`(-"p"."quantity") AS "n"`);
+    });
+
+    it("column on both sides — add(col)", () => {
+      const p = qAlias(Product, "p");
+      const { text } = createQb()
+        .select([p.price.add(p.stock).as("total")])
+        .getSql();
+      expect(text).toContain(`("p"."price" + "p"."stock") AS "total"`);
+    });
+  });
+
+  describe("math functions — ColumnExpression", () => {
+    it("abs / floor / ceil / sqrt", () => {
+      const p = qAlias(Product, "p");
+      const { text } = createQb()
+        .select([
+          p.price.abs().as("a"),
+          p.price.floor().as("f"),
+          p.price.ceil().as("c"),
+          p.price.sqrt().as("s"),
+        ])
+        .getSql();
+      expect(text).toContain(`ABS("p"."price")`);
+      expect(text).toContain(`FLOOR("p"."price")`);
+      expect(text).toContain(`CEIL("p"."price")`);
+      expect(text).toContain(`SQRT("p"."price")`);
+    });
+
+    it("round() and round(digits)", () => {
+      const p = qAlias(Product, "p");
+      const { text, values } = createQb()
+        .select([p.price.round().as("r1"), p.price.round(2).as("r2")])
+        .getSql();
+      expect(text).toContain(`ROUND("p"."price") AS "r1"`);
+      expect(text).toContain(`ROUND("p"."price", ?) AS "r2"`);
+      expect(values).toContain(2);
+    });
+  });
+
+  describe("ScalarExpression chaining", () => {
+    it("chain string fn on a coalesce result", () => {
+      const p = qAlias(Product, "p");
+      const { text } = createQb()
+        .select([coalesce(p.name, "(unnamed)").toUpperCase().as("label")])
+        .getSql();
+      expect(text).toContain(
+        `UPPER(COALESCE("p"."name", ?)) AS "label"`,
+      );
+    });
+
+    it("chain math after arithmetic", () => {
+      const p = qAlias(Product, "p");
+      const { text } = createQb()
+        .select([p.price.sub(1).abs().as("delta")])
+        .getSql();
+      expect(text).toContain(`ABS(("p"."price" - ?)) AS "delta"`);
+    });
+
+    it("chain trim + toLowerCase on cast result", () => {
+      const p = qAlias(Product, "p");
+      const qb = createQb()
+        .select([p.quantity.stringValue().trim().toLowerCase().as("q")]);
+      const { text } = qb.getSql();
+      expect(text).toContain(`LOWER(TRIM(CAST("p"."quantity" AS TEXT))) AS "q"`);
+    });
+
+    it("scalar .concat() mirrors column behavior", () => {
+      const p = qAlias(Product, "p");
+      // Start from a coalesce → scalar, then concat
+      const expr = coalesce(p.name, "?").concat(" / ", p.sku);
+      expect(isScalarExpression(expr)).toBe(true);
+      const { text } = createQb().select([expr.as("label")]).getSql();
+      expect(text).toContain(`CONCAT(COALESCE("p"."name", ?), ?, "p"."sku") AS "label"`);
+    });
+
+    it("scalar .add / .mul chain", () => {
+      const p = qAlias(Product, "p");
+      const expr = p.price.add(10).mul(2);
+      const { text, values } = createQb().select([expr.as("final")]).getSql();
+      expect(text).toContain(`(("p"."price" + ?) * ?) AS "final"`);
+      expect(values).toEqual(expect.arrayContaining([10, 2]));
+    });
+  });
+
+  describe("WHERE / HAVING usage", () => {
+    it("length().gt(N) filters", () => {
+      const p = qAlias(Product, "p");
+      const { text, values } = createQb()
+        .where(p.name.length().gt(20))
+        .getSql();
+      expect(text).toContain(`CHAR_LENGTH("p"."name") > ?`);
+      expect(values).toContain(20);
+    });
+
+    it("toLowerCase().eq() — case-insensitive equality via chain", () => {
+      const p = qAlias(Product, "p");
+      const { text, values } = createQb()
+        .where(p.name.toLowerCase().eq("alice"))
+        .getSql();
+      expect(text).toContain(`LOWER("p"."name") = ?`);
+      expect(values).toContain("alice");
+    });
+
+    it("price.mul(0.9).lte(100) — compute on column, compare", () => {
+      const p = qAlias(Product, "p");
+      const { text, values } = createQb()
+        .where(p.price.mul(0.9).lte(100))
+        .getSql();
+      expect(text).toContain(`("p"."price" * ?) <= ?`);
+      expect(values).toEqual(expect.arrayContaining([0.9, 100]));
+    });
+  });
+
+  describe("Error paths", () => {
+    it("indexOf() throws when detached (no dialect)", () => {
+      const p = qAlias(Product, "p");
+      const expr = p.name.indexOf("x");
+      expect(() => expr.renderer((ref) => ref)).toThrow(
+        /require.* DialectExpression/,
+      );
+    });
+  });
+});

--- a/__tests__/unit/qdsl-tier3-ts-native.test.ts
+++ b/__tests__/unit/qdsl-tier3-ts-native.test.ts
@@ -1,0 +1,227 @@
+import "reflect-metadata";
+import sql from "sql-template-tag";
+import { SelectQueryBuilder, qAlias } from "../../src/core/SelectQueryBuilder";
+import { Entity, PrimaryGeneratedColumn, Column } from "../../src/decorators";
+import { EntityManager } from "../../src/core/EntityManager";
+import { RelationMetadataResolver } from "../../src/core/RelationMetadataResolver";
+import { createDialectExpression } from "../../src/dialects/DialectExpression";
+import { Expressions } from "../../src/core/expressions/LogicalCondition";
+import { raw } from "../../src/core/expressions/RawExpression";
+import { isScalarExpression } from "../../src/core/expressions/ScalarExpression";
+
+@Entity()
+class Report {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @Column({ type: "varchar", length: 255 })
+  name!: string;
+
+  @Column({ type: "datetime" })
+  createdAt!: Date;
+
+  @Column({ type: "int" })
+  count!: number;
+
+  @Column({ type: "int" })
+  quantity!: number;
+}
+
+type DbType = "mysql" | "postgresql" | "sqlite";
+
+function createMockEm(dbType: DbType = "postgresql") {
+  const resolver = new RelationMetadataResolver();
+  function wrap(col: string) {
+    if (dbType === "mysql") return `\`${col.replace(/`/g, "``")}\``;
+    return `"${col.replace(/"/g, '""')}"`;
+  }
+  return {
+    wrap,
+    wrapTable: (t: string) => wrap(t),
+    resolver,
+    _ctx: {
+      isMySqlFamily: () => dbType === "mysql",
+      isPostgres: () => dbType === "postgresql",
+      isSqlite: () => dbType === "sqlite",
+      getDialect: () =>
+        dbType === "mysql" ? "mysql" : dbType === "sqlite" ? "sqlite" : "postgresql",
+    },
+  } as unknown as EntityManager;
+}
+
+function createQb(dbType: DbType = "postgresql") {
+  const em = createMockEm(dbType);
+  const qb = new SelectQueryBuilder<Report>(Report, "r", em);
+  const resolver = (em as any).resolver as RelationMetadataResolver;
+  const meta = resolver.resolveEntityMetadata(Report);
+  if (meta) {
+    const map = new Map<string, string>();
+    for (const c of meta.columns) {
+      map.set((c as any).propertyKey ?? c.name!, c.name!);
+    }
+    qb.setPropertyToColumnMap(map);
+  }
+  const dialectName = dbType === "postgresql" ? "postgres" : dbType;
+  qb.setDialectExpression(createDialectExpression(dialectName));
+  return qb;
+}
+
+describe("TS/Node-native helpers (QueryDSL Tier 3, Phase 3.3)", () => {
+  describe("Expressions.raw<T>()", () => {
+    it("wraps a Sql fragment as a ScalarExpression", () => {
+      const expr = raw(sql`CURRENT_TIMESTAMP`);
+      expect(isScalarExpression(expr)).toBe(true);
+    });
+
+    it("embeds in SELECT via .as()", () => {
+      const qb = createQb();
+      qb.select([raw(sql`CURRENT_TIMESTAMP`).as("now")]);
+      expect(qb.getSql().text).toContain(`CURRENT_TIMESTAMP AS "now"`);
+    });
+
+    it("preserves parameter bindings from the template", () => {
+      const qb = createQb("postgresql");
+      qb.select([
+        raw<number>(sql`EXTRACT(epoch FROM (NOW() - INTERVAL ${"1 day"}))`).as("ago"),
+      ]);
+      const { text, values } = qb.getSql();
+      expect(text).toContain("EXTRACT(epoch FROM (NOW() - INTERVAL ?))");
+      expect(values).toContain("1 day");
+    });
+
+    it("composes with comparison methods (WHERE)", () => {
+      const qb = createQb();
+      const epoch = raw<number>(sql`EXTRACT(epoch FROM NOW())`);
+      qb.where(epoch.gt(1700000000));
+      const { text, values } = qb.getSql();
+      expect(text).toContain("EXTRACT(epoch FROM NOW()) > ?");
+      expect(values).toContain(1700000000);
+    });
+
+    it("composes with coalesce()", () => {
+      const qb = createQb();
+      const rawScore = raw<number>(sql`(count + 10)`);
+      qb.select([Expressions.coalesce(rawScore, 0).as("boosted")]);
+      const { text } = qb.getSql();
+      expect(text).toContain("COALESCE((count + 10), ?)");
+    });
+
+    it("Expressions.raw<T>() delegates to the factory", () => {
+      expect(isScalarExpression(Expressions.raw<number>(sql`RANDOM()`))).toBe(true);
+    });
+  });
+
+  describe(".bigintValue()", () => {
+    it("PostgreSQL emits CAST(... AS BIGINT)", () => {
+      const r = qAlias(Report, "r");
+      const { text } = createQb("postgresql")
+        .select([r.count.bigintValue().as("c")])
+        .getSql();
+      expect(text).toContain(`CAST("r"."count" AS BIGINT) AS "c"`);
+    });
+
+    it("MySQL emits CAST(... AS SIGNED)", () => {
+      const r = qAlias(Report, "r");
+      const { text } = createQb("mysql")
+        .select([r.count.bigintValue().as("c")])
+        .getSql();
+      expect(text).toContain("CAST(`r`.`count` AS SIGNED) AS `c`");
+    });
+
+    it("SQLite emits CAST(... AS INTEGER)", () => {
+      const r = qAlias(Report, "r");
+      const { text } = createQb("sqlite")
+        .select([r.count.bigintValue().as("c")])
+        .getSql();
+      expect(text).toContain(`CAST("r"."count" AS INTEGER) AS "c"`);
+    });
+
+    it("chains after coalesce — coalesce(col, 0).bigintValue().as()", () => {
+      const r = qAlias(Report, "r");
+      const { text } = createQb("postgresql")
+        .select([
+          Expressions.coalesce(r.count, 0).bigintValue().as("total"),
+        ])
+        .getSql();
+      expect(text).toContain(
+        `CAST(COALESCE("r"."count", ?) AS BIGINT) AS "total"`,
+      );
+    });
+  });
+
+  describe("qb.selectSchema(schema)", () => {
+    it("attaches schema.parse as the row validator", async () => {
+      // Mock zod-like schema
+      const schema = {
+        parse: jest.fn((data: unknown) => data),
+      };
+      const qb = createQb();
+      const ret = qb.selectSchema(schema);
+      // Return type narrows — but runtime check: the builder is
+      // chainable and the same underlying object.
+      expect(ret).toBe(qb);
+      expect((qb as any).rowValidator).toBe(schema);
+    });
+
+    it("validates rows through schema.parse on getMany-like path", async () => {
+      const parse = jest.fn((data: unknown) => data);
+      const schema = { parse };
+      const qb = createQb();
+
+      qb.selectSchema(schema);
+      // Directly exercise the validator path
+      const row = { id: 1, name: "hello" };
+      const v = (qb as any).rowValidator;
+      expect(v).toBeDefined();
+      v.parse(row);
+      expect(parse).toHaveBeenCalledWith(row);
+    });
+
+    it("schema may be a plain function-wrapped object (Zod-compatible shape)", () => {
+      type ExpectedRow = { id: number; name: string };
+      const schema = {
+        parse(data: unknown): ExpectedRow {
+          if (typeof data !== "object" || data === null) {
+            throw new Error("bad row");
+          }
+          return data as ExpectedRow;
+        },
+      };
+      const qb = createQb().selectSchema(schema);
+      // Subsequent chain methods still work
+      expect(typeof qb.getSql).toBe("function");
+    });
+
+    it("throws on bad row when invoked", () => {
+      const schema = {
+        parse(data: unknown) {
+          if (typeof data !== "object" || data === null) throw new Error("nope");
+          return data;
+        },
+      };
+      const qb = createQb().selectSchema(schema);
+      const v = (qb as any).rowValidator;
+      expect(() => v.parse(null)).toThrow("nope");
+    });
+  });
+
+  describe("combination — raw + bigint + schema", () => {
+    it("raw expression chained through cast and alias", () => {
+      const qb = createQb("postgresql");
+      qb.select([
+        raw<number>(sql`(count * 2)`).bigintValue().as("doubled"),
+      ]);
+      const { text } = qb.getSql();
+      expect(text).toContain(`CAST((count * 2) AS BIGINT) AS "doubled"`);
+    });
+
+    it("raw + coalesce + schema validator", () => {
+      const schema = { parse: jest.fn((x: unknown) => x) };
+      const qb = createQb();
+      qb.select([Expressions.coalesce(raw<number>(sql`(count + 1)`), 0).as("x")])
+        .selectSchema(schema);
+      expect(qb.getSql().text).toContain("COALESCE((count + 1), ?)");
+      expect((qb as any).rowValidator).toBe(schema);
+    });
+  });
+});

--- a/docs/ko/query-builder.md
+++ b/docs/ko/query-builder.md
@@ -698,6 +698,40 @@ qb.select([weight.as("w")]);
 
 오용 방어도 들어가 있어요. `.otherwise()` 뒤의 `.when()`, 중복 `.otherwise()`, WHEN 없이 `.end()` — 이 세 경우는 명확한 에러 메시지로 막히니까, 잘못된 SQL이 쿼리 실행까지 가지 않아요.
 
+##### 문자열 / 숫자 / 수학 — JS와 같은 이름
+
+Tier 3의 문자열·숫자·수학 헬퍼는 TypeScript 개발자 손에 이미 익은 이름(`String.prototype`, 산술 연산자, `Math.*`)을 그대로 노출해요. 결과는 전부 `ScalarExpression`이니까 `.as()` / cast / coalesce / 비교 / 논리 결합 등 Tier 2에서 본 모든 기능과 바로 이어져요.
+
+```typescript
+const p = qAlias(Product, "p");
+
+qb.select([
+  p.name.toLowerCase().as("name_lc"),            // LOWER("p"."name")
+  p.name.substring(0, 10).as("preview"),         // SUBSTR("p"."name", 1, 10)
+  p.name.concat(" — ", p.sku).as("label"),       // CONCAT("p"."name", ' — ', "p"."sku")
+  p.price.mul(0.9).round(2).as("discounted"),    // ROUND(("p"."price" * 0.9), 2)
+  p.stock.abs().as("stock_abs"),                 // ABS("p"."stock")
+])
+.where(p.name.length().gt(20));                   // CHAR_LENGTH("p"."name") > 20
+```
+
+메서드 한눈에:
+
+| 분류 | 메서드 |
+|------|--------|
+| 문자열 | `.toLowerCase()`, `.toUpperCase()`, `.trim()`, `.length()`, `.substring(start, end?)`, `.concat(...args)`, `.indexOf(needle)`, `.replace(from, to)` |
+| 산술 | `.add(x)`, `.sub(x)`, `.mul(x)`, `.div(x)`, `.mod(x)`, `.neg()` |
+| 수학 | `.abs()`, `.floor()`, `.ceil()`, `.round(digits?)`, `.sqrt()` |
+
+알아두면 편한 동작 요약:
+
+- **`substring`** — JS와 똑같이 0-based, end exclusive. 내부에서 `SUBSTR(col, start + 1, end - start)`로 변환돼요.
+- **`length`** — `CHAR_LENGTH`라서 멀티바이트 안전. 바이트 수가 아니라 문자 수예요.
+- **`indexOf`** — 못 찾으면 `-1`, 찾으면 0-based 위치. 드라이버별(`STRPOS` / `LOCATE` / `INSTR`) 1-based 결과에서 1을 빼 JS와 일치하게 맞춰요.
+- **`mod`** — SQL `%` 연산자. 양수 피연산자는 JS와 결과가 같지만, 음수는 엔진마다 달라요 (PostgreSQL은 피제수 부호 유지, MySQL/SQLite는 JS와 같음).
+
+모든 인자는 원시값(파라미터 바인딩) 또는 다른 컬럼/스칼라 표현식을 받으니, `p.price.add(p.discount)` 처럼 컬럼끼리도, `p.name.concat(" (", p.sku, ")")` 같은 혼합도 자연스럽게 돼요.
+
 ##### 조건 묶기 — `.and()` / `.or()` / `.not()`
 
 조건 두 개를 AND로 묶거나, OR로 풀거나, 부정할 수 있어요.
@@ -803,6 +837,7 @@ qb.where(u.name.likeIgnoreCase("%Al%"));          // 와일드카드를 직접 �
 | 날짜 컴포넌트             | `.year()`, `.month()`, `.day()`, `.hour()`, `.minute()`, `.second()`, `.dayOfWeek()`, `.dayOfYear()`, `.week()` |
 | 서브쿼리 비교             | `.in(subQb)`, `.notIn(subQb)`, `.eq/.neq/.gt/.gte/.lt/.lte(subQb)`, `Expressions.exists`, `Expressions.notExists` |
 | CASE 표현식               | `Expressions.caseBuilder().when(...).then(...).otherwise(...).end()`; `Expressions.cases(subject)...end()`     |
+| 문자열 / 숫자 / 수학      | `.toLowerCase/.toUpperCase/.trim/.length/.substring/.concat/.indexOf/.replace`, `.add/.sub/.mul/.div/.mod/.neg`, `.abs/.floor/.ceil/.round/.sqrt` |
 | 조건 묶기                 | `.and(other)`, `.or(other)`, `.not()`                                         |
 | 그룹을 직접 짜고 싶을 때  | `Expressions.and(...)`, `Expressions.or(...)`, `Expressions.not(cond)`        |
 | 안전한 prefix / suffix / 포함 | `.startsWith`, `.endsWith`, `.contains` (LIKE 특수문자 자동 이스케이프)   |

--- a/docs/ko/query-builder.md
+++ b/docs/ko/query-builder.md
@@ -732,6 +732,58 @@ qb.select([
 
 모든 인자는 원시값(파라미터 바인딩) 또는 다른 컬럼/스칼라 표현식을 받으니, `p.price.add(p.discount)` 처럼 컬럼끼리도, `p.name.concat(" (", p.sku, ")")` 같은 혼합도 자연스럽게 돼요.
 
+##### 날짜 산술 — `.addDays()` / `.addMonths()` / …, `dateDiff`, `random`
+
+달력 단위별 `add*` 6개(`addYears/Months/Days/Hours/Minutes/Seconds`), 두 날짜의 정수 차이를 돌려주는 `Expressions.dateDiff(a, b, unit)`, 엔진별 RNG를 감싸는 `Expressions.random()`을 한 번에 다룰 수 있어요. 리포트성 쿼리에서 raw SQL로 내려가는 일이 줄어들어요.
+
+```typescript
+const e = qAlias(Event, "e");
+
+qb.select([
+  e.startsAt.addDays(7).as("next_week"),
+  e.startsAt.addMonths(-1).as("prev_month"),
+  Expressions.dateDiff(e.endsAt, e.startsAt, "day").as("span_days"),
+  Expressions.random().as("r"),
+]);
+```
+
+드라이버별 생성:
+
+| 연산 | MySQL | PostgreSQL | SQLite |
+|------|-------|------------|--------|
+| `addDays(7)` | `DATE_ADD(col, INTERVAL 7 DAY)` | `(col + (7 * INTERVAL '1 day'))` | `datetime(col, '+7 days')` |
+| `dateDiff(a, b, "day")` | `TIMESTAMPDIFF(DAY, b, a)` | `CAST(EXTRACT(EPOCH FROM (a - b)) / 86400 AS INTEGER)` | `CAST((julianday(a) - julianday(b)) * 1 AS INTEGER)` |
+| `dateDiff(a, b, "year")` | `TIMESTAMPDIFF(YEAR, b, a)` | 달력 기반 `age()` | `julianday() / 365.25` (근사) |
+| `random()` | `RAND()` | `RANDOM()` | `RANDOM()` |
+
+SQLite의 year/month 차이는 365.25 / 30.4375로 근사해요. 정확한 달력 차가 필요하면 MySQL `TIMESTAMPDIFF` 또는 PostgreSQL `age()` 쪽을 쓰세요.
+
+##### 윈도우 함수 — `aggregate.over()` + `WindowBuilder`
+
+집계(`count`, `sum`, `avg`, `min`, `max`, `countDistinct`)에는 `.over()`가 달려 있어요. 체인으로 PARTITION BY / ORDER BY / ROWS 또는 RANGE 프레임을 지정하고, `.as(alias)`로 마무리해요.
+
+```typescript
+const e = qAlias(Event, "e");
+
+qb.select([
+  e.score.sum().over()
+    .partitionBy(e.teamId)
+    .orderBy(e.createdAt.desc())
+    .rowsBetween("UNBOUNDED PRECEDING", "CURRENT ROW")
+    .as("running_total"),
+]);
+// SUM("e"."score") OVER (PARTITION BY "e"."teamId"
+//                        ORDER BY "e"."createdAt" DESC
+//                        ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
+// AS "running_total"
+```
+
+마무리는 둘 중 하나예요:
+- `.as("alias")` — `AliasedExpression`으로 끝내서 SELECT에 바로 사용.
+- `.toScalar()` — `ScalarExpression`으로 끝내서 다른 표현식 안에 중첩 (예: `qb.where(e.score.gt(avg.over().partitionBy(...).toScalar()))`).
+
+프레임 문자열(`"UNBOUNDED PRECEDING"`, `"CURRENT ROW"`, `"5 PRECEDING"` 등)은 그대로 SQL에 삽입돼요. **사용자 입력을 이 자리에 넘기지 마세요.** 누적 집계에는 `rowsBetween("UNBOUNDED PRECEDING", "CURRENT ROW")`를 쓰는 게 가장 일반적이에요.
+
 ##### 조건 묶기 — `.and()` / `.or()` / `.not()`
 
 조건 두 개를 AND로 묶거나, OR로 풀거나, 부정할 수 있어요.
@@ -838,6 +890,8 @@ qb.where(u.name.likeIgnoreCase("%Al%"));          // 와일드카드를 직접 �
 | 서브쿼리 비교             | `.in(subQb)`, `.notIn(subQb)`, `.eq/.neq/.gt/.gte/.lt/.lte(subQb)`, `Expressions.exists`, `Expressions.notExists` |
 | CASE 표현식               | `Expressions.caseBuilder().when(...).then(...).otherwise(...).end()`; `Expressions.cases(subject)...end()`     |
 | 문자열 / 숫자 / 수학      | `.toLowerCase/.toUpperCase/.trim/.length/.substring/.concat/.indexOf/.replace`, `.add/.sub/.mul/.div/.mod/.neg`, `.abs/.floor/.ceil/.round/.sqrt` |
+| 날짜 산술                 | `.addYears/Months/Days/Hours/Minutes/Seconds(n)`, `Expressions.dateDiff(a, b, unit)`, `Expressions.random()` |
+| 윈도우 함수               | `aggregate.over().partitionBy(...).orderBy(...).rowsBetween(start, end).as("alias")` — `WindowBuilder` 체인 |
 | 조건 묶기                 | `.and(other)`, `.or(other)`, `.not()`                                         |
 | 그룹을 직접 짜고 싶을 때  | `Expressions.and(...)`, `Expressions.or(...)`, `Expressions.not(cond)`        |
 | 안전한 prefix / suffix / 포함 | `.startsWith`, `.endsWith`, `.contains` (LIKE 특수문자 자동 이스케이프)   |

--- a/docs/ko/query-builder.md
+++ b/docs/ko/query-builder.md
@@ -784,6 +784,47 @@ qb.select([
 
 프레임 문자열(`"UNBOUNDED PRECEDING"`, `"CURRENT ROW"`, `"5 PRECEDING"` 등)은 그대로 SQL에 삽입돼요. **사용자 입력을 이 자리에 넘기지 마세요.** 누적 집계에는 `rowsBetween("UNBOUNDED PRECEDING", "CURRENT ROW")`를 쓰는 게 가장 일반적이에요.
 
+##### TS 네이티브 이스케이프 해치 — `Expressions.raw<T>()` / `.bigintValue()` / `qb.selectSchema(...)`
+
+TypeScript 생태계 맞춤 3종 세트예요.
+
+**`Expressions.raw<T>(fragment)`** — 어떤 `sql-template-tag` `Sql` fragment이든 `ScalarExpression`으로 감싸요. Tier 2/3 합성 체인(`.as`, `.eq`, `coalesce` 등)에 그대로 연결돼요. 제네릭 `T`는 다운스트림 체인의 타입 힌트용이지 런타임 검증용은 아니에요.
+
+```typescript
+import sql from "sql-template-tag";
+import { Expressions, qAlias } from "@stingerloom/orm";
+
+const u = qAlias(User, "u");
+
+const epoch = Expressions.raw<number>(
+  sql`EXTRACT(epoch FROM ${u.col("createdAt")})`,
+);
+
+qb.select([epoch.as("epoch_s")])
+  .where(epoch.gt(1700000000));
+```
+
+템플릿 내부의 파라미터 바인딩은 끝까지 그대로 보존돼요. 드라이버 고유 함수, 전문 검색 연산자 등 타입드 빌더가 아직 커버하지 않은 곳의 이스케이프 해치로 쓰세요.
+
+**`.bigintValue()`** — `.longValue()`의 이름만 다른 형제. JS `bigint`를 다룬다는 의도를 명확히 표시해요. SQL은 `BIGINT` / `SIGNED` / `INTEGER`로 드라이버별 생성. 드라이버가 결과를 문자열로 내주는 경우가 있어서 JS 쪽에서 `BigInt(row.col)`로 감싸 주면 돼요.
+
+**`qb.selectSchema(schema)`** — Zod / Valibot / Effect 등 `.parse(data)`를 가진 스키마를 row 검증기로 붙이면서, 동시에 `TResult` 타입을 `z.infer<schema>`로 좁혀줘요.
+
+```typescript
+import { z } from "zod";
+
+const UserRow = z.object({ id: z.number(), name: z.string() });
+
+const rows = await em
+  .createQueryBuilder(User, "u")
+  .select(["id", "name"])
+  .selectSchema(UserRow)
+  .getMany();
+//    ^? Array<{ id: number; name: string }>  — UserRow에서 추론
+```
+
+SELECT 리스트는 그대로예요 — 호출자가 `.select([...])`나 `.as("alias")`로 원하는 형태로 투영하고, `selectSchema`는 런타임 검증과 타입 추론만 걸어줘요. 두 번 호출 스타일을 선호하면 `.select(...).validate(schema)`로 같은 효과를 낼 수 있지만 타입 narrowing은 안 돼요.
+
 ##### 조건 묶기 — `.and()` / `.or()` / `.not()`
 
 조건 두 개를 AND로 묶거나, OR로 풀거나, 부정할 수 있어요.
@@ -892,6 +933,9 @@ qb.where(u.name.likeIgnoreCase("%Al%"));          // 와일드카드를 직접 �
 | 문자열 / 숫자 / 수학      | `.toLowerCase/.toUpperCase/.trim/.length/.substring/.concat/.indexOf/.replace`, `.add/.sub/.mul/.div/.mod/.neg`, `.abs/.floor/.ceil/.round/.sqrt` |
 | 날짜 산술                 | `.addYears/Months/Days/Hours/Minutes/Seconds(n)`, `Expressions.dateDiff(a, b, unit)`, `Expressions.random()` |
 | 윈도우 함수               | `aggregate.over().partitionBy(...).orderBy(...).rowsBetween(start, end).as("alias")` — `WindowBuilder` 체인 |
+| Raw SQL 이스케이프 해치   | `Expressions.raw<T>(sql`...`)` → `ScalarExpression` (체인 합성 가능) |
+| BigInt cast               | `.bigintValue()` (BIGINT / SIGNED / INTEGER) |
+| 스키마 기반 행 추론       | `qb.selectSchema(zodSchema)` — `TResult`를 `z.infer<schema>`로 narrow + 런타임 검증 |
 | 조건 묶기                 | `.and(other)`, `.or(other)`, `.not()`                                         |
 | 그룹을 직접 짜고 싶을 때  | `Expressions.and(...)`, `Expressions.or(...)`, `Expressions.not(cond)`        |
 | 안전한 prefix / suffix / 포함 | `.startsWith`, `.endsWith`, `.contains` (LIKE 특수문자 자동 이스케이프)   |

--- a/docs/query-builder.md
+++ b/docs/query-builder.md
@@ -938,6 +938,64 @@ are responsible for ensuring they're safe (do not pass user input).
 `rowsBetween("UNBOUNDED PRECEDING", "CURRENT ROW")` is the common
 cumulative-aggregate frame.
 
+##### TS-native escape hatches — `Expressions.raw<T>()` / `.bigintValue()` / `qb.selectSchema(...)`
+
+Three helpers specifically tuned to TypeScript ergonomics:
+
+**`Expressions.raw<T>(fragment)`** — wrap any `sql-template-tag` `Sql`
+fragment as a `ScalarExpression`, threading it through the Tier 2/3
+composition surface. The generic `T` documents the intended return
+type for downstream chains (`rawInt.gt(0)` reads as intended) but is
+not runtime-enforced.
+
+```typescript
+import sql from "sql-template-tag";
+import { Expressions, qAlias } from "@stingerloom/orm";
+
+const u = qAlias(User, "u");
+
+const epoch = Expressions.raw<number>(
+  sql`EXTRACT(epoch FROM ${u.col("createdAt")})`,
+);
+
+qb.select([epoch.as("epoch_s")])
+  .where(epoch.gt(1700000000));
+```
+
+The parameter bindings on the template are preserved end-to-end. Use
+this for vendor-specific functions, full-text operators, or anything
+the typed builder hasn't covered yet — without giving up chain
+composition.
+
+**`.bigintValue()`** — CAST helper sibling of `.longValue()`, with a
+name that signals JS `bigint` intent. Emits `BIGINT` / `SIGNED` /
+`INTEGER` per dialect; drivers may still deliver the value as a
+string, so wrap the field with `BigInt(...)` when reading the row if
+you want a native `bigint`.
+
+**`qb.selectSchema(schema)`** — attaches a Zod / Valibot / Effect
+(anything with `.parse(data)`) schema as the row validator AND
+narrows `TResult` to `z.infer<typeof schema>` at the type level.
+
+```typescript
+import { z } from "zod";
+
+const UserRow = z.object({ id: z.number(), name: z.string() });
+
+const rows = await em
+  .createQueryBuilder(User, "u")
+  .select(["id", "name"])
+  .selectSchema(UserRow)
+  .getMany();
+//    ^? Array<{ id: number; name: string }>  — inferred from UserRow
+```
+
+The SELECT list is unchanged — callers still project the shape they
+want via `.select([...])` or `.as("alias")` projections; `selectSchema`
+purely wires runtime validation plus type inference. For callers
+preferring two explicit calls, `.select(...).validate(schema)` is
+equivalent minus the type narrowing.
+
 ##### Logical composition — `.and()` / `.or()` / `.not()` + `Expressions`
 
 ```typescript
@@ -1041,6 +1099,9 @@ Method summary:
 | String / numeric / math | `.toLowerCase()`, `.toUpperCase()`, `.trim()`, `.length()`, `.substring()`, `.concat()`, `.indexOf()`, `.replace()`, `.add/.sub/.mul/.div/.mod/.neg`, `.abs/.floor/.ceil/.round/.sqrt` |
 | Date arithmetic       | `.addYears/Months/Days/Hours/Minutes/Seconds(n)`, `Expressions.dateDiff(a, b, unit)`, `Expressions.random()` |
 | Window functions      | `aggregate.over().partitionBy(...).orderBy(...).rowsBetween(start, end).as("alias")` — `WindowBuilder` chain |
+| Raw SQL escape hatch  | `Expressions.raw<T>(sql`...`)` returns a `ScalarExpression` (composable with `.as`, `.eq`, `coalesce`, ...) |
+| BigInt cast           | `.bigintValue()` on column / scalar — BIGINT / SIGNED / INTEGER target |
+| Schema-inferred rows  | `qb.selectSchema(zodSchema)` — narrows `TResult` to `z.infer<schema>` and validates rows at runtime |
 | Logical composition   | `ColumnCondition.and/.or/.not`, `Expressions.and`, `Expressions.or`, `Expressions.not`          |
 
 ### JOIN — Combining Tables

--- a/docs/query-builder.md
+++ b/docs/query-builder.md
@@ -829,6 +829,52 @@ Misuse-guard: `.when()` after `.otherwise()`, duplicate `.otherwise()`,
 or `.end()` with no branches each throw an explanatory error early,
 rather than producing malformed SQL.
 
+##### String, numeric & math — JS-idiomatic helpers
+
+Tier 3's string/numeric/math helpers borrow the names already in a
+TypeScript developer's muscle memory — `String.prototype`, arithmetic
+operators, and `Math.*`. Each returns a `ScalarExpression`, so they
+flow into `.as()`, cast, coalesce, comparisons, and the rest of the
+Tier 2 surface.
+
+```typescript
+const p = qAlias(Product, "p");
+
+qb.select([
+  p.name.toLowerCase().as("name_lc"),            // LOWER("p"."name")
+  p.name.substring(0, 10).as("preview"),         // SUBSTR("p"."name", 1, 10)
+  p.name.concat(" — ", p.sku).as("label"),       // CONCAT("p"."name", ' — ', "p"."sku")
+  p.price.mul(0.9).round(2).as("discounted"),    // ROUND(("p"."price" * 0.9), 2)
+  p.stock.abs().as("stock_abs"),                  // ABS("p"."stock")
+])
+.where(p.name.length().gt(20));                   // CHAR_LENGTH("p"."name") > 20
+```
+
+Method coverage:
+
+| Category | Methods |
+|----------|---------|
+| String | `.toLowerCase()`, `.toUpperCase()`, `.trim()`, `.length()`, `.substring(start, end?)`, `.concat(...args)`, `.indexOf(needle)`, `.replace(from, to)` |
+| Arithmetic | `.add(x)`, `.sub(x)`, `.mul(x)`, `.div(x)`, `.mod(x)`, `.neg()` |
+| Math | `.abs()`, `.floor()`, `.ceil()`, `.round(digits?)`, `.sqrt()` |
+
+Behavior notes worth knowing:
+
+- **`substring`** matches JS semantics (0-based, end exclusive). The
+  helper converts to SQL's 1-based `SUBSTR(col, start + 1, end - start)`.
+- **`length`** uses `CHAR_LENGTH` (character count) rather than byte
+  length — multibyte safe on every dialect.
+- **`indexOf`** returns `-1` when the needle is missing and a 0-based
+  position otherwise — dialect-specific (`STRPOS` / `LOCATE` / `INSTR`)
+  shifted down by 1 so it matches `String.prototype.indexOf`.
+- **`mod`** uses the SQL `%` operator; results match JS for positive
+  operands. For negative values the sign semantics vary per engine
+  (PostgreSQL keeps the dividend's sign, MySQL/SQLite match JS).
+
+All operands accept either primitives (bound as parameters) or other
+column/scalar expressions — so `p.price.add(p.discount)` or
+`p.name.concat(" (", p.sku, ")")` compose naturally.
+
 ##### Logical composition — `.and()` / `.or()` / `.not()` + `Expressions`
 
 ```typescript
@@ -929,6 +975,7 @@ Method summary:
 | Date components       | `.year()`, `.month()`, `.day()`, `.hour()`, `.minute()`, `.second()`, `.dayOfWeek()`, `.dayOfMonth()`, `.dayOfYear()`, `.week()` |
 | Subquery compare      | `.in(subQb)`, `.notIn(subQb)`, `.eq/.neq/.gt/.gte/.lt/.lte(subQb)`, `Expressions.exists`, `Expressions.notExists` |
 | CASE expressions      | `Expressions.caseBuilder().when(...).then(...).otherwise(...).end()`; `Expressions.cases(subject).when(val, result)...end()` |
+| String / numeric / math | `.toLowerCase()`, `.toUpperCase()`, `.trim()`, `.length()`, `.substring()`, `.concat()`, `.indexOf()`, `.replace()`, `.add/.sub/.mul/.div/.mod/.neg`, `.abs/.floor/.ceil/.round/.sqrt` |
 | Logical composition   | `ColumnCondition.and/.or/.not`, `Expressions.and`, `Expressions.or`, `Expressions.not`          |
 
 ### JOIN — Combining Tables

--- a/docs/query-builder.md
+++ b/docs/query-builder.md
@@ -875,6 +875,69 @@ All operands accept either primitives (bound as parameters) or other
 column/scalar expressions — so `p.price.add(p.discount)` or
 `p.name.concat(" (", p.sku, ")")` compose naturally.
 
+##### Date arithmetic — `.addDays()` / `.addMonths()` / …, `dateDiff`, `random`
+
+`ColumnExpression` and `ScalarExpression` gain six add-* helpers for
+the usual calendar units, `Expressions.dateDiff(a, b, unit)` returns
+an integer difference, and `Expressions.random()` wraps the engine's
+RNG. Together they cover reporting queries that don't want to resort
+to raw SQL.
+
+```typescript
+const e = qAlias(Event, "e");
+
+qb.select([
+  e.startsAt.addDays(7).as("next_week"),
+  e.startsAt.addMonths(-1).as("prev_month"),
+  Expressions.dateDiff(e.endsAt, e.startsAt, "day").as("span_days"),
+  Expressions.random().as("r"),
+]);
+```
+
+Dialect mapping:
+
+| Operation | MySQL | PostgreSQL | SQLite |
+|-----------|-------|------------|--------|
+| `addDays(7)` | `DATE_ADD(col, INTERVAL 7 DAY)` | `(col + (7 * INTERVAL '1 day'))` | `datetime(col, '+7 days')` |
+| `dateDiff(a, b, "day")` | `TIMESTAMPDIFF(DAY, b, a)` | `CAST(EXTRACT(EPOCH FROM (a - b)) / 86400 AS INTEGER)` | `CAST((julianday(a) - julianday(b)) * 1 AS INTEGER)` |
+| `dateDiff(a, b, "year")` | `TIMESTAMPDIFF(YEAR, b, a)` | calendar-aware `age()` | `julianday() / 365.25` (approx.) |
+| `random()` | `RAND()` | `RANDOM()` | `RANDOM()` |
+
+Year / month differences on SQLite are approximations (365.25 /
+30.4375 days). Use `TIMESTAMPDIFF` or `age()` targets for exact
+calendar math.
+
+##### Window functions — `aggregate.over()` + `WindowBuilder`
+
+Every aggregate (`count`, `sum`, `avg`, `min`, `max`, `countDistinct`)
+exposes `.over()` that returns a chainable `WindowBuilder`.
+
+```typescript
+const e = qAlias(Event, "e");
+
+qb.select([
+  e.score.sum().over()
+    .partitionBy(e.teamId)
+    .orderBy(e.createdAt.desc())
+    .rowsBetween("UNBOUNDED PRECEDING", "CURRENT ROW")
+    .as("running_total"),
+]);
+// SUM("e"."score") OVER (PARTITION BY "e"."teamId"
+//                        ORDER BY "e"."createdAt" DESC
+//                        ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
+// AS "running_total"
+```
+
+Terminals:
+- `.as("alias")` — finalize as an `AliasedExpression` for SELECT.
+- `.toScalar()` — finalize as a `ScalarExpression` (for nesting,
+  e.g. `qb.where(e.score.gt(avg.over().partitionBy(e.teamId).toScalar()))`).
+
+Frame clauses accept raw SQL strings for `ROWS` / `RANGE` — callers
+are responsible for ensuring they're safe (do not pass user input).
+`rowsBetween("UNBOUNDED PRECEDING", "CURRENT ROW")` is the common
+cumulative-aggregate frame.
+
 ##### Logical composition — `.and()` / `.or()` / `.not()` + `Expressions`
 
 ```typescript
@@ -976,6 +1039,8 @@ Method summary:
 | Subquery compare      | `.in(subQb)`, `.notIn(subQb)`, `.eq/.neq/.gt/.gte/.lt/.lte(subQb)`, `Expressions.exists`, `Expressions.notExists` |
 | CASE expressions      | `Expressions.caseBuilder().when(...).then(...).otherwise(...).end()`; `Expressions.cases(subject).when(val, result)...end()` |
 | String / numeric / math | `.toLowerCase()`, `.toUpperCase()`, `.trim()`, `.length()`, `.substring()`, `.concat()`, `.indexOf()`, `.replace()`, `.add/.sub/.mul/.div/.mod/.neg`, `.abs/.floor/.ceil/.round/.sqrt` |
+| Date arithmetic       | `.addYears/Months/Days/Hours/Minutes/Seconds(n)`, `Expressions.dateDiff(a, b, unit)`, `Expressions.random()` |
+| Window functions      | `aggregate.over().partitionBy(...).orderBy(...).rowsBetween(start, end).as("alias")` — `WindowBuilder` chain |
 | Logical composition   | `ColumnCondition.and/.or/.not`, `Expressions.and`, `Expressions.or`, `Expressions.not`          |
 
 ### JOIN — Combining Tables

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stingerloom/orm",
-  "version": "0.16.1",
+  "version": "0.19.0",
   "description": "A standalone, framework-agnostic TypeScript ORM that can be used with any Node.js framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/core/SelectQueryBuilder.ts
+++ b/src/core/SelectQueryBuilder.ts
@@ -42,6 +42,30 @@ import { ScalarExpression } from "./expressions/ScalarExpression";
 import { coalesce as coalesceFn } from "./expressions/NullishExpression";
 import { buildCastScalar } from "./expressions/CastExpression";
 import { buildDateComponentFromRef } from "./expressions/DateComponentExpression";
+import {
+  buildToLowerCase,
+  buildToUpperCase,
+  buildTrim,
+  buildLength,
+  buildSubstring,
+  buildConcat,
+  buildIndexOf,
+  buildReplace,
+  type InnerRenderer,
+} from "./expressions/StringExpression";
+import {
+  buildAdd,
+  buildSub,
+  buildMul,
+  buildDiv,
+  buildMod,
+  buildNeg,
+  buildAbs,
+  buildFloor,
+  buildCeil,
+  buildRound,
+  buildSqrt,
+} from "./expressions/NumericExpression";
 import type { CastKind, DateComponent } from "../dialects/DialectExpression";
 import type { InheritanceStrategy } from "../decorators/Inheritance";
 import type { ColumnMetadata } from "../scanner/ColumnScanner";
@@ -605,6 +629,103 @@ export class ColumnExpression {
 
   private buildDateComponent(component: DateComponent): ScalarExpression {
     return buildDateComponentFromRef(component, this.ref);
+  }
+
+  // ── String helpers (Tier 3 / JS-idiomatic) ─────────────
+
+  /** `LOWER(col)`. Matches JS `String.prototype.toLowerCase`. */
+  toLowerCase(): ScalarExpression {
+    return buildToLowerCase(this.innerRenderer());
+  }
+  /** `UPPER(col)`. Matches JS `String.prototype.toUpperCase`. */
+  toUpperCase(): ScalarExpression {
+    return buildToUpperCase(this.innerRenderer());
+  }
+  /** `TRIM(col)`. */
+  trim(): ScalarExpression {
+    return buildTrim(this.innerRenderer());
+  }
+  /** `CHAR_LENGTH(col)` — character count (multibyte safe). */
+  length(): ScalarExpression {
+    return buildLength(this.innerRenderer());
+  }
+  /**
+   * `SUBSTR(col, start+1[, end-start])` — matches JS `String.prototype
+   * .substring(indexStart, indexEnd?)` (0-based, end exclusive).
+   */
+  substring(start: number, end?: number): ScalarExpression {
+    return buildSubstring(this.innerRenderer(), start, end);
+  }
+  /** `CONCAT(col, ...args)`. */
+  concat(...args: unknown[]): ScalarExpression {
+    return buildConcat(this.innerRenderer(), args);
+  }
+  /**
+   * `STRPOS/LOCATE/INSTR(col, needle) - 1` — returns 0-based position,
+   * `-1` when not found. Matches JS `String.prototype.indexOf`.
+   */
+  indexOf(needle: unknown): ScalarExpression {
+    return buildIndexOf(this.innerRenderer(), needle);
+  }
+  /** `REPLACE(col, from, to)`. */
+  replace(from: unknown, to: unknown): ScalarExpression {
+    return buildReplace(this.innerRenderer(), from, to);
+  }
+
+  // ── Numeric arithmetic (Tier 3) ────────────────────────
+
+  /** `(col + right)`. Right may be a primitive or another expression. */
+  add(right: unknown): ScalarExpression {
+    return buildAdd(this.innerRenderer(), right);
+  }
+  /** `(col - right)`. */
+  sub(right: unknown): ScalarExpression {
+    return buildSub(this.innerRenderer(), right);
+  }
+  /** `(col * right)`. */
+  mul(right: unknown): ScalarExpression {
+    return buildMul(this.innerRenderer(), right);
+  }
+  /** `(col / right)`. */
+  div(right: unknown): ScalarExpression {
+    return buildDiv(this.innerRenderer(), right);
+  }
+  /** `(col % right)`. */
+  mod(right: unknown): ScalarExpression {
+    return buildMod(this.innerRenderer(), right);
+  }
+  /** `-col`. */
+  neg(): ScalarExpression {
+    return buildNeg(this.innerRenderer());
+  }
+
+  // ── Math functions (Tier 3) ────────────────────────────
+
+  /** `ABS(col)`. */
+  abs(): ScalarExpression {
+    return buildAbs(this.innerRenderer());
+  }
+  /** `FLOOR(col)`. */
+  floor(): ScalarExpression {
+    return buildFloor(this.innerRenderer());
+  }
+  /** `CEIL(col)`. */
+  ceil(): ScalarExpression {
+    return buildCeil(this.innerRenderer());
+  }
+  /** `ROUND(col)` or `ROUND(col, digits)`. */
+  round(digits?: number): ScalarExpression {
+    return buildRound(this.innerRenderer(), digits);
+  }
+  /** `SQRT(col)`. */
+  sqrt(): ScalarExpression {
+    return buildSqrt(this.innerRenderer());
+  }
+
+  /** @internal Inner-fragment renderer shared by Tier 3 helpers. */
+  private innerRenderer(): InnerRenderer {
+    const ref = this.ref;
+    return (resolveColumn) => sql`${raw(resolveColumn(ref))}`;
   }
 
   // ── Aggregate helpers (Tier 1) ─────────────────────────

--- a/src/core/SelectQueryBuilder.ts
+++ b/src/core/SelectQueryBuilder.ts
@@ -66,7 +66,12 @@ import {
   buildRound,
   buildSqrt,
 } from "./expressions/NumericExpression";
-import type { CastKind, DateComponent } from "../dialects/DialectExpression";
+import { buildDateAdd } from "./expressions/DateArithmeticExpression";
+import type {
+  CastKind,
+  DateAddUnit,
+  DateComponent,
+} from "../dialects/DialectExpression";
 import type { InheritanceStrategy } from "../decorators/Inheritance";
 import type { ColumnMetadata } from "../scanner/ColumnScanner";
 import type { DialectExpression } from "../dialects/DialectExpression";
@@ -720,6 +725,37 @@ export class ColumnExpression {
   /** `SQRT(col)`. */
   sqrt(): ScalarExpression {
     return buildSqrt(this.innerRenderer());
+  }
+
+  // ── Date arithmetic (Tier 3) ───────────────────────────
+
+  /** `col + N years` — calendar-aware on all supported drivers. */
+  addYears(n: number): ScalarExpression {
+    return this.buildDateAdd(n, "year");
+  }
+  /** `col + N months` — calendar-aware on all supported drivers. */
+  addMonths(n: number): ScalarExpression {
+    return this.buildDateAdd(n, "month");
+  }
+  /** `col + N days`. */
+  addDays(n: number): ScalarExpression {
+    return this.buildDateAdd(n, "day");
+  }
+  /** `col + N hours`. */
+  addHours(n: number): ScalarExpression {
+    return this.buildDateAdd(n, "hour");
+  }
+  /** `col + N minutes`. */
+  addMinutes(n: number): ScalarExpression {
+    return this.buildDateAdd(n, "minute");
+  }
+  /** `col + N seconds`. */
+  addSeconds(n: number): ScalarExpression {
+    return this.buildDateAdd(n, "second");
+  }
+
+  private buildDateAdd(n: number, unit: DateAddUnit): ScalarExpression {
+    return buildDateAdd(this.innerRenderer(), n, unit);
   }
 
   /** @internal Inner-fragment renderer shared by Tier 3 helpers. */

--- a/src/core/SelectQueryBuilder.ts
+++ b/src/core/SelectQueryBuilder.ts
@@ -581,6 +581,16 @@ export class ColumnExpression {
   booleanValue(): ScalarExpression {
     return this.buildCast("boolean");
   }
+  /**
+   * `CAST(column AS <dialect-bigint-type>)` — same SQL target as
+   * `.longValue()` (BIGINT / SIGNED / INTEGER), but the method name
+   * documents the intent for JavaScript `bigint` return values. The
+   * driver may still deliver the value as a string; wrap with `BigInt(...)`
+   * in application code to get a native `bigint`.
+   */
+  bigintValue(): ScalarExpression {
+    return this.buildCast("bigint");
+  }
 
   private buildCast(kind: CastKind): ScalarExpression {
     const ref = this.ref;
@@ -2853,6 +2863,49 @@ export class SelectQueryBuilder<T, TResult = T> {
   validate(validator: RowValidator<TResult>): this {
     this.rowValidator = validator;
     return this;
+  }
+
+  /**
+   * Type-inferred schema-validated result — a Zod / Valibot / Effect
+   * schema (anything with a `.parse(data)` method) is attached as the
+   * row validator AND the query builder's `TResult` type narrows to
+   * the schema's inferred output type.
+   *
+   * Combines `.validate(schema)` with a type-level reshaping — the
+   * caller no longer needs to carry a separate generic for the SELECT
+   * projection.
+   *
+   * @example
+   * ```ts
+   * import { z } from "zod";
+   *
+   * const UserRow = z.object({ id: z.number(), name: z.string() });
+   *
+   * const rows = await em
+   *   .createQueryBuilder(User, "u")
+   *   .select(["id", "name"])
+   *   .selectSchema(UserRow)
+   *   .getMany();
+   * //    ^? Array<{ id: number; name: string }>   — inferred from UserRow
+   * ```
+   *
+   * @remarks
+   * The SELECT list is untouched — the caller is responsible for
+   * projecting a compatible shape (e.g. via `.select([...])` or
+   * `.as("alias")` projections). This method purely wires runtime
+   * validation plus type inference.
+   */
+  selectSchema<TSchema extends { parse(data: unknown): unknown }>(
+    schema: TSchema,
+  ): SelectQueryBuilder<
+    T,
+    TSchema extends { parse(data: unknown): infer O } ? O : never
+  > {
+    this.rowValidator = schema as unknown as RowValidator<TResult>;
+    return this as unknown as SelectQueryBuilder<
+      T,
+      TSchema extends { parse(data: unknown): infer O } ? O : never
+    >;
   }
 
   /**

--- a/src/core/expressions/AggregateExpression.ts
+++ b/src/core/expressions/AggregateExpression.ts
@@ -112,7 +112,35 @@ export class AggregateExpression {
   desc(): OrderExpression {
     return new OrderExpression(this.ref, "DESC");
   }
+
+  // ── Window function (Tier 3) ──────────────────────────
+
+  /**
+   * Start a window-function chain. Returns a {@link WindowBuilder}
+   * that accepts PARTITION BY, ORDER BY, and ROWS/RANGE frame clauses
+   * before being finalized with `.as(alias)` or `.toScalar()`.
+   *
+   * @example
+   * ```ts
+   * qb.select([
+   *   u.score.sum().over()
+   *     .partitionBy(u.teamId)
+   *     .orderBy(u.createdAt.desc())
+   *     .rowsBetween("UNBOUNDED PRECEDING", "CURRENT ROW")
+   *     .as("running_total"),
+   * ]);
+   * ```
+   */
+  over(): WindowBuilder {
+    return new WindowBuilder(this);
+  }
 }
+
+// Imported after the class body to keep a one-way value dependency:
+// WindowExpression depends on AggregateExpression as a type only, so
+// AggregateExpression can freely construct WindowBuilder without
+// forming a compile-time cycle.
+import { WindowBuilder } from "./WindowExpression";
 
 /**
  * Type guard — true if `value` is an {@link AggregateExpression}.

--- a/src/core/expressions/DateArithmeticExpression.ts
+++ b/src/core/expressions/DateArithmeticExpression.ts
@@ -1,0 +1,107 @@
+import sql, { Sql, raw } from "sql-template-tag";
+import type {
+  DateAddUnit,
+  DialectExpression,
+} from "../../dialects/DialectExpression";
+import type { ColumnResolver } from "./ConditionLike";
+import { ScalarExpression } from "./ScalarExpression";
+import type { InnerRenderer } from "./StringExpression";
+
+/**
+ * @internal Render any argument usable as a date source — column /
+ * scalar expressions unwrap to their inner SQL, plain values bind as
+ * parameters.
+ */
+function renderDateArg(
+  arg: unknown,
+  resolveColumn: ColumnResolver,
+  dialect?: DialectExpression,
+): Sql {
+  if (
+    arg !== null &&
+    typeof arg === "object" &&
+    (arg as { __isScalarExpression?: unknown }).__isScalarExpression === true
+  ) {
+    return (arg as {
+      renderer: (r: ColumnResolver, d?: DialectExpression) => Sql;
+    }).renderer(resolveColumn, dialect);
+  }
+  if (
+    arg !== null &&
+    typeof arg === "object" &&
+    (arg as { __isColumnExpression?: unknown }).__isColumnExpression === true
+  ) {
+    return sql`${raw(resolveColumn((arg as { toString(): string }).toString()))}`;
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return sql`${arg as any}`;
+}
+
+/**
+ * Build a date-addition scalar — `value + N units`. Accepts negative
+ * `n` for subtraction (e.g. `addDays(-7)`).
+ */
+export function buildDateAdd(
+  inner: InnerRenderer,
+  n: number,
+  unit: DateAddUnit,
+): ScalarExpression {
+  return new ScalarExpression((resolveColumn, dialect) => {
+    if (!dialect) {
+      throw new Error(
+        "Date add expressions require a DialectExpression. Ensure the query " +
+          "builder was created via EntityManager.createQueryBuilder().",
+      );
+    }
+    const value = inner(resolveColumn, dialect);
+    return dialect.dateAdd(value, n, unit);
+  });
+}
+
+/**
+ * `dateDiff(a, b, unit)` — returns `(a - b)` in the given unit as an
+ * integer scalar expression. Accepts column / scalar / primitive
+ * operands on either side.
+ *
+ * Engine notes:
+ * - **MySQL**: uses `TIMESTAMPDIFF(UNIT, b, a)` — calendar-aware for
+ *   year/month, exact for smaller units.
+ * - **PostgreSQL**: calendar-aware via `age()` for year/month, epoch
+ *   seconds for day/hour/minute/second.
+ * - **SQLite**: `julianday()` difference scaled per unit; year/month
+ *   are approximations (365.25 and 30.4375 days).
+ */
+export function dateDiff(
+  a: unknown,
+  b: unknown,
+  unit: DateAddUnit,
+): ScalarExpression {
+  return new ScalarExpression((resolveColumn, dialect) => {
+    if (!dialect) {
+      throw new Error(
+        "dateDiff() requires a DialectExpression. Ensure the query builder " +
+          "was created via EntityManager.createQueryBuilder().",
+      );
+    }
+    const aSql = renderDateArg(a, resolveColumn, dialect);
+    const bSql = renderDateArg(b, resolveColumn, dialect);
+    return dialect.dateDiff(aSql, bSql, unit);
+  });
+}
+
+/**
+ * `Expressions.random()` — uniform random in `[0, 1)` (SQLite returns
+ * a 64-bit signed integer scalar; downstream code that expects `[0,
+ * 1)` should normalize). Commonly used for `ORDER BY random()`.
+ */
+export function random(): ScalarExpression {
+  return new ScalarExpression((_resolveColumn, dialect) => {
+    if (!dialect) {
+      throw new Error(
+        "random() requires a DialectExpression. Ensure the query builder was " +
+          "created via EntityManager.createQueryBuilder().",
+      );
+    }
+    return dialect.random();
+  });
+}

--- a/src/core/expressions/LogicalCondition.ts
+++ b/src/core/expressions/LogicalCondition.ts
@@ -27,6 +27,7 @@ import {
   dateDiff as dateDiffFactory,
   random as randomFactory,
 } from "./DateArithmeticExpression";
+import { raw as rawFactory } from "./RawExpression";
 import type { DateAddUnit } from "../../dialects/DialectExpression";
 
 export type LogicalOperator = "AND" | "OR" | "NOT";
@@ -240,6 +241,27 @@ export const Expressions = {
    */
   random(): ScalarExpression {
     return randomFactory();
+  },
+
+  /**
+   * Escape hatch — wrap a raw `Sql` fragment as a
+   * {@link ScalarExpression}. The generic `T` is a TypeScript marker
+   * that documents the intended return type; it flows through
+   * downstream chains but is not enforced at runtime.
+   *
+   * Callers take responsibility for the safety of the raw SQL.
+   *
+   * @example
+   * ```ts
+   * import sql from "sql-template-tag";
+   * const epoch = Expressions.raw<number>(
+   *   sql`EXTRACT(epoch FROM ${u.col("createdAt")})`,
+   * );
+   * qb.select([epoch.as("epoch_s")]).where(epoch.gt(1700000000));
+   * ```
+   */
+  raw<T = unknown>(fragment: import("sql-template-tag").Sql): ScalarExpression {
+    return rawFactory<T>(fragment);
   },
 } as const;
 

--- a/src/core/expressions/LogicalCondition.ts
+++ b/src/core/expressions/LogicalCondition.ts
@@ -23,6 +23,11 @@ import {
   CaseBuilder,
   CaseValueBuilder,
 } from "./CaseExpression";
+import {
+  dateDiff as dateDiffFactory,
+  random as randomFactory,
+} from "./DateArithmeticExpression";
+import type { DateAddUnit } from "../../dialects/DialectExpression";
 
 export type LogicalOperator = "AND" | "OR" | "NOT";
 
@@ -216,6 +221,25 @@ export const Expressions = {
    */
   cases(subject: unknown): CaseValueBuilder {
     return casesFactory(subject);
+  },
+
+  /**
+   * `dateDiff(a, b, unit)` — integer difference `a - b` in the given
+   * unit. Calendar-aware for `year`/`month` on MySQL and PostgreSQL;
+   * SQLite uses `julianday()` approximation for those.
+   */
+  dateDiff(a: unknown, b: unknown, unit: DateAddUnit): ScalarExpression {
+    return dateDiffFactory(a, b, unit);
+  },
+
+  /**
+   * `RANDOM()` / `RAND()` — dialect-native pseudo-random scalar.
+   * Commonly used as `qb.orderBy(Expressions.random().asc())` for
+   * random sampling, though the order expression wiring lives in a
+   * future phase.
+   */
+  random(): ScalarExpression {
+    return randomFactory();
   },
 } as const;
 

--- a/src/core/expressions/NumericExpression.ts
+++ b/src/core/expressions/NumericExpression.ts
@@ -1,0 +1,98 @@
+import sql, { Sql, raw } from "sql-template-tag";
+import type { DialectExpression } from "../../dialects/DialectExpression";
+import type { ColumnResolver } from "./ConditionLike";
+import { ScalarExpression } from "./ScalarExpression";
+import type { InnerRenderer } from "./StringExpression";
+import { renderStringArg } from "./StringExpression";
+
+/**
+ * Build a binary-operator scalar: `(left <op> right)`. Used by `.add`
+ * / `.sub` / `.mul` / `.div` / `.mod`.
+ */
+function buildBinaryOp(
+  inner: InnerRenderer,
+  op: string,
+  right: unknown,
+): ScalarExpression {
+  return new ScalarExpression((resolveColumn, dialect) => {
+    const left = inner(resolveColumn, dialect);
+    const r = renderStringArg(right, resolveColumn, dialect);
+    return sql`(${left} ${raw(op)} ${r})`;
+  });
+}
+
+export function buildAdd(inner: InnerRenderer, r: unknown): ScalarExpression {
+  return buildBinaryOp(inner, "+", r);
+}
+export function buildSub(inner: InnerRenderer, r: unknown): ScalarExpression {
+  return buildBinaryOp(inner, "-", r);
+}
+export function buildMul(inner: InnerRenderer, r: unknown): ScalarExpression {
+  return buildBinaryOp(inner, "*", r);
+}
+export function buildDiv(inner: InnerRenderer, r: unknown): ScalarExpression {
+  return buildBinaryOp(inner, "/", r);
+}
+/**
+ * `(x % y)` — standard SQL on PostgreSQL / SQLite; MySQL also accepts
+ * `%` as a MOD operator. Result semantics match JS `%` for positive
+ * operands; for negative values, SQL engines differ (MySQL/SQLite
+ * match JS, PostgreSQL returns the sign of the dividend).
+ */
+export function buildMod(inner: InnerRenderer, r: unknown): ScalarExpression {
+  return buildBinaryOp(inner, "%", r);
+}
+/** `-x` — unary minus. */
+export function buildNeg(inner: InnerRenderer): ScalarExpression {
+  return new ScalarExpression((resolveColumn, dialect) => {
+    const v = inner(resolveColumn, dialect);
+    return sql`(-${v})`;
+  });
+}
+
+// ── Math functions ─────────────────────────────────────
+
+/** `ABS(x)`. */
+export function buildAbs(inner: InnerRenderer): ScalarExpression {
+  return new ScalarExpression((resolveColumn, dialect) => {
+    return sql`ABS(${inner(resolveColumn, dialect)})`;
+  });
+}
+/** `FLOOR(x)`. */
+export function buildFloor(inner: InnerRenderer): ScalarExpression {
+  return new ScalarExpression((resolveColumn, dialect) => {
+    return sql`FLOOR(${inner(resolveColumn, dialect)})`;
+  });
+}
+/**
+ * `CEIL(x)` — MySQL, PostgreSQL, and SQLite (SQLite 3.35+) all accept
+ * `CEIL`. Older SQLite may require `CEILING` or a compile flag; this
+ * helper uses `CEIL` which matches PostgreSQL and MySQL docs.
+ */
+export function buildCeil(inner: InnerRenderer): ScalarExpression {
+  return new ScalarExpression((resolveColumn, dialect) => {
+    return sql`CEIL(${inner(resolveColumn, dialect)})`;
+  });
+}
+/**
+ * `ROUND(x)` or `ROUND(x, digits)`. Positive `digits` rounds to that
+ * many decimal places; 0 (default) rounds to integer.
+ */
+export function buildRound(
+  inner: InnerRenderer,
+  digits: number | undefined,
+): ScalarExpression {
+  return new ScalarExpression((resolveColumn, dialect) => {
+    const v = inner(resolveColumn, dialect);
+    if (digits === undefined) {
+      return sql`ROUND(${v})`;
+    }
+    return sql`ROUND(${v}, ${digits})`;
+  });
+}
+/** `SQRT(x)`. */
+export function buildSqrt(inner: InnerRenderer): ScalarExpression {
+  return new ScalarExpression((resolveColumn, dialect) => {
+    return sql`SQRT(${inner(resolveColumn, dialect)})`;
+  });
+}

--- a/src/core/expressions/RawExpression.ts
+++ b/src/core/expressions/RawExpression.ts
@@ -1,0 +1,40 @@
+import type { Sql } from "sql-template-tag";
+import { ScalarExpression } from "./ScalarExpression";
+
+/**
+ * Wrap a raw `Sql` fragment as a typed {@link ScalarExpression}.
+ *
+ * The escape hatch for anything the typed builder does not cover
+ * directly — `EXTRACT(epoch FROM ...)`, vendor-specific functions,
+ * full-text `to_tsquery(...)`, etc. — while preserving composability
+ * with the rest of the Tier 2/3 expression surface.
+ *
+ * The generic `T` is a TypeScript marker only: it documents the
+ * intended SQL return type and flows through downstream chains (e.g.
+ * `rawInt.gt(0)` type-checks against the intent of the raw SQL), but
+ * it is not enforced at runtime.
+ *
+ * ⚠ Callers take responsibility for the safety of the raw SQL.
+ * Column references, table aliases, and any user-supplied values must
+ * be passed as bound parameters through `sql-template-tag`
+ * interpolation — `sql`EXTRACT(epoch FROM ${col})`` — not inlined as
+ * strings.
+ *
+ * @example
+ * ```ts
+ * import sql from "sql-template-tag";
+ * import { Expressions, qAlias } from "@stingerloom/orm";
+ *
+ * const u = qAlias(User, "u");
+ * const epoch = Expressions.raw<number>(
+ *   sql`EXTRACT(epoch FROM ${u.col("createdAt")})`,
+ * );
+ *
+ * qb.select([epoch.as("epoch_s")])
+ *   .where(epoch.gt(1700000000));
+ * ```
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function raw<_T = unknown>(fragment: Sql): ScalarExpression {
+  return new ScalarExpression(() => fragment);
+}

--- a/src/core/expressions/ScalarExpression.ts
+++ b/src/core/expressions/ScalarExpression.ts
@@ -113,6 +113,10 @@ export class ScalarExpression {
   booleanValue(): ScalarExpression {
     return this.buildCast("boolean");
   }
+  /** Wrap in `CAST(... AS BIGINT/SIGNED/INTEGER)` — JS `bigint` intent. */
+  bigintValue(): ScalarExpression {
+    return this.buildCast("bigint");
+  }
 
   private buildCast(kind: CastKind): ScalarExpression {
     const innerRenderer = this.renderer;

--- a/src/core/expressions/ScalarExpression.ts
+++ b/src/core/expressions/ScalarExpression.ts
@@ -3,6 +3,7 @@ import sql, { Sql, raw, join } from "sql-template-tag";
 import type { ConditionLike, ColumnResolver } from "./ConditionLike";
 import type {
   CastKind,
+  DateAddUnit,
   DateComponent,
   DialectExpression,
 } from "../../dialects/DialectExpression";
@@ -255,6 +256,26 @@ export class ScalarExpression {
   sqrt(): ScalarExpression {
     return buildStringFn("SQRT", this.renderer);
   }
+
+  // ── Date arithmetic (Tier 3) ───────────────────────────
+  addYears(n: number): ScalarExpression {
+    return buildDateAddFromRenderer(this.renderer, n, "year");
+  }
+  addMonths(n: number): ScalarExpression {
+    return buildDateAddFromRenderer(this.renderer, n, "month");
+  }
+  addDays(n: number): ScalarExpression {
+    return buildDateAddFromRenderer(this.renderer, n, "day");
+  }
+  addHours(n: number): ScalarExpression {
+    return buildDateAddFromRenderer(this.renderer, n, "hour");
+  }
+  addMinutes(n: number): ScalarExpression {
+    return buildDateAddFromRenderer(this.renderer, n, "minute");
+  }
+  addSeconds(n: number): ScalarExpression {
+    return buildDateAddFromRenderer(this.renderer, n, "second");
+  }
 }
 
 // ── Shared helpers for ScalarExpression Tier 3 methods ──
@@ -379,6 +400,23 @@ function buildRoundFromRenderer(
     const v = inner(resolveColumn, dialect);
     if (digits === undefined) return sql`ROUND(${v})`;
     return sql`ROUND(${v}, ${digits})`;
+  });
+}
+
+function buildDateAddFromRenderer(
+  inner: InnerRender,
+  n: number,
+  unit: DateAddUnit,
+): ScalarExpression {
+  return new ScalarExpression((resolveColumn, dialect) => {
+    if (!dialect) {
+      throw new Error(
+        "Date add expressions require a DialectExpression. Ensure the query " +
+          "builder was created via EntityManager.createQueryBuilder().",
+      );
+    }
+    const v = inner(resolveColumn, dialect);
+    return dialect.dateAdd(v, n, unit);
   });
 }
 

--- a/src/core/expressions/ScalarExpression.ts
+++ b/src/core/expressions/ScalarExpression.ts
@@ -183,6 +183,203 @@ export class ScalarExpression {
       return dialect.dateComponent(value, component);
     });
   }
+
+  // ── String helpers (Tier 3 — chain on any scalar) ──────
+
+  /** `LOWER(x)` — matches JS `String.prototype.toLowerCase`. */
+  toLowerCase(): ScalarExpression {
+    return buildStringFn("LOWER", this.renderer);
+  }
+  /** `UPPER(x)`. */
+  toUpperCase(): ScalarExpression {
+    return buildStringFn("UPPER", this.renderer);
+  }
+  /** `TRIM(x)`. */
+  trim(): ScalarExpression {
+    return buildStringFn("TRIM", this.renderer);
+  }
+  /** `CHAR_LENGTH(x)` — character count. */
+  length(): ScalarExpression {
+    return buildStringFn("CHAR_LENGTH", this.renderer);
+  }
+  /** `SUBSTR(x, start+1[, end-start])` — JS `substring` semantics. */
+  substring(start: number, end?: number): ScalarExpression {
+    return buildSubstringFromRenderer(this.renderer, start, end);
+  }
+  /** `CONCAT(x, ...args)`. */
+  concat(...args: unknown[]): ScalarExpression {
+    return buildConcatFromRenderer(this.renderer, args);
+  }
+  /** JS-style `indexOf` — 0-based, `-1` when not found. */
+  indexOf(needle: unknown): ScalarExpression {
+    return buildIndexOfFromRenderer(this.renderer, needle);
+  }
+  /** `REPLACE(x, from, to)`. */
+  replace(from: unknown, to: unknown): ScalarExpression {
+    return buildReplaceFromRenderer(this.renderer, from, to);
+  }
+
+  // ── Numeric (Tier 3) ───────────────────────────────────
+  add(right: unknown): ScalarExpression {
+    return buildBinaryOpFromRenderer(this.renderer, "+", right);
+  }
+  sub(right: unknown): ScalarExpression {
+    return buildBinaryOpFromRenderer(this.renderer, "-", right);
+  }
+  mul(right: unknown): ScalarExpression {
+    return buildBinaryOpFromRenderer(this.renderer, "*", right);
+  }
+  div(right: unknown): ScalarExpression {
+    return buildBinaryOpFromRenderer(this.renderer, "/", right);
+  }
+  mod(right: unknown): ScalarExpression {
+    return buildBinaryOpFromRenderer(this.renderer, "%", right);
+  }
+  neg(): ScalarExpression {
+    return buildUnaryNegFromRenderer(this.renderer);
+  }
+
+  // ── Math (Tier 3) ──────────────────────────────────────
+  abs(): ScalarExpression {
+    return buildStringFn("ABS", this.renderer);
+  }
+  floor(): ScalarExpression {
+    return buildStringFn("FLOOR", this.renderer);
+  }
+  ceil(): ScalarExpression {
+    return buildStringFn("CEIL", this.renderer);
+  }
+  round(digits?: number): ScalarExpression {
+    return buildRoundFromRenderer(this.renderer, digits);
+  }
+  sqrt(): ScalarExpression {
+    return buildStringFn("SQRT", this.renderer);
+  }
+}
+
+// ── Shared helpers for ScalarExpression Tier 3 methods ──
+
+type InnerRender = (r: ColumnResolver, d?: DialectExpression) => Sql;
+
+/** @internal Build `FN(x)` wrapping the inner renderer. */
+function buildStringFn(fn: string, inner: InnerRender): ScalarExpression {
+  return new ScalarExpression((resolveColumn, dialect) => {
+    const v = inner(resolveColumn, dialect);
+    return sql`${raw(fn)}(${v})`;
+  });
+}
+
+/** @internal Render an argument as either a nested expression's inner SQL or a bound parameter. */
+function renderArg(
+  arg: unknown,
+  resolveColumn: ColumnResolver,
+  dialect?: DialectExpression,
+): Sql {
+  if (
+    arg !== null &&
+    typeof arg === "object" &&
+    (arg as { __isScalarExpression?: unknown }).__isScalarExpression === true
+  ) {
+    return (arg as { renderer: InnerRender }).renderer(resolveColumn, dialect);
+  }
+  if (
+    arg !== null &&
+    typeof arg === "object" &&
+    (arg as { __isColumnExpression?: unknown }).__isColumnExpression === true
+  ) {
+    return sql`${raw(resolveColumn((arg as { toString(): string }).toString()))}`;
+  }
+  return sql`${arg as string | number | boolean | null}`;
+}
+
+function buildSubstringFromRenderer(
+  inner: InnerRender,
+  start: number,
+  end: number | undefined,
+): ScalarExpression {
+  return new ScalarExpression((resolveColumn, dialect) => {
+    const v = inner(resolveColumn, dialect);
+    const sqlStart = start + 1;
+    if (end === undefined) return sql`SUBSTR(${v}, ${sqlStart})`;
+    const length = end - start;
+    return sql`SUBSTR(${v}, ${sqlStart}, ${length})`;
+  });
+}
+
+function buildConcatFromRenderer(
+  inner: InnerRender,
+  args: unknown[],
+): ScalarExpression {
+  return new ScalarExpression((resolveColumn, dialect) => {
+    const head = inner(resolveColumn, dialect);
+    const tail = args.map((a) => renderArg(a, resolveColumn, dialect));
+    const all = [head, ...tail];
+    // Inline manual join to avoid extra import churn.
+    let acc = sql`${all[0]}`;
+    for (let i = 1; i < all.length; i++) {
+      acc = sql`${acc}, ${all[i]}`;
+    }
+    return sql`CONCAT(${acc})`;
+  });
+}
+
+function buildIndexOfFromRenderer(
+  inner: InnerRender,
+  needle: unknown,
+): ScalarExpression {
+  return new ScalarExpression((resolveColumn, dialect) => {
+    if (!dialect) {
+      throw new Error(
+        "indexOf() requires a DialectExpression. Ensure the query builder was " +
+          "created via EntityManager.createQueryBuilder().",
+      );
+    }
+    const haystack = inner(resolveColumn, dialect);
+    const n = renderArg(needle, resolveColumn, dialect);
+    return sql`(${dialect.stringIndexOf(haystack, n)} - 1)`;
+  });
+}
+
+function buildReplaceFromRenderer(
+  inner: InnerRender,
+  from: unknown,
+  to: unknown,
+): ScalarExpression {
+  return new ScalarExpression((resolveColumn, dialect) => {
+    const v = inner(resolveColumn, dialect);
+    const a = renderArg(from, resolveColumn, dialect);
+    const b = renderArg(to, resolveColumn, dialect);
+    return sql`REPLACE(${v}, ${a}, ${b})`;
+  });
+}
+
+function buildBinaryOpFromRenderer(
+  inner: InnerRender,
+  op: string,
+  right: unknown,
+): ScalarExpression {
+  return new ScalarExpression((resolveColumn, dialect) => {
+    const left = inner(resolveColumn, dialect);
+    const r = renderArg(right, resolveColumn, dialect);
+    return sql`(${left} ${raw(op)} ${r})`;
+  });
+}
+
+function buildUnaryNegFromRenderer(inner: InnerRender): ScalarExpression {
+  return new ScalarExpression((resolveColumn, dialect) => {
+    return sql`(-${inner(resolveColumn, dialect)})`;
+  });
+}
+
+function buildRoundFromRenderer(
+  inner: InnerRender,
+  digits: number | undefined,
+): ScalarExpression {
+  return new ScalarExpression((resolveColumn, dialect) => {
+    const v = inner(resolveColumn, dialect);
+    if (digits === undefined) return sql`ROUND(${v})`;
+    return sql`ROUND(${v}, ${digits})`;
+  });
 }
 
 /**

--- a/src/core/expressions/StringExpression.ts
+++ b/src/core/expressions/StringExpression.ts
@@ -1,0 +1,154 @@
+import sql, { Sql, raw, join } from "sql-template-tag";
+import type { DialectExpression } from "../../dialects/DialectExpression";
+import type { ColumnResolver } from "./ConditionLike";
+import { ScalarExpression } from "./ScalarExpression";
+
+/**
+ * Renderer contract shared by column- and scalar-based callers —
+ * produces the inner SQL fragment that string helpers wrap.
+ */
+export type InnerRenderer = (
+  resolveColumn: ColumnResolver,
+  dialect?: DialectExpression,
+) => Sql;
+
+/**
+ * @internal Render any string-function argument:
+ * - Column / scalar / JSON-path expressions unwrap to their inner SQL.
+ * - Plain primitives are bound as parameters.
+ */
+export function renderStringArg(
+  arg: unknown,
+  resolveColumn: ColumnResolver,
+  dialect?: DialectExpression,
+): Sql {
+  if (
+    arg !== null &&
+    typeof arg === "object" &&
+    (arg as { __isScalarExpression?: unknown }).__isScalarExpression === true
+  ) {
+    return (arg as {
+      renderer: (r: ColumnResolver, d?: DialectExpression) => Sql;
+    }).renderer(resolveColumn, dialect);
+  }
+  if (
+    arg !== null &&
+    typeof arg === "object" &&
+    (arg as { __isColumnExpression?: unknown }).__isColumnExpression === true
+  ) {
+    return sql`${raw(resolveColumn((arg as { toString(): string }).toString()))}`;
+  }
+  return sql`${arg as string | number | boolean | null}`;
+}
+
+// ── Factories — each returns a ScalarExpression ──────────────
+
+/** `LOWER(x)`. Standard SQL, identical on MySQL / PostgreSQL / SQLite. */
+export function buildToLowerCase(inner: InnerRenderer): ScalarExpression {
+  return new ScalarExpression((resolveColumn, dialect) => {
+    const v = inner(resolveColumn, dialect);
+    return sql`LOWER(${v})`;
+  });
+}
+
+/** `UPPER(x)`. Standard SQL. */
+export function buildToUpperCase(inner: InnerRenderer): ScalarExpression {
+  return new ScalarExpression((resolveColumn, dialect) => {
+    const v = inner(resolveColumn, dialect);
+    return sql`UPPER(${v})`;
+  });
+}
+
+/** `TRIM(x)`. Standard SQL. */
+export function buildTrim(inner: InnerRenderer): ScalarExpression {
+  return new ScalarExpression((resolveColumn, dialect) => {
+    const v = inner(resolveColumn, dialect);
+    return sql`TRIM(${v})`;
+  });
+}
+
+/**
+ * `CHAR_LENGTH(x)` — number of characters (multibyte-safe). Supported
+ * by MySQL, PostgreSQL, and SQLite.
+ */
+export function buildLength(inner: InnerRenderer): ScalarExpression {
+  return new ScalarExpression((resolveColumn, dialect) => {
+    const v = inner(resolveColumn, dialect);
+    return sql`CHAR_LENGTH(${v})`;
+  });
+}
+
+/**
+ * `SUBSTR(x, jsStart + 1[, end - jsStart])` — matches JS
+ * `String.prototype.substring` semantics (0-based, end exclusive).
+ * Negative arguments are not adjusted: SQL engines interpret them
+ * engine-specifically, mirroring JS behavior for `start < 0` is not
+ * portable. Clamp at call site if needed.
+ */
+export function buildSubstring(
+  inner: InnerRenderer,
+  start: number,
+  end: number | undefined,
+): ScalarExpression {
+  return new ScalarExpression((resolveColumn, dialect) => {
+    const v = inner(resolveColumn, dialect);
+    const sqlStart = start + 1;
+    if (end === undefined) {
+      return sql`SUBSTR(${v}, ${sqlStart})`;
+    }
+    const length = end - start;
+    return sql`SUBSTR(${v}, ${sqlStart}, ${length})`;
+  });
+}
+
+/**
+ * `CONCAT(x, ...args)`. Arguments may be columns, scalar expressions,
+ * or plain values — each is rendered independently so bindings are
+ * preserved.
+ */
+export function buildConcat(
+  inner: InnerRenderer,
+  args: unknown[],
+): ScalarExpression {
+  return new ScalarExpression((resolveColumn, dialect) => {
+    const head = inner(resolveColumn, dialect);
+    const tail = args.map((a) => renderStringArg(a, resolveColumn, dialect));
+    return sql`CONCAT(${join([head, ...tail], ", ")})`;
+  });
+}
+
+/**
+ * `STRPOS / LOCATE / INSTR` (dialect-specific) minus 1 — matches JS
+ * `indexOf` semantics (0-based; `-1` when not found).
+ */
+export function buildIndexOf(
+  inner: InnerRenderer,
+  needle: unknown,
+): ScalarExpression {
+  return new ScalarExpression((resolveColumn, dialect) => {
+    if (!dialect) {
+      throw new Error(
+        "indexOf() requires a DialectExpression. Ensure the query builder was " +
+          "created via EntityManager.createQueryBuilder().",
+      );
+    }
+    const haystack = inner(resolveColumn, dialect);
+    const needleSql = renderStringArg(needle, resolveColumn, dialect);
+    const pos = dialect.stringIndexOf(haystack, needleSql);
+    return sql`(${pos} - 1)`;
+  });
+}
+
+/** `REPLACE(x, from, to)`. Standard SQL. */
+export function buildReplace(
+  inner: InnerRenderer,
+  from: unknown,
+  to: unknown,
+): ScalarExpression {
+  return new ScalarExpression((resolveColumn, dialect) => {
+    const v = inner(resolveColumn, dialect);
+    const a = renderStringArg(from, resolveColumn, dialect);
+    const b = renderStringArg(to, resolveColumn, dialect);
+    return sql`REPLACE(${v}, ${a}, ${b})`;
+  });
+}

--- a/src/core/expressions/WindowExpression.ts
+++ b/src/core/expressions/WindowExpression.ts
@@ -1,0 +1,163 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import sql, { Sql, raw, join } from "sql-template-tag";
+import type { ColumnResolver } from "./ConditionLike";
+import type { DialectExpression } from "../../dialects/DialectExpression";
+import type { AggregateExpression } from "./AggregateExpression";
+import { OrderExpression } from "./OrderExpression";
+import { ScalarExpression } from "./ScalarExpression";
+import { AliasedExpression } from "./AliasedExpression";
+
+/**
+ * Fluent builder for an `<aggregate> OVER (…)` expression — partition,
+ * ordering, and frame clause composed incrementally.
+ *
+ * Returned by {@link AggregateExpression.over}. Terminal methods
+ * (`toScalar`, `as`) convert it to a {@link ScalarExpression} /
+ * {@link AliasedExpression} for use in SELECT.
+ *
+ * @example
+ * ```ts
+ * const u = qAlias(User, "u");
+ *
+ * qb.select([
+ *   u.score.sum().over()
+ *     .partitionBy(u.teamId)
+ *     .orderBy(u.createdAt.desc())
+ *     .rowsBetween("UNBOUNDED PRECEDING", "CURRENT ROW")
+ *     .as("running_total"),
+ * ]);
+ * ```
+ */
+export class WindowBuilder {
+  private partitions: Array<unknown> = [];
+  private orderings: OrderExpression[] = [];
+  private frame: string | undefined;
+
+  constructor(private readonly aggregate: AggregateExpression) {}
+
+  /**
+   * Add one or more PARTITION BY columns. Accepts entity-aware
+   * `ColumnExpression`s (from `qAlias(Entity, "u").col`) or raw
+   * `"alias.prop"` strings.
+   */
+  partitionBy(...cols: Array<unknown>): this {
+    this.partitions.push(...cols);
+    return this;
+  }
+
+  /**
+   * Add ORDER BY within the window frame. Accepts `OrderExpression`
+   * instances (`u.createdAt.desc()`) — use `addOrderBy`-style fluency
+   * on the column expression to construct them.
+   */
+  orderBy(...orders: OrderExpression[]): this {
+    this.orderings.push(...orders);
+    return this;
+  }
+
+  /**
+   * Set a `ROWS BETWEEN <start> AND <end>` frame. `start` / `end`
+   * accept SQL frame keywords like `"UNBOUNDED PRECEDING"`,
+   * `"CURRENT ROW"`, `"5 PRECEDING"`, `"UNBOUNDED FOLLOWING"`.
+   *
+   * Callers are responsible for ensuring the strings are safe SQL
+   * fragments — do not pass user input here.
+   */
+  rowsBetween(start: string, end: string): this {
+    this.frame = `ROWS BETWEEN ${start} AND ${end}`;
+    return this;
+  }
+
+  /** Same as {@link rowsBetween} but emits `RANGE BETWEEN …`. */
+  rangeBetween(start: string, end: string): this {
+    this.frame = `RANGE BETWEEN ${start} AND ${end}`;
+    return this;
+  }
+
+  /** Finalize as a {@link ScalarExpression} for nesting. */
+  toScalar(): ScalarExpression {
+    return new ScalarExpression((resolveColumn, dialect) =>
+      this.render(resolveColumn, dialect),
+    );
+  }
+
+  /** Shorthand — finalize with a SELECT alias. */
+  as(alias: string): AliasedExpression {
+    return this.toScalar().as(alias);
+  }
+
+  /** @internal Build the final `FUNC(col) OVER (…)` fragment. */
+  private render(
+    resolveColumn: ColumnResolver,
+    dialect?: DialectExpression,
+  ): Sql {
+    const aggSql = this.aggregate.renderFunction(resolveColumn);
+
+    const clauses: Sql[] = [];
+    if (this.partitions.length > 0) {
+      const cols = this.partitions.map((p) =>
+        renderPartitionArg(p, resolveColumn, dialect),
+      );
+      clauses.push(sql`PARTITION BY ${join(cols, ", ")}`);
+    }
+    if (this.orderings.length > 0) {
+      const ordSqls = this.orderings.map((o) =>
+        renderOrderFragment(o, resolveColumn),
+      );
+      clauses.push(sql`ORDER BY ${join(ordSqls, ", ")}`);
+    }
+    if (this.frame !== undefined) {
+      clauses.push(sql`${raw(this.frame)}`);
+    }
+
+    if (clauses.length === 0) {
+      return sql`${aggSql} OVER ()`;
+    }
+    return sql`${aggSql} OVER (${join(clauses, " ")})`;
+  }
+}
+
+/** @internal Render a partition argument as qualified column SQL. */
+function renderPartitionArg(
+  arg: unknown,
+  resolveColumn: ColumnResolver,
+  dialect: DialectExpression | undefined,
+): Sql {
+  if (
+    arg !== null &&
+    typeof arg === "object" &&
+    (arg as { __isColumnExpression?: unknown }).__isColumnExpression === true
+  ) {
+    return sql`${raw(
+      resolveColumn((arg as { toString(): string }).toString()),
+    )}`;
+  }
+  if (
+    arg !== null &&
+    typeof arg === "object" &&
+    (arg as { __isScalarExpression?: unknown }).__isScalarExpression === true
+  ) {
+    return (arg as {
+      renderer: (r: ColumnResolver, d?: DialectExpression) => Sql;
+    }).renderer(resolveColumn, dialect);
+  }
+  if (typeof arg === "string") {
+    return sql`${raw(resolveColumn(arg))}`;
+  }
+  throw new Error(
+    `WindowBuilder.partitionBy: unsupported argument of type ${typeof arg}`,
+  );
+}
+
+/** @internal Render an OrderExpression as `col DIR` SQL inside OVER (). */
+function renderOrderFragment(
+  order: OrderExpression,
+  resolveColumn: ColumnResolver,
+): Sql {
+  // Aggregate-sourced OrderExpression carries already-rendered SQL via
+  // its internal bookkeeping; for window ORDER BY we only support the
+  // column-reference form (most common) to keep frame semantics
+  // predictable. Callers needing aggregate-in-window should open a
+  // follow-up.
+  return sql`${raw(resolveColumn(order.ref))} ${raw(order.direction)}`;
+}

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -51,4 +51,5 @@ export * from "./expressions/StringExpression";
 export * from "./expressions/NumericExpression";
 export * from "./expressions/DateArithmeticExpression";
 export * from "./expressions/WindowExpression";
+export * from "./expressions/RawExpression";
 export * from "./expressions/likeEscape";

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -49,4 +49,6 @@ export * from "./expressions/SubqueryExpression";
 export * from "./expressions/CaseExpression";
 export * from "./expressions/StringExpression";
 export * from "./expressions/NumericExpression";
+export * from "./expressions/DateArithmeticExpression";
+export * from "./expressions/WindowExpression";
 export * from "./expressions/likeEscape";

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -47,4 +47,6 @@ export * from "./expressions/CastExpression";
 export * from "./expressions/DateComponentExpression";
 export * from "./expressions/SubqueryExpression";
 export * from "./expressions/CaseExpression";
+export * from "./expressions/StringExpression";
+export * from "./expressions/NumericExpression";
 export * from "./expressions/likeEscape";

--- a/src/dialects/DialectExpression.ts
+++ b/src/dialects/DialectExpression.ts
@@ -149,6 +149,18 @@ export interface DialectExpression {
   castTypeName(kind: CastKind): string;
 
   /**
+   * Render a case-sensitive substring-search position for `needle`
+   * inside `haystack`, returning the SQL 1-based position (or `0` when
+   * not found). The caller is expected to subtract 1 to match JS
+   * `indexOf` semantics (0-based with `-1` for "not found").
+   *
+   * - PostgreSQL: `STRPOS(haystack, needle)`
+   * - MySQL: `LOCATE(needle, haystack)`
+   * - SQLite: `INSTR(haystack, needle)`
+   */
+  stringIndexOf(haystack: Sql, needle: Sql): Sql;
+
+  /**
    * Render a date/time component extraction on `value` — e.g.
    * `YEAR(col)` (MySQL), `EXTRACT(YEAR FROM col)` (PostgreSQL),
    * `CAST(strftime('%Y', col) AS INTEGER)` (SQLite).

--- a/src/dialects/DialectExpression.ts
+++ b/src/dialects/DialectExpression.ts
@@ -215,10 +215,16 @@ export interface DialectExpression {
 
 /**
  * Supported CAST target kinds for the `.stringValue()` /
- * `.intValue()` family. Resolved to a dialect-specific SQL type name
- * by {@link DialectExpression.castTypeName}.
+ * `.intValue()` / `.bigintValue()` family. Resolved to a dialect-
+ * specific SQL type name by {@link DialectExpression.castTypeName}.
  */
-export type CastKind = "string" | "int" | "long" | "float" | "boolean";
+export type CastKind =
+  | "string"
+  | "int"
+  | "long"
+  | "float"
+  | "boolean"
+  | "bigint";
 
 /**
  * Supported units for `dateAdd` / `dateDiff` helpers. Day, month,

--- a/src/dialects/DialectExpression.ts
+++ b/src/dialects/DialectExpression.ts
@@ -161,6 +161,33 @@ export interface DialectExpression {
   stringIndexOf(haystack: Sql, needle: Sql): Sql;
 
   /**
+   * Render date addition: `value + n units` as a date/timestamp.
+   *
+   * - PostgreSQL: `value + (N * INTERVAL '1 day')` (or similar)
+   * - MySQL: `DATE_ADD(value, INTERVAL N DAY)`
+   * - SQLite: `datetime(value, '+N days')`
+   *
+   * @param n can be negative for subtraction (`addDays(-7)`).
+   */
+  dateAdd(value: Sql, n: number, unit: DateAddUnit): Sql;
+
+  /**
+   * Render `dateDiff(a, b, unit)` — `(a - b)` in the requested unit.
+   *
+   * - PostgreSQL: `EXTRACT(epoch FROM (a - b)) / factor` or age()
+   * - MySQL: `TIMESTAMPDIFF(UNIT, b, a)`
+   * - SQLite: `CAST((julianday(a) - julianday(b)) * factor AS INTEGER)`
+   */
+  dateDiff(a: Sql, b: Sql, unit: DateAddUnit): Sql;
+
+  /**
+   * Render `RANDOM()` / `RAND()` — a scalar in `[0, 1)` (PG/SQLite) or
+   * `[0, 1)` / engine-specific range. Wrap in `ORDER BY` for random
+   * sampling.
+   */
+  random(): Sql;
+
+  /**
    * Render a date/time component extraction on `value` — e.g.
    * `YEAR(col)` (MySQL), `EXTRACT(YEAR FROM col)` (PostgreSQL),
    * `CAST(strftime('%Y', col) AS INTEGER)` (SQLite).
@@ -192,6 +219,19 @@ export interface DialectExpression {
  * by {@link DialectExpression.castTypeName}.
  */
 export type CastKind = "string" | "int" | "long" | "float" | "boolean";
+
+/**
+ * Supported units for `dateAdd` / `dateDiff` helpers. Day, month,
+ * year are calendar-aware where the engine supports it; hour, minute,
+ * second are straight time deltas.
+ */
+export type DateAddUnit =
+  | "year"
+  | "month"
+  | "day"
+  | "hour"
+  | "minute"
+  | "second";
 
 /**
  * Supported date-component extraction kinds. Resolved to dialect-

--- a/src/dialects/expression/MySqlExpression.ts
+++ b/src/dialects/expression/MySqlExpression.ts
@@ -3,6 +3,7 @@ import type { Sql } from "sql-template-tag";
 import type {
   CastKind,
   ColumnJsonMeta,
+  DateAddUnit,
   DateComponent,
   DialectExpression,
 } from "../DialectExpression";
@@ -133,9 +134,44 @@ export class MySqlExpression implements DialectExpression {
     return sql`LOCATE(${needle}, ${haystack})`;
   }
 
+  dateAdd(value: Sql, n: number, unit: DateAddUnit): Sql {
+    // MySQL uses an unquoted INTERVAL keyword + value + unit keyword.
+    // Injecting the unit via raw() because MySQL doesn't parameterize
+    // interval units.
+    const unitKw = mysqlUnitKeyword(unit);
+    return sql`DATE_ADD(${value}, INTERVAL ${n} ${raw(unitKw)})`;
+  }
+
+  dateDiff(a: Sql, b: Sql, unit: DateAddUnit): Sql {
+    // TIMESTAMPDIFF(UNIT, start, end) returns end - start.
+    const unitKw = mysqlUnitKeyword(unit);
+    return sql`TIMESTAMPDIFF(${raw(unitKw)}, ${b}, ${a})`;
+  }
+
+  random(): Sql {
+    return sql`RAND()`;
+  }
+
   dateComponent(value: Sql, component: DateComponent): Sql {
     const fn = mysqlDateFunction(component);
     return sql`${raw(fn)}(${value})`;
+  }
+}
+
+function mysqlUnitKeyword(unit: DateAddUnit): string {
+  switch (unit) {
+    case "year":
+      return "YEAR";
+    case "month":
+      return "MONTH";
+    case "day":
+      return "DAY";
+    case "hour":
+      return "HOUR";
+    case "minute":
+      return "MINUTE";
+    case "second":
+      return "SECOND";
   }
 }
 

--- a/src/dialects/expression/MySqlExpression.ts
+++ b/src/dialects/expression/MySqlExpression.ts
@@ -128,6 +128,11 @@ export class MySqlExpression implements DialectExpression {
     }
   }
 
+  stringIndexOf(haystack: Sql, needle: Sql): Sql {
+    // MySQL LOCATE takes (needle, haystack) — reversed from STRPOS/INSTR.
+    return sql`LOCATE(${needle}, ${haystack})`;
+  }
+
   dateComponent(value: Sql, component: DateComponent): Sql {
     const fn = mysqlDateFunction(component);
     return sql`${raw(fn)}(${value})`;

--- a/src/dialects/expression/MySqlExpression.ts
+++ b/src/dialects/expression/MySqlExpression.ts
@@ -121,6 +121,8 @@ export class MySqlExpression implements DialectExpression {
         return "CHAR";
       case "int":
       case "long":
+      case "bigint":
+        // MySQL SIGNED is 64-bit; no distinct 32-bit cast target.
         return "SIGNED";
       case "float":
         return "DECIMAL";

--- a/src/dialects/expression/PostgresExpression.ts
+++ b/src/dialects/expression/PostgresExpression.ts
@@ -224,6 +224,7 @@ export class PostgresExpression implements DialectExpression {
       case "int":
         return "INTEGER";
       case "long":
+      case "bigint":
         return "BIGINT";
       case "float":
         return "REAL";

--- a/src/dialects/expression/PostgresExpression.ts
+++ b/src/dialects/expression/PostgresExpression.ts
@@ -231,6 +231,10 @@ export class PostgresExpression implements DialectExpression {
     }
   }
 
+  stringIndexOf(haystack: Sql, needle: Sql): Sql {
+    return sql`STRPOS(${haystack}, ${needle})`;
+  }
+
   dateComponent(value: Sql, component: DateComponent): Sql {
     // PostgreSQL EXTRACT returns a numeric — cast to integer so
     // downstream comparisons stay on integer arithmetic.

--- a/src/dialects/expression/PostgresExpression.ts
+++ b/src/dialects/expression/PostgresExpression.ts
@@ -3,6 +3,7 @@ import type { Sql } from "sql-template-tag";
 import type {
   CastKind,
   ColumnJsonMeta,
+  DateAddUnit,
   DateComponent,
   DialectExpression,
 } from "../DialectExpression";
@@ -235,11 +236,69 @@ export class PostgresExpression implements DialectExpression {
     return sql`STRPOS(${haystack}, ${needle})`;
   }
 
+  dateAdd(value: Sql, n: number, unit: DateAddUnit): Sql {
+    // `value + (N * INTERVAL '1 unit')` — the literal is injected as
+    // raw SQL because PostgreSQL does not accept a parameter for the
+    // INTERVAL type specifier.
+    const literal = pgIntervalLiteral(unit);
+    return sql`(${value} + (${n} * INTERVAL ${raw(literal)}))`;
+  }
+
+  dateDiff(a: Sql, b: Sql, unit: DateAddUnit): Sql {
+    if (unit === "year") {
+      return sql`CAST(EXTRACT(YEAR FROM age(${a}, ${b})) AS INTEGER)`;
+    }
+    if (unit === "month") {
+      return sql`CAST(
+        EXTRACT(YEAR FROM age(${a}, ${b})) * 12
+        + EXTRACT(MONTH FROM age(${a}, ${b}))
+      AS INTEGER)`;
+    }
+    const factor = secondsPerUnit(unit);
+    return sql`CAST(EXTRACT(EPOCH FROM (${a} - ${b})) / ${factor} AS INTEGER)`;
+  }
+
+  random(): Sql {
+    return sql`RANDOM()`;
+  }
+
   dateComponent(value: Sql, component: DateComponent): Sql {
     // PostgreSQL EXTRACT returns a numeric — cast to integer so
     // downstream comparisons stay on integer arithmetic.
     const field = pgExtractField(component);
     return sql`CAST(EXTRACT(${raw(field)} FROM ${value}) AS INTEGER)`;
+  }
+}
+
+function pgIntervalLiteral(unit: DateAddUnit): string {
+  switch (unit) {
+    case "year":
+      return "'1 year'";
+    case "month":
+      return "'1 month'";
+    case "day":
+      return "'1 day'";
+    case "hour":
+      return "'1 hour'";
+    case "minute":
+      return "'1 minute'";
+    case "second":
+      return "'1 second'";
+  }
+}
+
+function secondsPerUnit(unit: DateAddUnit): number {
+  switch (unit) {
+    case "day":
+      return 86400;
+    case "hour":
+      return 3600;
+    case "minute":
+      return 60;
+    case "second":
+      return 1;
+    default:
+      throw new Error(`Unsupported unit for seconds-based diff: ${unit}`);
   }
 }
 

--- a/src/dialects/expression/SqliteExpression.ts
+++ b/src/dialects/expression/SqliteExpression.ts
@@ -3,6 +3,7 @@ import type { Sql } from "sql-template-tag";
 import type {
   CastKind,
   ColumnJsonMeta,
+  DateAddUnit,
   DateComponent,
   DialectExpression,
 } from "../DialectExpression";
@@ -127,9 +128,64 @@ export class SqliteExpression implements DialectExpression {
     return sql`INSTR(${haystack}, ${needle})`;
   }
 
+  dateAdd(value: Sql, n: number, unit: DateAddUnit): Sql {
+    // SQLite uses modifier strings: '+N days', '+N months', etc.
+    // The modifier must be a bound string parameter.
+    const modifier = sqliteModifier(n, unit);
+    return sql`datetime(${value}, ${modifier})`;
+  }
+
+  dateDiff(a: Sql, b: Sql, unit: DateAddUnit): Sql {
+    if (unit === "year") {
+      return sql`CAST((julianday(${a}) - julianday(${b})) / 365.25 AS INTEGER)`;
+    }
+    if (unit === "month") {
+      return sql`CAST((julianday(${a}) - julianday(${b})) / 30.4375 AS INTEGER)`;
+    }
+    const factor = juliandayFactor(unit);
+    return sql`CAST((julianday(${a}) - julianday(${b})) * ${factor} AS INTEGER)`;
+  }
+
+  random(): Sql {
+    return sql`RANDOM()`;
+  }
+
   dateComponent(value: Sql, component: DateComponent): Sql {
     const format = sqliteStrftimeFormat(component);
     return sql`CAST(strftime(${format}, ${value}) AS INTEGER)`;
+  }
+}
+
+function sqliteModifier(n: number, unit: DateAddUnit): string {
+  const sign = n >= 0 ? "+" : "-";
+  const abs = Math.abs(n);
+  const noun =
+    unit === "year"
+      ? "years"
+      : unit === "month"
+        ? "months"
+        : unit === "day"
+          ? "days"
+          : unit === "hour"
+            ? "hours"
+            : unit === "minute"
+              ? "minutes"
+              : "seconds";
+  return `${sign}${abs} ${noun}`;
+}
+
+function juliandayFactor(unit: DateAddUnit): number {
+  switch (unit) {
+    case "day":
+      return 1;
+    case "hour":
+      return 24;
+    case "minute":
+      return 1440;
+    case "second":
+      return 86400;
+    default:
+      throw new Error(`Unsupported unit for julianday diff: ${unit}`);
   }
 }
 

--- a/src/dialects/expression/SqliteExpression.ts
+++ b/src/dialects/expression/SqliteExpression.ts
@@ -116,6 +116,8 @@ export class SqliteExpression implements DialectExpression {
         return "TEXT";
       case "int":
       case "long":
+      case "bigint":
+        // SQLite INTEGER is already 64-bit.
         return "INTEGER";
       case "float":
         return "REAL";

--- a/src/dialects/expression/SqliteExpression.ts
+++ b/src/dialects/expression/SqliteExpression.ts
@@ -123,6 +123,10 @@ export class SqliteExpression implements DialectExpression {
     }
   }
 
+  stringIndexOf(haystack: Sql, needle: Sql): Sql {
+    return sql`INSTR(${haystack}, ${needle})`;
+  }
+
   dateComponent(value: Sql, component: DateComponent): Sql {
     const format = sqliteStrftimeFormat(component);
     return sql`CAST(strftime(${format}, ${value}) AS INTEGER)`;


### PR DESCRIPTION
## Summary

QueryDSL **Tier 3 — re-planned for TS/Node rather than Java QueryDSL parity**. Drops `Projections`, `stringTemplate`, `useLiterals`, and `streamWindow` (each either redundant with TS/sql-template-tag idioms or trivially covered by existing primitives). Adds what a TypeScript developer actually expects from a modern query builder — JS-idiomatic string / numeric / math helpers, date arithmetic, window functions, and three TS-native escape hatches.

Three phase commits, independently reviewable:

- **Phase 3.1 — JS-idiomatic string / numeric / math** (b1732b8)
  - String: `.toLowerCase`, `.toUpperCase`, `.trim`, `.length`, `.substring(s, e?)`, `.concat(...)`, `.indexOf(needle)`, `.replace(from, to)`
  - Arithmetic: `.add`, `.sub`, `.mul`, `.div`, `.mod`, `.neg`
  - Math: `.abs`, `.floor`, `.ceil`, `.round(digits?)`, `.sqrt`
  - Method names match `String.prototype` / `Math.*` / BigInt arithmetic — no mental context-switch.
  - JS semantics preserved where they differ from SQL: `substring` is 0-based / end-exclusive → emits `SUBSTR(col, s+1, e-s)`; `length` uses `CHAR_LENGTH` (multibyte safe); `indexOf` returns `-1` / 0-based position (shifts dialect-specific `STRPOS` / `LOCATE` / `INSTR` down by one).

- **Phase 3.2 — Date arithmetic / window / random** (44ff9d0)
  - `.addYears/Months/Days/Hours/Minutes/Seconds(n)` — calendar-aware per dialect.
  - `Expressions.dateDiff(a, b, unit)` — integer difference with engine-appropriate implementation (`TIMESTAMPDIFF` / `age()` / `julianday()`).
  - `Expressions.random()` — `RAND()` / `RANDOM()`.
  - `AggregateExpression.over()` returns a `WindowBuilder` chain: `.partitionBy(...).orderBy(...).rowsBetween(start, end).as(alias)`. `toScalar()` terminal allows nesting as a comparison operand.

- **Phase 3.3 — TS-native escape hatches** (c5729b0)
  - `Expressions.raw<T>(sql`...`)` — typed raw escape that threads through the full Tier 2/3 composition surface. Parameter bindings survive end-to-end.
  - `.bigintValue()` — CAST sibling of `.longValue()` with a name signaling JS `bigint` intent.
  - `qb.selectSchema(zodSchema)` — runtime validation + `TResult` narrowing to `z.infer<typeof schema>`.

## What was NOT ported from Java QueryDSL

| Java feature | Decision | Reason |
|--------------|----------|--------|
| `Projections.constructor / fields / tuple` | Skip | TS generics + `.as()` + `getRawMany<T>()` + `class-transformer` already cover DTO mapping. Reflection-driven API doesn't translate cleanly. |
| `Expressions.stringTemplate` etc. | Skip | `sql-template-tag` is native — `Expressions.raw<T>(sql`...`)` gives the same power with a TS-friendly signature. |
| `useLiterals` toggle | Skip | Always-parameterize is the security policy. Not debatable. |
| `Collection path` (`posts.size()`) | Defer to Tier 4 / likely skip | `leftJoinRelation(...).count()` covers it. |

## Stats

- **Full suite:** 5,041 passed / 21 skipped / **0 failures** across 236 suites (unit + MySQL + PostgreSQL + SQLite).
- **Tier 3 new unit tests:** 71 (26 + 29 + 16).
- **Files changed:** 32, +2,500+ LOC (Tier 3 total).
- **New modules:** `StringExpression`, `NumericExpression`, `DateArithmeticExpression`, `WindowExpression`, `RawExpression`.
- **DialectExpression additions:** `stringIndexOf`, `dateAdd`, `dateDiff`, `random`, expanded `CastKind` with `"bigint"`.
- **Docs:** `docs/query-builder.md` (EN) + `docs/ko/query-builder.md` (KO) updated with 5 new sections plus summary-table rows.

## Release

→ **v0.19.0 "QueryDSL Tier 3 — TS/Node-native"**

## Test plan

- [x] Unit — all Tier 3 test files pass individually (26 + 29 + 16).
- [x] Full run (unit + all integrations) — 5,041 passed / 21 skipped / 0 failures in ~36s.
- [x] Regression clean on MySQL + PostgreSQL + SQLite.
- [ ] Example projects `tsc --noEmit` (none touch the new surface, but confirm no type regression — CI covers).
- [ ] Tag release as v0.19.0 after merge.

AI-assistant: claude-opus-4-7