### PR TITLE
test(json-column): integration round-trip + drop dead applyPatch transforms

### DIFF
--- a/__tests__/integration/json-column-roundtrip.test.ts
+++ b/__tests__/integration/json-column-roundtrip.test.ts
@@ -1,0 +1,171 @@
+/**
+ * JSON 컬럼 auto-transformer 통합 테스트 — save() → findOne() 라운드트립
+ *
+ * `@Column({ type: "json" | "jsonb" })` 가 caller-side `JSON.stringify` 없이
+ * 평범한 JS 객체/배열을 그대로 직렬화하고, 읽을 때 다시 파싱해 돌려주는지
+ * 실제 DB 에 대해 검증한다. Issue #338 의 acceptance criteria — 서비스 코드는
+ * plain object 만 넘긴다 — 를 라운드트립으로 못박는다.
+ *
+ * 같은 시나리오를 MySQL(`json`) 과 PostgreSQL(`jsonb`) 양쪽에서 실행한다.
+ * MySQL/SQLite 드라이버는 JSON 컬럼을 문자열로 surface 하고 pg jsonb 는 이미
+ * 파싱된 값을 돌려주지만, ORM 레벨 transformer 가 두 경로를 동일하게 정규화한다.
+ *
+ * 요구사항:
+ *   INTEGRATION_TEST=true (jest config gate)
+ *   접근 가능한 MySQL / PostgreSQL
+ *     개별 비활성화: INTEGRATION_TEST_MYSQL=false / INTEGRATION_TEST_POSTGRES=false
+ */
+
+import "reflect-metadata";
+import { EntityManager } from "../../src/core/EntityManager";
+import {
+  createTestConnection,
+  dropTestTable,
+  truncateTestTable,
+  type TestConnectionResult,
+} from "./helpers/test-connection";
+import {
+  createDynamicEntity,
+  type DynamicEntityResult,
+} from "./helpers/create-test-entity";
+import { getTestDrivers, type TestDriverConfig } from "./helpers/driver-config";
+
+const skipReason = !process.env.INTEGRATION_TEST
+  ? "INTEGRATION_TEST 환경변수가 설정되지 않음"
+  : undefined;
+const describeIf = skipReason ? describe.skip : describe;
+
+describeIf.each(getTestDrivers())(
+  "[Integration] JSON 컬럼 auto-transformer 라운드트립 ($label)",
+  ({ type, options }: TestDriverConfig) => {
+    let conn: TestConnectionResult;
+    let em: EntityManager;
+    let testEntity: DynamicEntityResult;
+
+    // PostgreSQL 은 jsonb(네이티브 파싱), MySQL 은 json.
+    const jsonType = type === "postgres" ? "jsonb" : "json";
+
+    beforeAll(async () => {
+      conn = await createTestConnection(
+        { synchronize: true, logging: false, ...options },
+        () => {
+          testEntity = createDynamicEntity("json_roundtrip", [
+            { name: "id", designType: Number, primary: true },
+            {
+              name: "name",
+              designType: String,
+              options: { type: "varchar", length: 255 },
+            },
+            {
+              // 실제 엔티티의 `customFields: Record<string, unknown>` 와 동일하게
+              // design:type 은 Object, 컬럼 타입은 명시적으로 json/jsonb.
+              name: "customFields",
+              designType: Object,
+              options: { type: jsonType, nullable: true },
+            },
+          ]);
+          return { entities: [testEntity.EntityClass] };
+        },
+      );
+      em = conn.em;
+    }, 30000);
+
+    afterAll(async () => {
+      try {
+        if (testEntity) await dropTestTable(testEntity.tableName);
+      } catch {
+        // ignore
+      }
+      if (conn) await conn.cleanup();
+    }, 15000);
+
+    beforeEach(async () => {
+      await truncateTestTable(testEntity.tableName);
+    });
+
+    it("plain object 를 save 하면 caller 의 JSON.stringify 없이 라운드트립된다", async () => {
+      // Issue #338 본문이 명시한 예시 페이로드.
+      const customFields = { severity: "S0", labels: ["a", "b"] };
+
+      const saved = await em.save(testEntity.EntityClass, {
+        name: "issue-1",
+        customFields,
+      });
+
+      const found = await em.findOne(testEntity.EntityClass, {
+        where: { id: saved.id },
+      });
+
+      expect(found).not.toBeNull();
+      // 읽기 시 객체로 복원되어야 한다 — 문자열이 아님.
+      expect(typeof found!.customFields).toBe("object");
+      expect(found!.customFields).toEqual(customFields);
+    });
+
+    it("최상위 배열 값도 라운드트립된다", async () => {
+      const customFields = ["red", "green", { nested: true }];
+
+      const saved = await em.save(testEntity.EntityClass, {
+        name: "array-fields",
+        customFields,
+      });
+      const found = await em.findOne(testEntity.EntityClass, {
+        where: { id: saved.id },
+      });
+
+      expect(Array.isArray(found!.customFields)).toBe(true);
+      expect(found!.customFields).toEqual(customFields);
+    });
+
+    it("깊게 중첩된 객체/배열 구조를 그대로 보존한다", async () => {
+      const customFields = {
+        meta: { tags: ["x", "y"], counts: { open: 3, closed: 7 } },
+        items: [
+          { id: 1, ok: true },
+          { id: 2, ok: false },
+        ],
+      };
+
+      const saved = await em.save(testEntity.EntityClass, {
+        name: "nested-fields",
+        customFields,
+      });
+      const found = await em.findOne(testEntity.EntityClass, {
+        where: { id: saved.id },
+      });
+
+      expect(found!.customFields).toEqual(customFields);
+    });
+
+    it("nullable JSON 컬럼에 null 을 저장하면 null 로 돌아온다", async () => {
+      const saved = await em.save(testEntity.EntityClass, {
+        name: "null-fields",
+        customFields: null,
+      });
+      const found = await em.findOne(testEntity.EntityClass, {
+        where: { id: saved.id },
+      });
+
+      expect(found).not.toBeNull();
+      expect(found!.customFields == null).toBe(true);
+    });
+
+    it("이미 직렬화된 문자열은 이중 인코딩하지 않는다 (idempotency)", async () => {
+      // 마이그레이션 전 레거시 코드가 수동으로 JSON.stringify 한 값.
+      const payload = { severity: "S1", labels: ["legacy"] };
+      const preSerialized = JSON.stringify(payload);
+
+      const saved = await em.save(testEntity.EntityClass, {
+        name: "pre-serialized",
+        customFields: preSerialized as unknown as Record<string, unknown>,
+      });
+      const found = await em.findOne(testEntity.EntityClass, {
+        where: { id: saved.id },
+      });
+
+      // 이중 인코딩됐다면 읽을 때 객체가 아닌 문자열이 나왔을 것이다.
+      // 한 번만 인코딩 → 객체로 정상 복원.
+      expect(found!.customFields).toEqual(payload);
+    });
+  },
+);

