### PR TITLE
feat(core): typed coercion API for getRawMany() / getRawOne()

### DIFF
--- a/__tests__/integration/raw-value-coercion.test.ts
+++ b/__tests__/integration/raw-value-coercion.test.ts
@@ -1,0 +1,195 @@
+/**
+ * getRawMany / getRawOne `coerce` 옵션 통합 테스트 — 실제 드라이버 검증
+ *
+ * `mysql2` 는 `BIGINT` 와 집계 결과(`COUNT` / `SUM` / `AVG`)를 문자열로,
+ * `pg` 는 `BIGINT` / `NUMERIC` 를 문자열로 surface 한다. 분석/집계 쿼리
+ * 호출처가 매번 `Number(row.x)` 를 손으로 적던 보일러플레이트를, 쿼리
+ * 빌더의 `coerce` 옵션이 ORM 레벨에서 정규화하는지 MySQL/PostgreSQL
+ * 양쪽에서 검증한다.
+ *
+ * 요구사항:
+ *   INTEGRATION_TEST=true (jest config gate)
+ *   접근 가능한 MySQL / PostgreSQL
+ *     개별 비활성화: INTEGRATION_TEST_MYSQL=false / INTEGRATION_TEST_POSTGRES=false
+ */
+
+import "reflect-metadata";
+import { EntityManager } from "../../src/core/EntityManager";
+import { Expressions, qAlias } from "../../src";
+import {
+  createTestConnection,
+  dropTestTable,
+  truncateTestTable,
+  type TestConnectionResult,
+} from "./helpers/test-connection";
+import {
+  createDynamicEntity,
+  type DynamicEntityResult,
+} from "./helpers/create-test-entity";
+import { getTestDrivers, type TestDriverConfig } from "./helpers/driver-config";
+
+const skipReason = !process.env.INTEGRATION_TEST
+  ? "INTEGRATION_TEST 환경변수가 설정되지 않음"
+  : undefined;
+const describeIf = skipReason ? describe.skip : describe;
+
+describeIf.each(getTestDrivers())(
+  "[Integration] getRawMany coerce 옵션 ($label)",
+  ({ type, options }: TestDriverConfig) => {
+    let conn: TestConnectionResult;
+    let em: EntityManager;
+    let testEntity: DynamicEntityResult;
+
+    const jsonType = type === "postgres" ? "jsonb" : "json";
+
+    beforeAll(async () => {
+      conn = await createTestConnection(
+        { synchronize: true, logging: false, ...options },
+        () => {
+          testEntity = createDynamicEntity("raw_coerce", [
+            { name: "id", designType: Number, primary: true },
+            { name: "amount", designType: Number, options: { type: "int" } },
+            {
+              name: "bigCounter",
+              designType: Number,
+              options: { type: "bigint" },
+            },
+            {
+              name: "meta",
+              designType: Object,
+              options: { type: jsonType, nullable: true },
+            },
+            {
+              name: "recordedAt",
+              designType: Date,
+              options: { type: "datetime" },
+            },
+          ]);
+          return { entities: [testEntity.EntityClass] };
+        },
+      );
+      em = conn.em;
+    }, 30000);
+
+    afterAll(async () => {
+      try {
+        if (testEntity) await dropTestTable(testEntity.tableName);
+      } catch {
+        // ignore
+      }
+      if (conn) await conn.cleanup();
+    }, 15000);
+
+    beforeEach(async () => {
+      await truncateTestTable(testEntity.tableName);
+      // amounts 10/20/30 → COUNT 3, SUM 60, AVG 20.
+      await em.save(testEntity.EntityClass, {
+        amount: 10,
+        bigCounter: 9007199254740,
+        meta: { tag: "a", scores: [1, 2] },
+        recordedAt: new Date("2026-05-01T08:00:00.000Z"),
+      });
+      await em.save(testEntity.EntityClass, {
+        amount: 20,
+        bigCounter: 1,
+        meta: null,
+        recordedAt: new Date("2026-05-02T08:00:00.000Z"),
+      });
+      await em.save(testEntity.EntityClass, {
+        amount: 30,
+        bigCounter: 42,
+        meta: { tag: "c", scores: [] },
+        recordedAt: new Date("2026-05-03T08:00:00.000Z"),
+      });
+    });
+
+    it("coerces COUNT / SUM / AVG aggregate results to numbers", async () => {
+      const e = qAlias(testEntity.EntityClass, "e") as any;
+      const row = await em
+        .createQueryBuilder(testEntity.EntityClass, "e")
+        .select([
+          Expressions.count("*").as("cnt"),
+          Expressions.sum(e.amount).as("total"),
+          Expressions.avg(e.amount).as("avg"),
+        ])
+        .getRawOne<{ cnt: number; total: number; avg: number }>({
+          coerce: { cnt: "number", total: "number", avg: "number" },
+        });
+
+      expect(row).not.toBeNull();
+      expect(typeof row!.cnt).toBe("number");
+      expect(typeof row!.total).toBe("number");
+      expect(typeof row!.avg).toBe("number");
+      expect(row!.cnt).toBe(3);
+      expect(row!.total).toBe(60);
+      expect(row!.avg).toBe(20);
+    });
+
+    it("without coerce, the driver surfaces SUM() as a non-number", async () => {
+      // The motivating problem: a SUM over an integer column comes back as
+      // DECIMAL (mysql2) / bigint (pg), which both drivers surface as a
+      // string. This is exactly what the coerce option compensates for.
+      const e = qAlias(testEntity.EntityClass, "e") as any;
+      const rawRow = await em
+        .createQueryBuilder(testEntity.EntityClass, "e")
+        .select([Expressions.sum(e.amount).as("total")])
+        .getRawOne();
+
+      expect(rawRow).not.toBeNull();
+      expect(typeof rawRow!.total).not.toBe("number");
+    });
+
+    it("coerces a BIGINT column to a number", async () => {
+      const e = qAlias(testEntity.EntityClass, "e") as any;
+      const rows = await em
+        .createQueryBuilder(testEntity.EntityClass, "e")
+        .addOrderBy(e.amount, "ASC")
+        .getRawMany<{ amount: number; bigCounter: number }>({
+          coerce: { amount: "number", bigCounter: "number" },
+        });
+
+      expect(rows).toHaveLength(3);
+      expect(typeof rows[0].bigCounter).toBe("number");
+      expect(rows[0].bigCounter).toBe(9007199254740);
+      expect(rows[2].bigCounter).toBe(42);
+    });
+
+    it("coerces a JSON column to an object and preserves null", async () => {
+      const e = qAlias(testEntity.EntityClass, "e") as any;
+      const rows = await em
+        .createQueryBuilder(testEntity.EntityClass, "e")
+        .addOrderBy(e.amount, "ASC")
+        .getRawMany<{ amount: number; meta: { tag: string } | null }>({
+          coerce: { amount: "number", meta: "json" },
+        });
+
+      expect(rows[0].meta).toEqual({ tag: "a", scores: [1, 2] });
+      expect(rows[1].meta).toBeNull();
+    });
+
+    it("coerces a DATETIME column to a Date", async () => {
+      const e = qAlias(testEntity.EntityClass, "e") as any;
+      const rows = await em
+        .createQueryBuilder(testEntity.EntityClass, "e")
+        .addOrderBy(e.amount, "ASC")
+        .getRawMany<{ recordedAt: Date }>({
+          coerce: { recordedAt: "date" },
+        });
+
+      expect(rows).toHaveLength(3);
+      // Every coerced value is a Date regardless of whether the driver
+      // surfaced it as a Date or a string.
+      for (const row of rows) {
+        expect(row.recordedAt).toBeInstanceOf(Date);
+        expect(Number.isNaN(row.recordedAt.getTime())).toBe(false);
+      }
+      // Rows were inserted on consecutive days — coercion preserves order.
+      expect(rows[0].recordedAt.getTime()).toBeLessThan(
+        rows[1].recordedAt.getTime(),
+      );
+      expect(rows[1].recordedAt.getTime()).toBeLessThan(
+        rows[2].recordedAt.getTime(),
+      );
+    });
+  },
+);

