### PR TITLE
refactor(examples/linear-clone): extract ProjectNumberingService to remove module cycles

### DIFF
--- a/examples/nestjs-linear-clone/src/modules/bulk-operations/bulk-operations.module.ts
+++ b/examples/nestjs-linear-clone/src/modules/bulk-operations/bulk-operations.module.ts
@@ -1,4 +1,4 @@
-import { Module, forwardRef } from "@nestjs/common";
+import { Module } from "@nestjs/common";
 import { StingerloomOrmModule } from "@stingerloom/orm/nestjs";
 import { BulkOperation } from "./bulk-operation.entity";
 import { BulkOperationsService } from "./bulk-operations.service";
@@ -8,7 +8,9 @@ import { IssuesModule } from "../issues/issues.module";
 @Module({
   imports: [
     StingerloomOrmModule.forFeature([BulkOperation]),
-    forwardRef(() => IssuesModule),
+    // One-way edge: BulkOperationsService calls IssuesService.update, and
+    // nothing in the Issues subtree imports BulkOperationsModule back.
+    IssuesModule,
   ],
   controllers: [BulkOperationsController],
   providers: [BulkOperationsService],

--- a/examples/nestjs-linear-clone/src/modules/bulk-operations/bulk-operations.service.ts
+++ b/examples/nestjs-linear-clone/src/modules/bulk-operations/bulk-operations.service.ts
@@ -1,7 +1,6 @@
 import {
   Injectable,
   Inject,
-  forwardRef,
   ConflictException,
   NotFoundException,
 } from "@nestjs/common";
@@ -24,7 +23,6 @@ export class BulkOperationsService {
     private readonly repo: BaseRepository<BulkOperation>,
     @Inject(EntityManager)
     private readonly em: EntityManager,
-    @Inject(forwardRef(() => IssuesService))
     private readonly issues: IssuesService,
   ) {}
 

--- a/examples/nestjs-linear-clone/src/modules/import-export/import-export.module.ts
+++ b/examples/nestjs-linear-clone/src/modules/import-export/import-export.module.ts
@@ -6,14 +6,14 @@ import { Issue } from "../issues/issue.entity";
 import { Comment } from "../comments/comment.entity";
 import { Sprint } from "../sprints/sprint.entity";
 import { Label } from "../labels/label.entity";
-import { ProjectsModule } from "../projects/projects.module";
+import { ProjectNumberingModule } from "../projects/project-numbering.module";
 import { ImportExportService } from "./import-export.service";
 import { ImportExportController } from "./import-export.controller";
 
 @Module({
   imports: [
     StingerloomOrmModule.forFeature([Workspace, Project, Issue, Comment, Sprint, Label]),
-    ProjectsModule,
+    ProjectNumberingModule,
   ],
   controllers: [ImportExportController],
   providers: [ImportExportService],

--- a/examples/nestjs-linear-clone/src/modules/import-export/import-export.service.ts
+++ b/examples/nestjs-linear-clone/src/modules/import-export/import-export.service.ts
@@ -12,7 +12,7 @@ import { Issue } from "../issues/issue.entity";
 import { Comment } from "../comments/comment.entity";
 import { Sprint } from "../sprints/sprint.entity";
 import { Label } from "../labels/label.entity";
-import { ProjectsService } from "../projects/projects.service";
+import { ProjectNumberingService } from "../projects/project-numbering.service";
 import { parseIssueCsv } from "./csv";
 import { ISSUE_STATUS, IssueStatus, IssuePriority } from "../../common/enums";
 
@@ -58,7 +58,7 @@ export class ImportExportService {
     private readonly issueRepo: BaseRepository<Issue>,
     @Inject(EntityManager)
     private readonly em: EntityManager,
-    private readonly projects: ProjectsService,
+    private readonly projectNumbering: ProjectNumberingService,
   ) {}
 
   /**
@@ -121,7 +121,7 @@ export class ImportExportService {
       // Sequential per-project number assignment via the row-locked counter.
       // Inside the same @Transactional frame the counter increments survive
       // commit-or-rollback together with the inserted issue rows.
-      const number = await this.projects.nextIssueNumber(projectId);
+      const number = await this.projectNumbering.nextIssueNumber(projectId);
       rows.push({
         projectId,
         number,

--- a/examples/nestjs-linear-clone/src/modules/issues/issues.module.ts
+++ b/examples/nestjs-linear-clone/src/modules/issues/issues.module.ts
@@ -1,11 +1,11 @@
-import { Module, forwardRef } from "@nestjs/common";
+import { Module } from "@nestjs/common";
 import { StingerloomOrmModule } from "@stingerloom/orm/nestjs";
 import { Issue } from "./issue.entity";
 import { IssuesService } from "./issues.service";
 import { IssuesController } from "./issues.controller";
 import { IssueAuditSubscriber } from "./issue-audit.subscriber";
 import { ActivityModule } from "../activity/activity.module";
-import { ProjectsModule } from "../projects/projects.module";
+import { ProjectNumberingModule } from "../projects/project-numbering.module";
 import { WorkflowsModule } from "../workflows/workflows.module";
 import { WebhooksModule } from "../webhooks/webhooks.module";
 
@@ -13,9 +13,13 @@ import { WebhooksModule } from "../webhooks/webhooks.module";
   imports: [
     StingerloomOrmModule.forFeature([Issue]),
     ActivityModule,
-    forwardRef(() => ProjectsModule),
-    forwardRef(() => WorkflowsModule),
-    forwardRef(() => WebhooksModule),
+    // All plain imports — IssuesService depends only on the narrow surface
+    // of each (ProjectNumberingService, WorkflowsService, WebhooksService),
+    // and none of those modules import IssuesModule back, so there is no
+    // cycle left to break with forwardRef.
+    ProjectNumberingModule,
+    WorkflowsModule,
+    WebhooksModule,
   ],
   controllers: [IssuesController],
   providers: [IssuesService, IssueAuditSubscriber],

--- a/examples/nestjs-linear-clone/src/modules/issues/issues.service.ts
+++ b/examples/nestjs-linear-clone/src/modules/issues/issues.service.ts
@@ -3,7 +3,6 @@ import {
   NotFoundException,
   ConflictException,
   Inject,
-  forwardRef,
 } from "@nestjs/common";
 import {
   BaseRepository,
@@ -22,7 +21,8 @@ import {
   AssignLabelDto,
   AssignAssigneeDto,
 } from "./dto/issue.dto";
-import { ProjectsService } from "../projects/projects.service";
+import { Project } from "../projects/project.entity";
+import { ProjectNumberingService } from "../projects/project-numbering.service";
 import { ActivityService } from "../activity/activity.service";
 import { WorkflowsService } from "../workflows/workflows.service";
 import { WebhooksService } from "../webhooks/webhooks.service";
@@ -54,17 +54,15 @@ export class IssuesService {
     private readonly repo: BaseRepository<Issue>,
     @Inject(EntityManager)
     private readonly em: EntityManager,
-    private readonly projects: ProjectsService,
+    private readonly projectNumbering: ProjectNumberingService,
     private readonly activity: ActivityService,
-    @Inject(forwardRef(() => WorkflowsService))
     private readonly workflows: WorkflowsService,
-    @Inject(forwardRef(() => WebhooksService))
     private readonly webhooks: WebhooksService,
   ) {}
 
   @Transactional()
   async create(dto: CreateIssueDto, actorUserId: number): Promise<Issue> {
-    const number = await this.projects.nextIssueNumber(dto.projectId);
+    const number = await this.projectNumbering.nextIssueNumber(dto.projectId);
 
     const issue = new Issue();
     issue.projectId = dto.projectId;
@@ -245,8 +243,10 @@ export class IssuesService {
     projectId: number,
     actorUserId: number,
   ): Promise<MembershipRole | null> {
-    const project = await this.projects.findOne(projectId);
-    if (project.workspaceId == null) return null;
+    const project = await this.em.findOne(Project, {
+      where: { id: projectId },
+    });
+    if (project?.workspaceId == null) return null;
     const m = qAlias(Membership, "m");
     const row = await this.em
       .createQueryBuilder(m)
@@ -476,7 +476,9 @@ export class IssuesService {
   }
 
   private async workspaceIdForProject(projectId: number): Promise<number | null> {
-    const project = await this.projects.findOne(projectId);
-    return project.workspaceId ?? null;
+    const project = await this.em.findOne(Project, {
+      where: { id: projectId },
+    });
+    return project?.workspaceId ?? null;
   }
 }

--- a/examples/nestjs-linear-clone/src/modules/projects/project-numbering.module.ts
+++ b/examples/nestjs-linear-clone/src/modules/projects/project-numbering.module.ts
@@ -1,0 +1,18 @@
+import { Module } from "@nestjs/common";
+import { StingerloomOrmModule } from "@stingerloom/orm/nestjs";
+import { Project } from "./project.entity";
+import { ProjectNumberingService } from "./project-numbering.service";
+
+/**
+ * Standalone home for the issue-number counter. Depends only on the
+ * `Project` repository, so importing it never drags in `ProjectsModule`
+ * (and the controller's back-edge to `IssuesModule`). That is what lets
+ * `IssuesModule` and `ImportExportModule` import the counter without a
+ * `forwardRef`.
+ */
+@Module({
+  imports: [StingerloomOrmModule.forFeature([Project])],
+  providers: [ProjectNumberingService],
+  exports: [ProjectNumberingService],
+})
+export class ProjectNumberingModule {}

--- a/examples/nestjs-linear-clone/src/modules/projects/project-numbering.service.ts
+++ b/examples/nestjs-linear-clone/src/modules/projects/project-numbering.service.ts
@@ -1,0 +1,41 @@
+import { Injectable } from "@nestjs/common";
+import { BaseRepository, qAlias } from "@stingerloom/orm";
+import { InjectRepository } from "@stingerloom/orm/nestjs";
+import { Project } from "./project.entity";
+
+/**
+ * Owns the atomic per-project issue-number counter.
+ *
+ * Carved out of `ProjectsService` so `IssuesModule` and `ImportExportModule`
+ * can depend on just the counter — they need a fresh issue number, not the
+ * full project CRUD surface. Because this service depends only on the
+ * `Project` repository (never on `IssuesService`), the Issues ↔ Projects
+ * module cycle disappears and neither side needs `forwardRef`.
+ */
+@Injectable()
+export class ProjectNumberingService {
+  constructor(
+    @InjectRepository(Project)
+    private readonly repo: BaseRepository<Project>,
+  ) {}
+
+  /**
+   * Atomic per-project counter increment used to assign issue numbers.
+   * `forUpdate()` locks the row, then `save()` writes the bumped counter —
+   * concurrent `nextIssueNumber()` calls serialize on the row lock, so
+   * each one sees a fresh value. Callers wrap this in `@Transactional`,
+   * which is required for the lock to span the read/write pair.
+   */
+  async nextIssueNumber(projectId: number): Promise<number> {
+    const p = qAlias(Project, "p");
+    const project = await this.repo
+      .createQueryBuilder(p)
+      .where(p.id.eq(projectId))
+      .forUpdate()
+      .getOneOrFail();
+
+    project.issueCounter = (project.issueCounter ?? 0) + 1;
+    await this.repo.save(project);
+    return project.issueCounter;
+  }
+}

--- a/examples/nestjs-linear-clone/src/modules/projects/projects.controller.ts
+++ b/examples/nestjs-linear-clone/src/modules/projects/projects.controller.ts
@@ -9,8 +9,6 @@ import {
   ParseIntPipe,
   Query,
   HttpCode,
-  Inject,
-  forwardRef,
 } from "@nestjs/common";
 import { ApiBearerAuth, ApiTags, ApiOperation } from "@nestjs/swagger";
 import { ProjectsService } from "./projects.service";
@@ -25,7 +23,6 @@ import { IssuesService } from "../issues/issues.service";
 export class ProjectsController {
   constructor(
     private readonly service: ProjectsService,
-    @Inject(forwardRef(() => IssuesService))
     private readonly issues: IssuesService,
   ) {}
 

--- a/examples/nestjs-linear-clone/src/modules/projects/projects.module.ts
+++ b/examples/nestjs-linear-clone/src/modules/projects/projects.module.ts
@@ -1,4 +1,4 @@
-import { Module, forwardRef } from "@nestjs/common";
+import { Module } from "@nestjs/common";
 import { StingerloomOrmModule } from "@stingerloom/orm/nestjs";
 import { Project } from "./project.entity";
 import { ProjectsService } from "./projects.service";
@@ -9,9 +9,10 @@ import { IssuesModule } from "../issues/issues.module";
   imports: [
     StingerloomOrmModule.forFeature([Project]),
     // Lets ProjectsController expose `/projects/:id/trash` (which delegates
-    // to IssuesService.findTrash). IssuesModule already imports
-    // ProjectsModule (for ProjectsService), so the back-edge needs forwardRef.
-    forwardRef(() => IssuesModule),
+    // to IssuesService.findTrash). IssuesModule depends on the issue-number
+    // counter via ProjectNumberingModule, not ProjectsModule, so this edge
+    // is one-way — a plain import, no forwardRef.
+    IssuesModule,
   ],
   controllers: [ProjectsController],
   providers: [ProjectsService],

--- a/examples/nestjs-linear-clone/src/modules/projects/projects.service.ts
+++ b/examples/nestjs-linear-clone/src/modules/projects/projects.service.ts
@@ -93,24 +93,4 @@ export class ProjectsService {
     await this.findOne(id);
     await this.repo.delete({ id });
   }
-
-  /**
-   * Atomic per-project counter increment used to assign issue numbers.
-   * `forUpdate()` locks the row, then `save()` writes the bumped counter —
-   * concurrent `nextIssueNumber()` calls serialize on the row lock, so
-   * each one sees a fresh value. Callers wrap this in `@Transactional`,
-   * which is required for the lock to span the read/write pair.
-   */
-  async nextIssueNumber(projectId: number): Promise<number> {
-    const p = qAlias(Project, "p");
-    const project = await this.repo
-      .createQueryBuilder(p)
-      .where(p.id.eq(projectId))
-      .forUpdate()
-      .getOneOrFail();
-
-    project.issueCounter = (project.issueCounter ?? 0) + 1;
-    await this.repo.save(project);
-    return project.issueCounter;
-  }
 }

--- a/examples/nestjs-linear-clone/src/modules/workflows/workflows.module.ts
+++ b/examples/nestjs-linear-clone/src/modules/workflows/workflows.module.ts
@@ -1,15 +1,13 @@
-import { Module, forwardRef } from "@nestjs/common";
+import { Module } from "@nestjs/common";
 import { StingerloomOrmModule } from "@stingerloom/orm/nestjs";
 import { WorkflowDefinition } from "./workflow-definition.entity";
 import { WorkflowTransition } from "./workflow-transition.entity";
 import { WorkflowsService } from "./workflows.service";
 import { WorkflowsController } from "./workflows.controller";
-import { ProjectsModule } from "../projects/projects.module";
 
 @Module({
   imports: [
     StingerloomOrmModule.forFeature([WorkflowDefinition, WorkflowTransition]),
-    forwardRef(() => ProjectsModule),
   ],
   controllers: [WorkflowsController],
   providers: [WorkflowsService],

--- a/examples/nestjs-linear-clone/src/modules/workflows/workflows.service.ts
+++ b/examples/nestjs-linear-clone/src/modules/workflows/workflows.service.ts
@@ -15,7 +15,7 @@ import { InjectRepository } from "@stingerloom/orm/nestjs";
 import { WorkflowDefinition } from "./workflow-definition.entity";
 import { WorkflowTransition } from "./workflow-transition.entity";
 import { CreateTransitionDto } from "./dto/workflow.dto";
-import { ProjectsService } from "../projects/projects.service";
+import { Project } from "../projects/project.entity";
 import {
   ISSUE_STATUS,
   IssueStatus,
@@ -107,7 +107,6 @@ export class WorkflowsService {
     private readonly transitions: BaseRepository<WorkflowTransition>,
     @Inject(EntityManager)
     private readonly em: EntityManager,
-    private readonly projects: ProjectsService,
   ) {}
 
   // Get or atomically seed the default chain. Concurrent first-time readers race on the unique(project_id) index; loser re-reads.
@@ -116,7 +115,15 @@ export class WorkflowsService {
     definition: WorkflowDefinition;
     transitions: WorkflowTransition[];
   }> {
-    await this.projects.findOne(projectId);
+    // Confirm the project exists (404 otherwise) without depending on
+    // ProjectsService — a direct EntityManager read keeps WorkflowsModule
+    // off the Issues ↔ Projects cycle, so it needs no forwardRef.
+    const project = await this.em.findOne(Project, {
+      where: { id: projectId },
+    });
+    if (!project) {
+      throw new NotFoundException(`Project ${projectId} not found`);
+    }
     let def = await this.defs.findOne({ where: { projectId } });
     if (!def) {
       try {


### PR DESCRIPTION
## Summary

Resolves #340. Extracts the per-project issue-number counter into a standalone `ProjectNumberingService` so the Issues ↔ Projects module cycle disappears and **every `forwardRef` in `examples/nestjs-linear-clone` is removed (7 → 0)**.

## Cycles found & cut

- **Issues ↔ Projects** — `IssuesService` needed `ProjectsService` (`nextIssueNumber` + `findOne`); `ProjectsController` needed `IssuesService` (`findTrash`).
- **Issues → Workflows → Projects → Issues** — `WorkflowsService.getOrSeed` validated project existence via `ProjectsService.findOne`.
- **Webhooks / BulkOperations** `forwardRef`s were spurious — no real back-edge.

## Changes

- New `ProjectNumberingService` + `ProjectNumberingModule`, depending only on `forFeature([Project])`.
- `IssuesService` injects `ProjectNumberingService`; workspace lookups read the `Project` entity directly via `EntityManager` (the pattern already used for `Membership`).
- `WorkflowsService` validates project existence via `EntityManager`, dropping its `ProjectsService` dependency.
- `ImportExportService` switches to `ProjectNumberingService`; `nextIssueNumber` is removed from `ProjectsService` (single home).
- All `forwardRef` module imports and `@Inject(forwardRef(...))` become plain imports.

The module graph is now a DAG.

## Verification

- `pnpm typecheck` + `pnpm build` — green
- `grep -r forwardRef src/` — 0 occurrences in code
- `INTEGRATION_TEST=true pnpm test:e2e` — 200 passed. The 3 remaining failures (`tenancy GET /projects/cursor`, `search projectId filter`, `webhooks worker tick`) reproduce identically on `main` with this branch stashed — pre-existing and unrelated. Every spec touching the refactored modules (`issues`, `issues-relations`, `workflows`, `bulk-operations`, `import-export`) passes.
