### PR TITLE
feat(nestjs): export correctly-spelled 'StingerloomOrmModule' / 'StingerloomOrmService' aliases

### DIFF
--- a/src/integration/nestjs/index.ts
+++ b/src/integration/nestjs/index.ts
@@ -1,5 +1,6 @@
 export {
   StinglerloomOrmModule,
+  StinglerloomOrmModule as StingerloomOrmModule,
   makeInjectRepositoryToken,
   getEntityManagerToken,
   STINGERLOOM_ORM_OPTION_TOKEN,
@@ -8,6 +9,7 @@ export {
 export { StingerloomOrmCoreModule } from "./stingerloom-orm-core.module";
 export {
   StinglerloomOrmService,
+  StinglerloomOrmService as StingerloomOrmService,
   STINGERLOOM_ORM_SERVICE_TOKEN,
   getOrmServiceToken,
 } from "./stingerloom-orm.service";


### PR DESCRIPTION
## Summary

Per #261, the NestJS integration exported \`StinglerloomOrmModule\` (extra \`l\`) and \`StinglerloomOrmService\`, while the package, README, and docs all use \`Stingerloom\` (no extra \`l\`). A NestJS user writing:

\`\`\`typescript
import { StingerloomOrmModule } from \"@stingerloom/orm/nestjs\";
\`\`\`

hits the TypeScript error \`'@stingerloom/orm/nestjs' has no exported member named 'StingerloomOrmModule'. Did you mean 'StinglerloomOrmModule'?\`, which is jarring for the first import a user types.

This PR is scoped to a **non-breaking** fix: re-export \`StinglerloomOrmModule\` as \`StingerloomOrmModule\` and \`StinglerloomOrmService\` as \`StingerloomOrmService\` from the public barrel so both names resolve. Existing code using the misspelled names keeps working; new code can use the correct spelling.

A follow-up can flip the canonical definition to the correctly-spelled name, deprecate the misspelled alias, and update README / docs. Holding that change back so this PR can land with zero risk.

Refs #261

## Testing

Type-level change; added re-exports only. Import:

\`\`\`typescript
import { StingerloomOrmModule, StinglerloomOrmModule } from \"@stingerloom/orm/nestjs\";
\`\`\`

should now type-check and both bindings refer to the same class.