--- a/__tests__/unit/raw-value-coercion.test.ts
+++ b/__tests__/unit/raw-value-coercion.test.ts
@@ -1,0 +1,195 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import "reflect-metadata";
+import {
+  coerceRow,
+  coerceRows,
+  type CoerceType,
+} from "../../src/core/RawValueCoercion";
+
+/** Coerce a single value through the public coerceRow API. */
+function coerce(value: unknown, type: CoerceType): unknown {
+  return (coerceRow({ v: value }, { v: type }) as { v: unknown }).v;
+}
+
+describe("RawValueCoercion", () => {
+  // ── number ────────────────────────────────────────────────────────────
+  describe('coerce "number"', () => {
+    it("converts a mysql2 BIGINT-as-string to a number", () => {
+      // mysql2 surfaces BIGINT columns as strings.
+      expect(coerce("9007199254740", "number")).toBe(9007199254740);
+    });
+
+    it("converts a pg DECIMAL/NUMERIC-as-string to a number", () => {
+      // both the pg and mysql2 drivers return DECIMAL/NUMERIC as strings.
+      expect(coerce("12.50", "number")).toBe(12.5);
+      expect(coerce("0.00", "number")).toBe(0);
+      expect(coerce("-3.75", "number")).toBe(-3.75);
+    });
+
+    it("passes an existing number through unchanged", () => {
+      expect(coerce(42, "number")).toBe(42);
+      expect(coerce(0, "number")).toBe(0);
+    });
+
+    it("coerces an integer string", () => {
+      expect(coerce("100", "number")).toBe(100);
+    });
+  });
+
+  // ── bigint ────────────────────────────────────────────────────────────
+  describe('coerce "bigint"', () => {
+    it("converts an integer string to a bigint", () => {
+      expect(coerce("9007199254740993", "bigint")).toBe(9007199254740993n);
+    });
+
+    it("converts a number to a bigint", () => {
+      expect(coerce(123, "bigint")).toBe(123n);
+    });
+
+    it("passes an existing bigint through unchanged", () => {
+      expect(coerce(10n, "bigint")).toBe(10n);
+    });
+
+    it("throws a column-named error on an invalid bigint value", () => {
+      expect(() => coerceRow({ id: "not-a-number" }, { id: "bigint" })).toThrow(
+        /column "id".*bigint/,
+      );
+    });
+  });
+
+  // ── string ────────────────────────────────────────────────────────────
+  describe('coerce "string"', () => {
+    it("converts a number to a string", () => {
+      expect(coerce(7, "string")).toBe("7");
+    });
+
+    it("passes an existing string through unchanged", () => {
+      expect(coerce("hello", "string")).toBe("hello");
+    });
+  });
+
+  // ── date ──────────────────────────────────────────────────────────────
+  describe('coerce "date"', () => {
+    it("wraps an ISO date string in a Date", () => {
+      const out = coerce("2026-05-21T00:00:00.000Z", "date");
+      expect(out).toBeInstanceOf(Date);
+      expect((out as Date).toISOString()).toBe("2026-05-21T00:00:00.000Z");
+    });
+
+    it("passes an existing Date through unchanged", () => {
+      const d = new Date("2026-01-01T00:00:00.000Z");
+      expect(coerce(d, "date")).toBe(d);
+    });
+
+    it("wraps a numeric epoch timestamp in a Date", () => {
+      const out = coerce(0, "date");
+      expect(out).toBeInstanceOf(Date);
+      expect((out as Date).getTime()).toBe(0);
+    });
+  });
+
+  // ── json ──────────────────────────────────────────────────────────────
+  describe('coerce "json"', () => {
+    it("parses a JSON string into an object", () => {
+      expect(coerce('{"a":1,"b":[2,3]}', "json")).toEqual({ a: 1, b: [2, 3] });
+    });
+
+    it("passes an already-parsed object through (pg jsonb path)", () => {
+      const obj = { a: 1 };
+      expect(coerce(obj, "json")).toBe(obj);
+    });
+
+    it("throws a column-named error on malformed JSON", () => {
+      expect(() => coerceRow({ payload: "{bad" }, { payload: "json" })).toThrow(
+        /column "payload".*json/,
+      );
+    });
+  });
+
+  // ── boolean ───────────────────────────────────────────────────────────
+  describe('coerce "boolean"', () => {
+    it("normalizes MySQL/SQLite TINYINT 0/1", () => {
+      expect(coerce(1, "boolean")).toBe(true);
+      expect(coerce(0, "boolean")).toBe(false);
+    });
+
+    it("normalizes string 0/1", () => {
+      expect(coerce("1", "boolean")).toBe(true);
+      expect(coerce("0", "boolean")).toBe(false);
+    });
+
+    it("normalizes string true/false (case-insensitive)", () => {
+      expect(coerce("true", "boolean")).toBe(true);
+      expect(coerce("TRUE", "boolean")).toBe(true);
+      expect(coerce("false", "boolean")).toBe(false);
+    });
+
+    it("passes a real boolean through unchanged", () => {
+      expect(coerce(true, "boolean")).toBe(true);
+      expect(coerce(false, "boolean")).toBe(false);
+    });
+  });
+
+  // ── null / undefined passthrough ──────────────────────────────────────
+  describe("null / undefined passthrough", () => {
+    const types: CoerceType[] = [
+      "number",
+      "bigint",
+      "string",
+      "date",
+      "json",
+      "boolean",
+    ];
+
+    it.each(types)("preserves null for type %s", (type) => {
+      expect(coerce(null, type)).toBeNull();
+    });
+
+    it.each(types)("preserves undefined for type %s", (type) => {
+      expect(coerce(undefined, type)).toBeUndefined();
+    });
+  });
+
+  // ── coerceRow semantics ───────────────────────────────────────────────
+  describe("coerceRow", () => {
+    it("leaves columns not present in the coerce map untouched", () => {
+      const out = coerceRow(
+        { id: "1", name: "Alice", raw: { keep: true } },
+        { id: "number" },
+      );
+      expect(out).toEqual({ id: 1, name: "Alice", raw: { keep: true } });
+    });
+
+    it("does not mutate the input row", () => {
+      const input = { id: "1" };
+      coerceRow(input, { id: "number" });
+      expect(input.id).toBe("1");
+    });
+
+    it("skips coerce keys absent from the row without error", () => {
+      const out = coerceRow({ id: "1" }, { id: "number", missing: "date" });
+      expect(out).toEqual({ id: 1 });
+    });
+  });
+
+  // ── coerceRows over a result set ──────────────────────────────────────
+  describe("coerceRows", () => {
+    it("applies the coerce map to every row", () => {
+      const rows = [
+        { day: "2026-05-01T00:00:00.000Z", completedCount: "3" },
+        { day: "2026-05-02T00:00:00.000Z", completedCount: "0" },
+      ];
+      const out = coerceRows<{ day: Date; completedCount: number }>(rows, {
+        day: "date",
+        completedCount: "number",
+      });
+      expect(out[0].day).toBeInstanceOf(Date);
+      expect(out[0].completedCount).toBe(3);
+      expect(out[1].completedCount).toBe(0);
+    });
+
+    it("returns an empty array for an empty result set", () => {
+      expect(coerceRows([], { id: "number" })).toEqual([]);
+    });
+  });
+});