--- a/examples/nestjs-linear-clone/src/common/dto-helpers.ts
+++ b/examples/nestjs-linear-clone/src/common/dto-helpers.ts
@@ -9,10 +9,13 @@
  *                                   keys whose value isn't `undefined`.
  *                                   When `keys` is omitted every own enumerable
  *                                   key on `obj` is considered.
- *   - `applyPatch(target, patch, transforms?)`
- *     — mutate `target` with the keys from `patch`, optionally running each
- *       value through a per-key transformer first (e.g. `JSON.stringify` for
- *       JSON columns).
+ *   - `applyPatch(target, patch)` — mutate `target` with the keys from `patch`,
+ *                                   skipping `undefined` values.
+ *
+ * JSON columns no longer need a per-key transformer here: a column declared
+ * `@Column({ type: "json" | "jsonb" })` auto-serializes plain objects on write
+ * and parses them back on read, so service code assigns
+ * `entity.customFields = { ... }` directly — no `JSON.stringify` plumbing.
  */
 
 export function pickDefined<T extends object>(
@@ -28,34 +31,21 @@ export function pickDefined<T extends object>(
   return out;
 }
 
-export type Transformer<T, K extends keyof T = keyof T> = (
-  value: NonNullable<T[K]>,
-) => unknown;
-
-export type Transformers<T> = {
-  [K in keyof T]?: Transformer<T, K>;
-};
-
 /**
- * Mutate `target` with values from `patch`, applying per-key transformers
- * before assignment. Keys whose source value is `undefined` are left
- * untouched on `target`.
+ * Mutate `target` with values from `patch`. Keys whose source value is
+ * `undefined` are left untouched on `target`.
  *
  * @example
- *   applyPatch(issue, dto, { customFields: JSON.stringify });
+ *   applyPatch(issue, pickDefined(dto, PATCHABLE_KEYS));
  */
 export function applyPatch<T extends object, P extends Partial<T>>(
   target: T,
   patch: P,
-  transforms?: Transformers<T>,
 ): T {
   for (const k in patch) {
     const value = patch[k];
     if (value === undefined) continue;
-    const transform = transforms?.[k as unknown as keyof T];
-    (target as any)[k] = transform
-      ? transform(value as NonNullable<T[keyof T]>)
-      : value;
+    (target as any)[k] = value;
   }
   return target;
 }


### PR DESCRIPTION
## Summary

Closes #338.

The core auto-transformer for `@Column({ type: "json" | "jsonb" })` — auto `JSON.stringify` on write, auto-parse on read — already landed in `31aa150`. This PR closes the two remaining checklist items from the issue.

### 1. Dual-driver integration test

`__tests__/integration/json-column-roundtrip.test.ts` round-trips values through `save()` -> `findOne()` on **both MySQL (`json`) and PostgreSQL (`jsonb`)** via the shared `describe.each(getTestDrivers())` pattern:

- plain object (`{ severity: "S0", labels: ["a","b"] }` — the exact issue payload)
- top-level array
- deeply nested object/array structure
- `null` on a nullable JSON column
- pre-serialized string -> **no double-encoding** (idempotency)

All assertions confirm service code passes plain objects with zero caller-side `JSON.stringify`. Verified green on MySQL locally (5/5); PostgreSQL runs in CI.

### 2. Drop dead `transforms` plumbing

`examples/nestjs-linear-clone` `applyPatch` still carried a `transforms?` parameter (plus `Transformer` / `Transformers` types) whose only documented use was `{ customFields: JSON.stringify }`. Since JSON columns now auto-serialize, all four call sites use the 2-arg form and the per-key transformer path is unreachable — removed. The `examples/nestjs-linear-clone` `README.md:179-181` claim is now accurate.

## Checklist mapping (#338)

- [x] Audit current behavior — core landed in `31aa150`
- [x] MySQL default `transformer` injection — `defaultJsonColumnWrite`
- [x] PostgreSQL `jsonb` — same path, verified
- [x] Idempotency (string passthrough, no double-stringify)
- [x] Docs EN + KO — `docs/entities.md` (in `31aa150`)
- [x] Sweep `examples/nestjs-linear-clone` — `json.transformer.ts` removed in `31aa150`; dead `applyPatch` `transforms` removed here
- [x] Unit + integration tests — `json-column-defaults.test.ts` (24, existing) + `json-column-roundtrip.test.ts` (new)

## Test plan

- `npx jest json-column` — 24/24 unit tests pass
- `INTEGRATION_TEST=true INTEGRATION_TEST_POSTGRES=false npx jest json-column-roundtrip` — 5/5 MySQL pass
- `tsc --noEmit` on `examples/nestjs-linear-clone` — clean