--- a/docs/ko/query-builder-execution.md
+++ b/docs/ko/query-builder-execution.md
@@ -375,14 +375,29 @@ const users = await em
 
 역직렬화도, 필수 컬럼 검증도 하지 않습니다. `select(["id", "name"])`를 쓰면 반환 타입이 `Pick<T, "id" | "name">[]`로 좁혀져요 — 선택하지 않은 컬럼에 접근하면 컴파일 에러입니다. `em.save()`에는 넘기지 마세요.
 
-**Raw — 타입 없는 plain object:**
+**Raw — plain object + 선택적 값 변환:**
 
 | 메서드 | 반환 | 설명 |
 |--------|------|------|
-| `getRawMany()` | `Record<string, unknown>[]` | 타입 없는 plain object |
-| `getRawOne()` | `Record<string, unknown> \| null` | 단일 plain object 또는 null |
+| `getRawMany<T>(options?)` | `T[]` | plain object (타입 인자 없으면 `Record<string, unknown>`) |
+| `getRawOne<T>(options?)` | `T \| null` | 단일 plain object 또는 null |
 
-엔티티에 없는 계산 컬럼(예: `addSelect(sql`COUNT(*)`, "cnt")`)이 결과에 섞일 때 씁니다. 타입 정보도 역직렬화도 없습니다.
+엔티티에 없는 계산 컬럼(예: `addSelect(sql`COUNT(*)`, "cnt")`)이 결과에 섞일 때 씁니다. 역직렬화는 없습니다.
+
+#### 값 변환 — `coerce`
+
+드라이버는 raw 결과를 dialect별로 다른 형태로 내려줍니다. `mysql2` 는 `BIGINT` / `DECIMAL`(그리고 `SUM` / `AVG` 집계 결과)을 문자열로, `pg` 는 `NUMERIC` / `bigint` 를 문자열로, 날짜는 드라이버 옵션에 따라 `Date` 또는 문자열로 surface 합니다. `coerce` 옵션은 컬럼별로 원하는 primitive 를 선언해 ORM 이 값을 정규화하게 합니다 — 호출처에서 `Number(row.x)` 를 손으로 적을 필요가 없습니다.
+
+```typescript
+const rows = await qb
+  .select([day.as("day"), completed.as("completedCount"), est.as("estimate")])
+  .getRawMany<{ day: Date; completedCount: number; estimate: number }>({
+    coerce: { day: "date", completedCount: "number", estimate: "number" },
+  });
+// rows[0].completedCount 는 진짜 number, rows[0].day 는 진짜 Date
+```
+
+지원하는 타입 태그: `"number"`, `"bigint"`, `"string"`, `"date"`, `"json"`, `"boolean"`. `null` / `undefined` 는 그대로 통과하고, `coerce` 에 없는 컬럼은 드라이버 원본 값을 유지합니다. `getRawOne()` 도 같은 옵션을 받습니다.
 
 **유틸 (결과 모양 변경 없음):**
 

--- a/docs/query-builder-execution.md
+++ b/docs/query-builder-execution.md
@@ -354,14 +354,29 @@ These always deserialize rows into entity class instances. `instanceof` works, c
 
 No deserialization, no required-column validation. When `select(["id", "name"])` is used, the return type narrows to `Pick<T, "id" | "name">[]` — accessing unselected columns is a compile error. Do not pass results to `em.save()`.
 
-**Raw — untyped plain objects:**
+**Raw — plain objects with optional value coercion:**
 
 | Method | Returns | Description |
 |--------|---------|-------------|
-| `getRawMany()` | `Record<string, unknown>[]` | Untyped plain objects |
-| `getRawOne()` | `Record<string, unknown> \| null` | Single untyped object or null |
+| `getRawMany<T>(options?)` | `T[]` | Plain objects (`Record<string, unknown>` when no type parameter) |
+| `getRawOne<T>(options?)` | `T \| null` | Single plain object or null |
 
-Use when the result includes computed columns not in the entity (e.g. `addSelect(sql`COUNT(*)`, "cnt")`). No type information, no deserialization.
+Use when the result includes computed columns not in the entity (e.g. `addSelect(sql`COUNT(*)`, "cnt")`). No deserialization.
+
+#### Value coercion — `coerce`
+
+Drivers surface raw results in dialect-dependent shapes: `mysql2` returns `BIGINT` / `DECIMAL` (and `SUM` / `AVG` aggregates) as strings, `pg` returns `NUMERIC` / `bigint` as strings, and dates arrive as `Date` or string depending on driver options. The `coerce` option declares the intended primitive per column so the ORM normalizes the value — no hand-written `Number(row.x)` blocks at the call site.
+
+```typescript
+const rows = await qb
+  .select([day.as("day"), completed.as("completedCount"), est.as("estimate")])
+  .getRawMany<{ day: Date; completedCount: number; estimate: number }>({
+    coerce: { day: "date", completedCount: "number", estimate: "number" },
+  });
+// rows[0].completedCount is a real number, rows[0].day is a real Date
+```
+
+Supported type tags: `"number"`, `"bigint"`, `"string"`, `"date"`, `"json"`, `"boolean"`. `null` / `undefined` pass through untouched, and columns not listed in `coerce` keep the driver's native value. `getRawOne()` accepts the same option.
 
 **Utility (unchanged):**
 

--- a/examples/nestjs-linear-clone/src/modules/analytics/analytics.service.ts
+++ b/examples/nestjs-linear-clone/src/modules/analytics/analytics.service.ts
@@ -181,8 +181,10 @@ export class AnalyticsService {
       ])
       .where(i.sprintId.eq(sprintId))
       .andWhere(i.deletedAt.isNull())
-      .getRawOne();
-    const totalEstimate = Number(totalRow?.totalEstimate ?? 0);
+      .getRawOne<{ totalEstimate: number }>({
+        coerce: { totalEstimate: "number" },
+      });
+    const totalEstimate = totalRow?.totalEstimate ?? 0;
 
     // Step 2 — daily aggregates over completed issues, grouped + ordered
     // by `dateTrunc(completedAt, 'day')`. The dialect-aware day truncation
@@ -203,7 +205,17 @@ export class AnalyticsService {
       .andWhere(i.completedAt.isNotNull())
       .groupBy([day])
       .addOrderBy(day, "ASC")
-      .getRawMany();
+      .getRawMany<{
+        day: Date;
+        completedCount: number;
+        completedEstimate: number;
+      }>({
+        coerce: {
+          day: "date",
+          completedCount: "number",
+          completedEstimate: "number",
+        },
+      });
 
     // Step 3 — running totals + remaining estimate are derived in JS;
     // the row counts here are bounded by sprint length (~30 days) so
@@ -212,14 +224,11 @@ export class AnalyticsService {
     let cumulativeCompleted = 0;
     let cumulativeEstimate = 0;
     return dailyRows.map((row) => {
-      cumulativeCompleted += Number(row.completedCount);
-      cumulativeEstimate += Number(row.completedEstimate);
+      cumulativeCompleted += row.completedCount;
+      cumulativeEstimate += row.completedEstimate;
       return {
-        day:
-          row.day instanceof Date
-            ? row.day.toISOString().slice(0, 10)
-            : String(row.day),
-        completedThatDay: Number(row.completedCount),
+        day: row.day.toISOString().slice(0, 10),
+        completedThatDay: row.completedCount,
         cumulativeCompleted,
         remainingEstimate: totalEstimate - cumulativeEstimate,
       };
@@ -281,17 +290,31 @@ export class AnalyticsService {
       // strict GROUP BY happy when the column is projected.
       .groupBy([i.assigneeId, u.id, u.name])
       .addOrderBy(rankInProject.toScalar(), "ASC")
-      .getRawMany();
+      .getRawMany<{
+        assigneeId: number | null;
+        assigneeName: string | null;
+        completedCount: number;
+        averageCycleHours: number | null;
+        rankInProject: number;
+      }>({
+        coerce: {
+          assigneeId: "number",
+          assigneeName: "string",
+          completedCount: "number",
+          averageCycleHours: "number",
+          rankInProject: "number",
+        },
+      });
 
     return rows.map((row) => ({
-      assigneeId: row.assigneeId === null ? null : Number(row.assigneeId),
-      assigneeName: row.assigneeName ? String(row.assigneeName) : null,
-      completedCount: Number(row.completedCount),
+      assigneeId: row.assigneeId,
+      assigneeName: row.assigneeName,
+      completedCount: row.completedCount,
       averageCycleHours:
         row.averageCycleHours === null
           ? 0
-          : Number(Number(row.averageCycleHours).toFixed(2)),
-      rankInProject: Number(row.rankInProject),
+          : Number(row.averageCycleHours.toFixed(2)),
+      rankInProject: row.rankInProject,
     }));
   }
 
@@ -332,28 +355,31 @@ export class AnalyticsService {
       .where(a.issueId.eq(issueId))
       .andWhere(a.statusTo.isNotNull())
       .addOrderBy(a.createdAt, "ASC")
-      .getRawMany();
+      .getRawMany<{
+        issueId: number;
+        status: string | null;
+        enteredAt: Date;
+        leftAt: Date | null;
+        hoursInStatus: number | null;
+      }>({
+        coerce: {
+          issueId: "number",
+          status: "string",
+          enteredAt: "date",
+          leftAt: "date",
+          hoursInStatus: "number",
+        },
+      });
 
     return rows.map((row) => ({
-      issueId: Number(row.issueId),
-      status:
-        row.status === null || row.status === undefined
-          ? ""
-          : String(row.status),
-      enteredAt:
-        row.enteredAt instanceof Date
-          ? row.enteredAt.toISOString()
-          : String(row.enteredAt),
-      leftAt:
-        row.leftAt === null
-          ? null
-          : row.leftAt instanceof Date
-            ? row.leftAt.toISOString()
-            : String(row.leftAt),
+      issueId: row.issueId,
+      status: row.status ?? "",
+      enteredAt: row.enteredAt.toISOString(),
+      leftAt: row.leftAt === null ? null : row.leftAt.toISOString(),
       hoursInStatus:
         row.hoursInStatus === null
           ? null
-          : Number(Number(row.hoursInStatus).toFixed(2)),
+          : Number(row.hoursInStatus.toFixed(2)),
     }));
   }
 
@@ -396,15 +422,22 @@ export class AnalyticsService {
       .andWhere(i.deletedAt.isNull())
       .groupBy([week])
       .addOrderBy(week, "ASC")
-      .getRawMany();
+      .getRawMany<{
+        weekStart: Date;
+        leadTimeHours: number | null;
+        closedCount: number;
+      }>({
+        coerce: {
+          weekStart: "date",
+          leadTimeHours: "number",
+          closedCount: "number",
+        },
+      });
 
     return rows.map((row) => ({
-      weekStart:
-        row.weekStart instanceof Date
-          ? row.weekStart.toISOString().slice(0, 10)
-          : String(row.weekStart),
-      leadTimeHours: Number(Number(row.leadTimeHours ?? 0).toFixed(2)),
-      closedCount: Number(row.closedCount),
+      weekStart: row.weekStart.toISOString().slice(0, 10),
+      leadTimeHours: Number((row.leadTimeHours ?? 0).toFixed(2)),
+      closedCount: row.closedCount,
     }));
   }
 
@@ -481,7 +514,16 @@ export class AnalyticsService {
       .andWhere(i.completedAt.isNotNull())
       .andWhere(i.completedAt.gte(cutoff))
       .andWhere(i.deletedAt.isNull())
-      .getRawOne();
+      .getRawOne<{ p50: number; p75: number; p95: number; sampleSize: number }>(
+        {
+          coerce: {
+            p50: "number",
+            p75: "number",
+            p95: "number",
+            sampleSize: "number",
+          },
+        },
+      );
 
     return this.toPercentileRow(row ?? undefined);
   }

--- a/src/core/RawValueCoercion.ts
+++ b/src/core/RawValueCoercion.ts
@@ -1,0 +1,125 @@
+/**
+ * Per-column value coercion for `getRawMany()` / `getRawOne()`.
+ *
+ * Drivers surface raw query results in dialect- and option-dependent
+ * shapes: `mysql2` returns `BIGINT` / `DECIMAL` columns as strings, the
+ * `pg` driver returns `DECIMAL` / `NUMERIC` as strings, dates arrive as
+ * `Date` or string depending on driver options, and JSON columns may or
+ * may not be parsed. Aggregate / analytics queries hit all of these.
+ *
+ * The coerce layer lets a caller declare the intended primitive per
+ * column once, so application code stops hand-writing
+ * `Number(row.x)` / `row.d instanceof Date ? … : …` blocks.
+ */
+
+/** Primitive type tag for a single coerced column. */
+export type CoerceType =
+  | "number"
+  | "bigint"
+  | "string"
+  | "date"
+  | "json"
+  | "boolean";
+
+/**
+ * Column-name → {@link CoerceType} map. Every key is optional; columns
+ * not listed are returned with the driver's native value untouched.
+ */
+export type CoerceMap<T> = {
+  [K in keyof T]?: CoerceType;
+};
+
+/** Options accepted by `getRawMany()` / `getRawOne()`. */
+export interface RawResultOptions<T> {
+  /**
+   * Per-column coercion map. Each listed column's driver-native value is
+   * normalized to the tagged primitive. `null` / `undefined` pass through
+   * untouched; unlisted columns are returned verbatim.
+   *
+   * @example
+   * ```ts
+   * .getRawMany<{ day: Date; completedCount: number }>({
+   *   coerce: { day: "date", completedCount: "number" },
+   * });
+   * ```
+   */
+  coerce?: CoerceMap<T>;
+}
+
+/**
+ * Coerce a single driver-native value to the requested primitive.
+ *
+ * `null` / `undefined` always pass through so SQL NULL semantics are
+ * preserved (a nullable aggregate stays nullable).
+ *
+ * - `number`  — `Number(v)`; handles `mysql2` BIGINT-as-string and
+ *   `pg` DECIMAL/NUMERIC-as-string. Use `bigint` instead when the value
+ *   can exceed `Number.MAX_SAFE_INTEGER`.
+ * - `bigint`  — `BigInt(v)`; for integer columns wider than 53 bits.
+ * - `string`  — `String(v)`.
+ * - `date`    — wraps non-`Date` values in `new Date(v)`.
+ * - `json`    — `JSON.parse` when the value is a string, otherwise
+ *   passes through (the `pg` driver already parses `json`/`jsonb`).
+ * - `boolean` — normalizes `0/1`, `"0"/"1"`, `"true"/"false"` and real
+ *   booleans (MySQL/SQLite store booleans as `TINYINT` 0/1).
+ */
+function coerceValue(value: unknown, type: CoerceType): unknown {
+  if (value === null || value === undefined) return value;
+
+  switch (type) {
+    case "number":
+      return typeof value === "number" ? value : Number(value);
+    case "bigint":
+      return typeof value === "bigint" ? value : BigInt(value as never);
+    case "string":
+      return typeof value === "string" ? value : String(value);
+    case "date":
+      return value instanceof Date ? value : new Date(value as never);
+    case "json":
+      return typeof value === "string" ? JSON.parse(value) : value;
+    case "boolean":
+      if (typeof value === "boolean") return value;
+      if (typeof value === "number") return value !== 0;
+      if (typeof value === "string")
+        return value === "1" || value.toLowerCase() === "true";
+      return Boolean(value);
+    default:
+      return value;
+  }
+}
+
+/**
+ * Apply a {@link CoerceMap} to a single raw row, returning a shallow copy
+ * with the listed columns coerced. The input row is not mutated.
+ *
+ * @throws when a converter fails (e.g. `BigInt("abc")`), with a message
+ *   naming the offending column, type tag, and value.
+ */
+export function coerceRow<T>(
+  row: Record<string, unknown>,
+  coerce: CoerceMap<T>,
+): T {
+  const out: Record<string, unknown> = { ...row };
+  for (const key in coerce) {
+    const type = coerce[key as keyof T];
+    if (!type || !(key in out)) continue;
+    try {
+      out[key] = coerceValue(out[key], type);
+    } catch (err) {
+      throw new Error(
+        `getRawMany: failed to coerce column "${key}" to "${type}" ` +
+          `(value: ${String(out[key])}): ` +
+          (err instanceof Error ? err.message : String(err)),
+      );
+    }
+  }
+  return out as T;
+}
+
+/** Apply a {@link CoerceMap} to every row in a raw result set. */
+export function coerceRows<T>(
+  rows: Record<string, unknown>[],
+  coerce: CoerceMap<T>,
+): T[] {
+  return rows.map((row) => coerceRow<T>(row, coerce));
+}

--- a/src/core/SelectQueryBuilder.ts
+++ b/src/core/SelectQueryBuilder.ts
@@ -11,6 +11,7 @@ import { EntityNotFoundError } from "../errors/EntityNotFoundError";
 import { DeserializerRegistry } from "./deserializer/DeserializerRegistry";
 import { ResultTransformerFactory } from "./ResultTransformerFactory";
 import { CompiledQuery } from "./CompiledQuery";
+import { coerceRows, type RawResultOptions } from "./RawValueCoercion";
 import { COLUMN_TOKEN } from "../decorators/Column";
 import { InheritanceResolver } from "./InheritanceResolver";
 import {
@@ -3871,26 +3872,53 @@ export class SelectQueryBuilder<T, TResult = T> {
   // ── EXECUTION: Raw (untyped plain objects) ─────────────
 
   /**
-   * Execute the query and return untyped plain objects.
+   * Execute the query and return plain objects.
    *
    * Use when the result includes columns not in the entity definition
    * (e.g. `addSelect(sql\`COUNT(*)\`, "cnt")`). No deserialization,
-   * no validation, no type narrowing.
+   * no validation.
+   *
+   * Pass a type parameter to declare the row shape, and an optional
+   * `coerce` map to normalize driver-native values — `mysql2` returns
+   * `BIGINT` / `DECIMAL` as strings, `pg` returns `NUMERIC` as strings,
+   * dates arrive as `Date` or string depending on driver options. The
+   * coerce step removes the hand-written `Number(row.x)` boilerplate
+   * that aggregate / analytics call sites otherwise accumulate.
+   *
+   * @example
+   * ```ts
+   * const rows = await qb
+   *   .select([day.as("day"), count.as("completedCount")])
+   *   .getRawMany<{ day: Date; completedCount: number }>({
+   *     coerce: { day: "date", completedCount: "number" },
+   *   });
+   * ```
    */
-  async getRawMany(): Promise<Record<string, unknown>[]> {
+  async getRawMany<T = Record<string, unknown>>(
+    options?: RawResultOptions<T>,
+  ): Promise<T[]> {
     const built = this.toSql();
-    return this.em.query<Record<string, unknown>>(built);
+    const rows = await this.em.query<Record<string, unknown>>(built);
+    if (options?.coerce) {
+      return coerceRows<T>(rows, options.coerce);
+    }
+    return rows as unknown as T[];
   }
 
   /**
-   * Execute the query and return a single untyped plain object or null.
+   * Execute the query and return a single plain object or null.
    * Automatically adds LIMIT 1 if not already set.
+   *
+   * Accepts the same type parameter and `coerce` option as
+   * {@link getRawMany}.
    */
-  async getRawOne(): Promise<Record<string, unknown> | null> {
+  async getRawOne<T = Record<string, unknown>>(
+    options?: RawResultOptions<T>,
+  ): Promise<T | null> {
     if (this.limitValue === undefined) {
       this.limitValue = 1;
     }
-    const results = await this.getRawMany();
+    const results = await this.getRawMany<T>(options);
     return results.length > 0 ? results[0] : null;
   }
 

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -8,6 +8,7 @@ export * from "./ResultTransformerFactory";
 export * from "./RawQueryBuilderFactory";
 export * from "./BaseRawQueryBuilder";
 export * from "./SelectQueryBuilder";
+export * from "./RawValueCoercion";
 export * from "./UpdateQueryBuilder";
 export * from "./BaseInsertQueryBuilder";
 export * from "./deserializer";


### PR DESCRIPTION
## Summary

Closes #337.

`getRawMany()` / `getRawOne()` now take an optional type parameter and a `coerce` map, so a caller declares the row shape once and the ORM normalizes driver-native values. `mysql2` returns `BIGINT` / `DECIMAL` (and `SUM` / `AVG` aggregates) as strings, `pg` returns `NUMERIC` / `bigint` as strings, and dates arrive as `Date` or string depending on driver options — the coerce step removes the hand-written `Number(row.x)` boilerplate that aggregate / analytics call sites accumulate.

## API

```ts
const rows = await this.em
  .createQueryBuilder(Issue, "i")
  .select([day.as("day"), completed.as("completedCount")])
  .getRawMany<{ day: Date; completedCount: number }>({
    coerce: { day: "date", completedCount: "number" },
  });
```

- New `src/core/RawValueCoercion.ts` — `CoerceType` / `RawResultOptions` / `coerceRows`.
- Type tags: `number`, `bigint`, `string`, `date`, `json`, `boolean`.
- `null` / `undefined` pass through untouched; columns not listed in `coerce` keep the driver's native value.
- **Backward compatible** — the no-arg `getRawMany()` / `getRawOne()` still return `Record<string, unknown>`.
- Option (a) from the issue: a `coerce` map keyed by column name. No new runtime deps.

## Example sweep

`examples/nestjs-linear-clone/src/modules/analytics/analytics.service.ts` — 6 call sites drop their manual coercion blocks:

- `sprintBurndown` — step-1 `getRawOne` and step-2 `getRawMany`
- `assigneeThroughput` — `Number()` x4 + `String()` + null ternaries
- `timeInStatus` — `Number()` / `String()` / `instanceof Date` x2
- `leadTimeByWeek` — `Number()` x2 + `instanceof Date`
- `cycleTimePercentilesPg` — typed `getRawOne`

(`issueTree` and `cycleTimePercentilesMySqlEmulation` use `RawQueryBuilder` + `em.query` and are out of scope for the `getRawMany` API.)

## Checklist mapping (#337)

- [x] Design — chose option (a): `coerce` map keyed by column name → type tag (dependency-light)
- [x] Coerce step inside `getRawMany`; null/undefined pass through
- [x] `getRawOne<T>({ coerce })` parallel
- [x] Unit test matrix — BIGINT/DECIMAL-as-string → number, DATETIME → Date, JSON text → object, boolean, bigint
- [x] Sweep `analytics.service.ts` — 6 coercion blocks removed
- [x] No new runtime deps

## Test plan

- `npx jest raw-value-coercion` — 37 unit tests pass
- `INTEGRATION_TEST=true INTEGRATION_TEST_POSTGRES=false npx jest raw-value-coercion` — 5/5 MySQL integration pass (PG runs in CI)
- `npx jest` — full unit suite green (239 suites, 4815 tests), no regressions
- `tsc --noEmit` on core + `examples/nestjs-linear-clone` — clean
