### PR TITLE
fix(core): aggregate/criteria column resolution — soft-delete, NamingStrategy, FK shadow props

### DIFF
--- a/__tests__/integration/snake-naming-strategy.test.ts
+++ b/__tests__/integration/snake-naming-strategy.test.ts
@@ -307,6 +307,58 @@ describeIf("[Integration] SnakeNamingStrategy", () => {
     expect(remaining).toHaveLength(0);
   });
 
+  // ── Aggregate / explain WHERE under NamingStrategy (#352) ──
+
+  it("should count() with camelCase property in where clause", async () => {
+    const em = conn.em as any;
+
+    await em.save(AuthorEntity, { firstName: "Cnt", lastName: "Same", postCount: 1 });
+    await em.save(AuthorEntity, { firstName: "Cnt", lastName: "Same", postCount: 2 });
+    await em.save(AuthorEntity, { firstName: "Other", lastName: "Same", postCount: 3 });
+
+    // Before the fix this threw "unknown column firstName" because the
+    // aggregate WHERE bypassed the property→column map.
+    const n = await em.count(AuthorEntity, { firstName: "Cnt" });
+    expect(n).toBe(2);
+  });
+
+  it("should sum()/avg() a camelCase numeric field with camelCase where", async () => {
+    const em = conn.em as any;
+
+    await em.save(AuthorEntity, { firstName: "Agg", lastName: "Z", postCount: 10 });
+    await em.save(AuthorEntity, { firstName: "Agg", lastName: "Z", postCount: 30 });
+
+    // Both the aggregate field (postCount) and the where key must resolve
+    // to snake_case columns.
+    const total = await em.sum(AuthorEntity, "postCount", { firstName: "Agg" });
+    expect(total).toBe(40);
+
+    const mean = await em.avg(AuthorEntity, "postCount", { firstName: "Agg" });
+    expect(mean).toBe(20);
+  });
+
+  it("should exists() with camelCase property in where clause", async () => {
+    const em = conn.em as any;
+
+    await em.save(AuthorEntity, { firstName: "ExistsMe", lastName: "Q", postCount: 5 });
+
+    expect(await em.exists(AuthorEntity, { firstName: "ExistsMe" })).toBe(true);
+    expect(await em.exists(AuthorEntity, { firstName: "NoOne" })).toBe(false);
+  });
+
+  it("should explain() a query whose where uses a camelCase property", async () => {
+    const em = conn.em as any;
+
+    await em.save(AuthorEntity, { firstName: "Explained", lastName: "E", postCount: 1 });
+
+    // Must not throw "unknown column firstName"; the plan references the
+    // snake_case column.
+    const plan = await em.explain(AuthorEntity, {
+      where: { firstName: "Explained" },
+    });
+    expect(plan).toBeDefined();
+  });
+
   // ── Explicit name preserved ────────────────────────
 
   it("should read/write explicit @Column({ name }) correctly", async () => {

--- a/__tests__/integration/sqlite/relations-advanced.test.ts
+++ b/__tests__/integration/sqlite/relations-advanced.test.ts
@@ -265,6 +265,42 @@ describe("[Integration] SQLite In-Memory: ManyToOne / OneToMany", () => {
     expect(parents[0].children.length).toBe(3);
     expect(parents[1].children.length).toBe(1);
   });
+
+  // #353: updateMany/delete may filter by the @ManyToOne FK shadow property
+  // (parentId → parentFk). Before the fix, validateCriteriaKeys rejected it as
+  // `Unknown column "parentId"` even though the SQL builder resolves it.
+  // (SQLite reports affected=0, so we assert data state instead of the count.)
+  it("updateMany() can filter by the @ManyToOne FK shadow property (#353)", async () => {
+    const { em } = conn;
+
+    const p = await em.save(ParentClass, { name: "FkUpd" });
+    await em.save(ChildClass, { title: "before", parentFk: p.id });
+    await em.save(ChildClass, { title: "before", parentFk: p.id });
+
+    await em.updateMany(
+      ChildClass,
+      { title: "after" } as any,
+      { where: { parentId: p.id } as any },
+    );
+
+    const rows = await em.find(ChildClass, { where: { parentFk: p.id } as any });
+    expect(rows.length).toBe(2);
+    expect(rows.every((r: any) => r.title === "after")).toBe(true);
+  });
+
+  it("delete() can filter by the @ManyToOne FK shadow property (#353)", async () => {
+    const { em } = conn;
+
+    const p = await em.save(ParentClass, { name: "FkDel" });
+    await em.save(ChildClass, { title: "doomed", parentFk: p.id });
+
+    await em.delete(ChildClass, { parentId: p.id } as any);
+
+    const remaining = await em.find(ChildClass, {
+      where: { parentFk: p.id } as any,
+    });
+    expect(remaining.length).toBe(0);
+  });
 });
 
 // ─────────────────────────────────────────────────────────

--- a/__tests__/integration/sqlite/soft-delete-batch-timestamp.test.ts
+++ b/__tests__/integration/sqlite/soft-delete-batch-timestamp.test.ts
@@ -182,6 +182,57 @@ describe("[Integration] SQLite: Soft Delete", () => {
     expect(names).toContain("Recoverable");
   });
 
+  // ── #351: aggregate paths must honor @DeletedAt like find() ──────────
+  it("count() should exclude soft-deleted rows by default (#351)", async () => {
+    const repo = conn.em.getRepository(SdEntity);
+    await repo.save({ name: "Live1", age: 20 });
+    await repo.save({ name: "Live2", age: 21 });
+    const trashed = await repo.save({ name: "Trashed", age: 22 });
+    await repo.softDelete({ id: trashed.id } as any);
+
+    expect(await conn.em.count(SdEntity)).toBe(2);
+  });
+
+  it("count() with withDeleted=true should include soft-deleted rows (#351)", async () => {
+    const repo = conn.em.getRepository(SdEntity);
+    await repo.save({ name: "Live1", age: 20 });
+    const trashed = await repo.save({ name: "Trashed", age: 22 });
+    await repo.softDelete({ id: trashed.id } as any);
+
+    expect(await conn.em.count(SdEntity, undefined, true)).toBe(2);
+  });
+
+  it("exists() should not see a soft-deleted row by default (#351)", async () => {
+    const repo = conn.em.getRepository(SdEntity);
+    const trashed = await repo.save({ name: "Ghost", age: 99 });
+    await repo.softDelete({ id: trashed.id } as any);
+
+    expect(await conn.em.exists(SdEntity, { id: trashed.id } as any)).toBe(false);
+    expect(
+      await conn.em.exists(SdEntity, { id: trashed.id } as any, true),
+    ).toBe(true);
+  });
+
+  it("findAndCount() should return a consistent [rows, count] tuple (#351)", async () => {
+    const repo = conn.em.getRepository(SdEntity);
+    await repo.save({ name: "Live1", age: 20 });
+    await repo.save({ name: "Live2", age: 21 });
+    const trashed = await repo.save({ name: "Trashed", age: 22 });
+    await repo.softDelete({ id: trashed.id } as any);
+
+    const [rows, total] = await conn.em.findAndCount(SdEntity, {});
+    // The bug: rows excluded the trashed row but count included it (3),
+    // so rows.length (2) !== total (3). They must agree.
+    expect(rows.length).toBe(2);
+    expect(total).toBe(2);
+
+    const [allRows, allTotal] = await conn.em.findAndCount(SdEntity, {
+      withDeleted: true,
+    } as any);
+    expect(allRows.length).toBe(3);
+    expect(allTotal).toBe(3);
+  });
+
   it("restore() should make entity visible again in find()", async () => {
     const repo = conn.em.getRepository(SdEntity);
     const saved = await repo.save({ name: "Restorable", age: 40 });

--- a/__tests__/unit/aggregate-query-handler.test.ts
+++ b/__tests__/unit/aggregate-query-handler.test.ts
@@ -317,18 +317,48 @@ describe("AggregateQueryHandler convenience methods", () => {
     aggregateSpy.mockRestore();
   });
 
+  // aggregate() signature is (entity, fn, field, where, existingSession, withDeleted).
+  // Convenience methods never pass a session, so existingSession is undefined and
+  // withDeleted lands in the 6th slot.
   it("count() should delegate to aggregate() with COUNT and *", async () => {
     const result = await handler.count(Product);
 
     expect(result).toBe(42);
-    expect(aggregateSpy).toHaveBeenCalledWith(Product, "COUNT", "*", undefined);
+    expect(aggregateSpy).toHaveBeenCalledWith(
+      Product,
+      "COUNT",
+      "*",
+      undefined,
+      undefined,
+      undefined,
+    );
   });
 
   it("count() should pass where clause", async () => {
     const where = { price: 100 } as any;
     await handler.count(Product, where);
 
-    expect(aggregateSpy).toHaveBeenCalledWith(Product, "COUNT", "*", where);
+    expect(aggregateSpy).toHaveBeenCalledWith(
+      Product,
+      "COUNT",
+      "*",
+      where,
+      undefined,
+      undefined,
+    );
+  });
+
+  it("count() should forward withDeleted opt-in", async () => {
+    await handler.count(Product, undefined, true);
+
+    expect(aggregateSpy).toHaveBeenCalledWith(
+      Product,
+      "COUNT",
+      "*",
+      undefined,
+      undefined,
+      true,
+    );
   });
 
   it("sum() should delegate to aggregate() with SUM and field", async () => {
@@ -340,14 +370,23 @@ describe("AggregateQueryHandler convenience methods", () => {
       "SUM",
       "price",
       undefined,
+      undefined,
+      undefined,
     );
   });
 
-  it("sum() should pass where clause", async () => {
+  it("sum() should pass where clause and withDeleted", async () => {
     const where = { quantity: 10 } as any;
-    await handler.sum(Product, "price", where);
+    await handler.sum(Product, "price", where, true);
 
-    expect(aggregateSpy).toHaveBeenCalledWith(Product, "SUM", "price", where);
+    expect(aggregateSpy).toHaveBeenCalledWith(
+      Product,
+      "SUM",
+      "price",
+      where,
+      undefined,
+      true,
+    );
   });
 
   it("avg() should delegate to aggregate() with AVG and field", async () => {
@@ -359,6 +398,8 @@ describe("AggregateQueryHandler convenience methods", () => {
       "AVG",
       "price",
       undefined,
+      undefined,
+      undefined,
     );
   });
 
@@ -366,7 +407,14 @@ describe("AggregateQueryHandler convenience methods", () => {
     const where = { id: 1 } as any;
     await handler.avg(Product, "price", where);
 
-    expect(aggregateSpy).toHaveBeenCalledWith(Product, "AVG", "price", where);
+    expect(aggregateSpy).toHaveBeenCalledWith(
+      Product,
+      "AVG",
+      "price",
+      where,
+      undefined,
+      undefined,
+    );
   });
 
   it("min() should delegate to aggregate() with MIN and field", async () => {
@@ -378,6 +426,8 @@ describe("AggregateQueryHandler convenience methods", () => {
       "MIN",
       "price",
       undefined,
+      undefined,
+      undefined,
     );
   });
 
@@ -385,7 +435,14 @@ describe("AggregateQueryHandler convenience methods", () => {
     const where = { id: 5 } as any;
     await handler.min(Product, "price", where);
 
-    expect(aggregateSpy).toHaveBeenCalledWith(Product, "MIN", "price", where);
+    expect(aggregateSpy).toHaveBeenCalledWith(
+      Product,
+      "MIN",
+      "price",
+      where,
+      undefined,
+      undefined,
+    );
   });
 
   it("max() should delegate to aggregate() with MAX and field", async () => {
@@ -397,6 +454,8 @@ describe("AggregateQueryHandler convenience methods", () => {
       "MAX",
       "price",
       undefined,
+      undefined,
+      undefined,
     );
   });
 
@@ -404,6 +463,87 @@ describe("AggregateQueryHandler convenience methods", () => {
     const where = { quantity: 100 } as any;
     await handler.max(Product, "price", where);
 
-    expect(aggregateSpy).toHaveBeenCalledWith(Product, "MAX", "price", where);
+    expect(aggregateSpy).toHaveBeenCalledWith(
+      Product,
+      "MAX",
+      "price",
+      where,
+      undefined,
+      undefined,
+    );
+  });
+});
+
+// ==========================================================================
+// describe: soft-delete (@DeletedAt) filtering — regression for #351
+// ==========================================================================
+describe("AggregateQueryHandler @DeletedAt filtering (#351)", () => {
+  let ctx: EntityManagerInternals;
+  let resolver: RelationMetadataResolver;
+  let handler: AggregateQueryHandler;
+
+  function captureSql(): { getText: () => string } {
+    const box: { text: string } = { text: "" };
+    (ctx.executeReadOnly as jest.Mock).mockImplementation(async (fn: any) => {
+      const mockSession = {
+        query: jest.fn().mockImplementation((q: any) => {
+          box.text = q.text || q.sql || String(q);
+          return Promise.resolve({ results: [{ result: 7 }], fields: [] });
+        }),
+      };
+      return fn(mockSession);
+    });
+    return { getText: () => box.text };
+  }
+
+  beforeEach(() => {
+    ctx = createMockCtx();
+    // Entity declares a soft-delete column "deleted_at".
+    resolver = createMockResolver({
+      getDeletedAtColumn: jest.fn().mockReturnValue("deleted_at"),
+    });
+    (resolver.resolveEntityMetadata as jest.Mock).mockReturnValue(
+      productMetadata,
+    );
+    handler = new AggregateQueryHandler(resolver, ctx);
+  });
+
+  it("excludes soft-deleted rows by default (adds deleted_at IS NULL)", async () => {
+    const cap = captureSql();
+    await handler.aggregate(Product, "COUNT", "*");
+    expect(cap.getText()).toContain("`deleted_at` IS NULL");
+  });
+
+  it("excludes soft-deleted rows even when a where clause is present", async () => {
+    const cap = captureSql();
+    await handler.aggregate(Product, "COUNT", "*", { price: 100 } as any);
+    const sql = cap.getText();
+    expect(sql).toContain("WHERE");
+    expect(sql).toContain("`deleted_at` IS NULL");
+  });
+
+  it("includes soft-deleted rows when withDeleted=true", async () => {
+    const cap = captureSql();
+    await handler.aggregate(Product, "COUNT", "*", undefined, undefined, true);
+    expect(cap.getText()).not.toContain("deleted_at");
+  });
+
+  it("count() excludes soft-deleted rows by default", async () => {
+    const cap = captureSql();
+    await handler.count(Product);
+    expect(cap.getText()).toContain("`deleted_at` IS NULL");
+  });
+
+  it("count() with withDeleted=true includes soft-deleted rows", async () => {
+    const cap = captureSql();
+    await handler.count(Product, undefined, true);
+    expect(cap.getText()).not.toContain("deleted_at");
+  });
+
+  it("does not add the filter when the entity has no @DeletedAt column", async () => {
+    (resolver.getDeletedAtColumn as jest.Mock).mockReturnValue(null);
+    const cap = captureSql();
+    await handler.aggregate(Product, "COUNT", "*");
+    expect(cap.getText()).not.toContain("deleted_at");
   });
 });

--- a/__tests__/unit/aggregate-query-handler.test.ts
+++ b/__tests__/unit/aggregate-query-handler.test.ts
@@ -48,6 +48,13 @@ function createMockCtx(
     delete: jest.fn(),
     getTenantColumnConfig: jest.fn().mockReturnValue(null),
     buildTenantWhereClause: jest.fn().mockReturnValue(null),
+    buildPropertyToColumnMap: jest.fn((m: any) => {
+      const map = new Map<string, string>();
+      for (const c of m?.columns ?? []) {
+        map.set(c.propertyKey ?? c.name, c.name);
+      }
+      return map;
+    }),
     ...overrides,
   } as unknown as EntityManagerInternals;
 }
@@ -545,5 +552,66 @@ describe("AggregateQueryHandler @DeletedAt filtering (#351)", () => {
     const cap = captureSql();
     await handler.aggregate(Product, "COUNT", "*");
     expect(cap.getText()).not.toContain("deleted_at");
+  });
+});
+
+// ==========================================================================
+// describe: NamingStrategy column mapping — regression for #352
+// ==========================================================================
+describe("AggregateQueryHandler NamingStrategy mapping (#352)", () => {
+  class Author {
+    id!: number;
+    firstName!: string;
+    postCount!: number;
+  }
+  const snakeMetadata = {
+    name: "author",
+    target: Author,
+    columns: [
+      { propertyKey: "id", name: "id", options: { primary: true } },
+      { propertyKey: "firstName", name: "first_name", options: {} },
+      { propertyKey: "postCount", name: "post_count", options: {} },
+    ],
+  };
+
+  let ctx: EntityManagerInternals;
+  let resolver: RelationMetadataResolver;
+  let handler: AggregateQueryHandler;
+
+  function captureSql(): { getText: () => string } {
+    const box: { text: string } = { text: "" };
+    (ctx.executeReadOnly as jest.Mock).mockImplementation(async (fn: any) => {
+      const mockSession = {
+        query: jest.fn().mockImplementation((q: any) => {
+          box.text = q.text || q.sql || String(q);
+          return Promise.resolve({ results: [{ result: 3 }], fields: [] });
+        }),
+      };
+      return fn(mockSession);
+    });
+    return { getText: () => box.text };
+  }
+
+  beforeEach(() => {
+    ctx = createMockCtx();
+    resolver = createMockResolver();
+    (resolver.resolveEntityMetadata as jest.Mock).mockReturnValue(snakeMetadata);
+    handler = new AggregateQueryHandler(resolver, ctx);
+  });
+
+  it("maps a camelCase where key to its snake_case column", async () => {
+    const cap = captureSql();
+    await handler.aggregate(Author, "COUNT", "*", { firstName: "Ada" } as any);
+    const sql = cap.getText();
+    expect(sql).toContain("`first_name`");
+    expect(sql).not.toContain("firstName");
+  });
+
+  it("maps a camelCase aggregate field to its snake_case column", async () => {
+    const cap = captureSql();
+    await handler.aggregate(Author, "SUM", "postCount");
+    const sql = cap.getText();
+    expect(sql).toContain("SUM(`post_count`)");
+    expect(sql).not.toContain("postCount");
   });
 });

--- a/__tests__/unit/aggregate.test.ts
+++ b/__tests__/unit/aggregate.test.ts
@@ -47,7 +47,10 @@ const mockEntityScanner = {
 jest.mock("../../src/scanner/ScannerContainer", () => ({
   getScannerInstance: (cls: any) => {
     if (cls === EntityScanner) return mockEntityScanner as any;
-    return {} as any;
+    // Relation scanners (ManyToOne/OneToOne/...) are reached via
+    // buildPropertyToColumnMap → collectFkPropertyMappings. Product declares no
+    // relations, so getByTarget() returns no relation metadata.
+    return { getByTarget: () => [] } as any;
   },
   resetScannerContainer: jest.fn(),
 }));

--- a/__tests__/unit/criteria-fk-shadow-validation.test.ts
+++ b/__tests__/unit/criteria-fk-shadow-validation.test.ts
@@ -1,0 +1,135 @@
+import "reflect-metadata";
+import { resetScannerContainer } from "../../src/scanner/ScannerContainer";
+import { EntityManager } from "../../src/core/EntityManager";
+import { MetadataLayerRegistry } from "../../src/scanner/MetadataScanner";
+import { InvalidQueryError } from "../../src/errors/InvalidQueryError";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+// Regression for #353: validateCriteriaKeys() used to build its allow-list
+// from metadata.columns only, so a @ManyToOne/@OneToOne FK shadow property
+// (e.g. `userId` backing a `user` relation) — which the SQL builder
+// (buildPropertyToColumnMap → collectFkPropertyMappings) resolves fine — was
+// rejected with `Unknown column "userId"`. The guard now derives its allow-list
+// from the same builder, so updateMany/delete/softDelete/restore accept FK
+// shadow props.
+
+jest.mock("../../src/DatabaseClient", () => ({
+  DatabaseClient: {
+    getInstance: jest.fn().mockReturnValue({
+      type: "mysql",
+      getConnection: jest.fn(),
+      getOptions: jest.fn().mockReturnValue({ synchronize: false }),
+      connect: jest.fn(),
+    }),
+  },
+}));
+
+jest.mock("../../src/dialects/TransactionSessionManager", () => {
+  const mockQuery = jest.fn().mockResolvedValue({ affectedRows: 1, rowCount: 1 });
+  return {
+    TransactionSessionManager: jest.fn().mockImplementation(() => ({
+      connect: jest.fn().mockResolvedValue(undefined),
+      startTransaction: jest.fn().mockResolvedValue(undefined),
+      query: mockQuery,
+      commit: jest.fn().mockResolvedValue(undefined),
+      rollback: jest.fn().mockResolvedValue(undefined),
+      close: jest.fn().mockResolvedValue(undefined),
+    })),
+    __mockQuery: mockQuery,
+  };
+});
+
+class Notification {}
+
+const metadata = {
+  name: "Notification",
+  target: Notification,
+  columns: [
+    { name: "id", propertyKey: "id", options: { primary: true, autoIncrement: true } },
+    { name: "read_at", propertyKey: "readAt", options: {} },
+  ],
+};
+
+function createEm(deletedAtColumn: string | null = null): EntityManager {
+  const em = new EntityManager();
+  (em as any).driver = { wrap: (n: string) => `\`${n}\`` };
+  (em as any).resolver = {
+    resolveEntityMetadata: jest.fn().mockReturnValue(metadata),
+    getDeletedAtColumn: jest.fn().mockReturnValue(deletedAtColumn),
+    getUpdateTimestampColumn: jest.fn().mockReturnValue(null),
+    getCreateTimestampColumn: jest.fn().mockReturnValue(null),
+    getVersionColumn: jest.fn().mockReturnValue(null),
+    // What collectFkPropertyMappings() yields for a `@ManyToOne user` with
+    // joinColumn "user_id": the FK shadow property maps to the FK column.
+    collectFkPropertyMappings: jest
+      .fn()
+      .mockReturnValue(new Map([["userId", "user_id"]])),
+  };
+  return em;
+}
+
+describe("validateCriteriaKeys accepts @RelationColumn FK shadow props (#353)", () => {
+  beforeEach(() => {
+    MetadataLayerRegistry.reset();
+    resetScannerContainer();
+    jest.clearAllMocks();
+  });
+
+  it("delete() by an FK shadow prop passes validation", async () => {
+    const em = createEm();
+    await expect(
+      em.delete(Notification, { userId: 5 } as any),
+    ).resolves.not.toThrow();
+  });
+
+  it("updateMany() filtering by an FK shadow prop passes validation", async () => {
+    const em = createEm();
+    await expect(
+      em.updateMany(
+        Notification,
+        { readAt: new Date() } as any,
+        { where: { userId: 5 } as any },
+      ),
+    ).resolves.not.toThrow();
+  });
+
+  it("updateMany() SETTING an FK shadow prop passes validation", async () => {
+    const em = createEm();
+    await expect(
+      em.updateMany(
+        Notification,
+        { userId: 9 } as any,
+        { where: { id: 1 } as any },
+      ),
+    ).resolves.not.toThrow();
+  });
+
+  it("softDelete() by an FK shadow prop passes validation", async () => {
+    const em = createEm("deleted_at");
+    await expect(
+      em.softDelete(Notification, { userId: 5 } as any),
+    ).resolves.not.toThrow();
+  });
+
+  it("restore() by an FK shadow prop passes validation", async () => {
+    const em = createEm("deleted_at");
+    await expect(
+      em.restore(Notification, { userId: 5 } as any),
+    ).resolves.not.toThrow();
+  });
+
+  it("still rejects a genuinely unknown column", async () => {
+    const em = createEm();
+    await expect(
+      em.delete(Notification, { totallyBogus: 1 } as any),
+    ).rejects.toThrow(InvalidQueryError);
+  });
+
+  it("error message still names the unknown key", async () => {
+    const em = createEm();
+    await expect(
+      em.delete(Notification, { totallyBogus: 1 } as any),
+    ).rejects.toThrow(/totallyBogus/);
+  });
+});

--- a/__tests__/unit/explain-query-handler.test.ts
+++ b/__tests__/unit/explain-query-handler.test.ts
@@ -89,6 +89,13 @@ function createMockCtx(overrides: Partial<EntityManagerInternals> = {}): jest.Mo
     saveWithSession: jest.fn(),
     find: jest.fn(),
     delete: jest.fn(),
+    buildPropertyToColumnMap: jest.fn((m: any) => {
+      const map = new Map<string, string>();
+      for (const c of m?.columns ?? []) {
+        map.set(c.propertyKey ?? c.name, c.name);
+      }
+      return map;
+    }),
     ...overrides,
   } as any;
 }

--- a/__tests__/unit/find-and-count.test.ts
+++ b/__tests__/unit/find-and-count.test.ts
@@ -54,7 +54,14 @@ describe("findAndCount()", () => {
     await em.findAndCount(User, { where });
 
     expect(findInternalSpy).toHaveBeenCalledWith(User, { where }, {});
-    expect(aggregateSpy).toHaveBeenCalledWith(User, "COUNT", "*", where, {});
+    expect(aggregateSpy).toHaveBeenCalledWith(
+      User,
+      "COUNT",
+      "*",
+      where,
+      {},
+      undefined,
+    );
   });
 
   it("take/limit 옵션이 findInternal()에만 영향을 미치고 aggregate()에는 영향을 주지 않아야 한다", async () => {
@@ -81,6 +88,7 @@ describe("findAndCount()", () => {
       "*",
       findOption.where,
       {},
+      undefined,
     );
   });
 
@@ -106,6 +114,7 @@ describe("findAndCount()", () => {
       "*",
       undefined,
       {},
+      undefined,
     );
   });
 
@@ -135,6 +144,34 @@ describe("findAndCount()", () => {
       "*",
       undefined,
       mockSession,
+      undefined,
+    );
+  });
+
+  it("withDeleted 옵션을 aggregate()에 전달해 [rows, count] 일관성을 유지해야 한다 (#351)", async () => {
+    const findInternalSpy = jest
+      .spyOn(em as any, "findInternal")
+      .mockResolvedValue([] as any);
+    const aggregateSpy = jest
+      .spyOn((em as any).aggregateHandler, "aggregate")
+      .mockResolvedValue(0);
+    jest.spyOn(em as any, "executeReadOnly").mockImplementation(
+      async (fn: any) => fn({}),
+    );
+
+    const findOption = { where: { name: "Alice" } as any, withDeleted: true };
+    await em.findAndCount(User, findOption);
+
+    // The count half must honor the same withDeleted flag as the rows half,
+    // otherwise findAndCount returns an inconsistent [rows, count] tuple.
+    expect(findInternalSpy).toHaveBeenCalledWith(User, findOption, {});
+    expect(aggregateSpy).toHaveBeenCalledWith(
+      User,
+      "COUNT",
+      "*",
+      findOption.where,
+      {},
+      true,
     );
   });
 

--- a/examples/nestjs-linear-clone/src/modules/notifications/notifications.service.ts
+++ b/examples/nestjs-linear-clone/src/modules/notifications/notifications.service.ts
@@ -5,7 +5,6 @@ import {
   Transactional,
   CursorPaginationResult,
   qAlias,
-  sql,
 } from "@stingerloom/orm";
 import { InjectRepository } from "@stingerloom/orm/nestjs";
 import { Notification, NotificationKind } from "./notification.entity";
@@ -103,23 +102,15 @@ export class NotificationsService {
 
   @Transactional()
   async markAllRead(userId: number): Promise<{ marked: number }> {
-    // Bypass repo.updateMany() because @RelationColumn-derived FK shadow
-    // accessors (`userId`) aren't visible in its property-to-column resolver
-    // — the where clause throws "Unknown column userId". Use a raw UPDATE
-    // until the ORM treats RelationColumn FKs as queryable columns.
-    const N = this.em.ref(Notification);
-    const result = await this.em.query<unknown>(sql`
-      UPDATE ${N}
-         SET ${N.readAt} = NOW()
-       WHERE ${N.userId} = ${userId}
-         AND ${N.readAt} IS NULL
-    `);
-    const marked =
-      (result as { affectedRows?: number; rowCount?: number; affected?: number } | null)
-        ?.affectedRows ??
-      (result as { rowCount?: number } | null)?.rowCount ??
-      0;
-    return { marked };
+    // `userId` is the @RelationColumn FK shadow property (→ user_id); the
+    // typed updateMany() now accepts it directly (stingerloom #353), so no
+    // raw-SQL escape hatch is needed.
+    const { affected } = await this.em.updateMany(
+      Notification,
+      { readAt: new Date() },
+      { where: { userId, readAt: { isNull: true } } },
+    );
+    return { marked: affected };
   }
 
   // ── Emission (called by the EntitySubscriber) ───────────────

--- a/src/core/AggregateQueryHandler.ts
+++ b/src/core/AggregateQueryHandler.ts
@@ -26,6 +26,7 @@ export class AggregateQueryHandler {
     field: string,
     where?: WhereClause<T> | WhereClause<T>[],
     existingSession?: TransactionSessionManager,
+    withDeleted?: boolean,
   ): Promise<number> {
     const metadata = this.resolver.resolveEntityMetadata(entity);
     if (!metadata) {
@@ -48,6 +49,16 @@ export class AggregateQueryHandler {
         wrapColumn: (n) => this.ctx.wrap(n),
         dialect: this.ctx.getDialect(),
       });
+
+      // If an @DeletedAt column exists, exclude soft-deleted rows by default,
+      // mirroring findInternal so count()/exists()/sum()/avg()/min()/max() —
+      // and therefore findAndCount() — never count trashed rows. Callers opt
+      // back in via `withDeleted: true`. The aggregate query is never joined,
+      // so the unqualified column form is correct.
+      const deletedAtColumn = this.resolver.getDeletedAtColumn(entity);
+      if (deletedAtColumn && !withDeleted) {
+        whereMap.push(Conditions.isNull(this.ctx.wrap(deletedAtColumn)));
+      }
 
       // Tenant scoping under the "tenant_column" strategy. Kept consistent
       // with findInternal so exists()/count()/sum()/avg()/min()/max() never
@@ -81,39 +92,44 @@ export class AggregateQueryHandler {
   async count<T>(
     entity: ClazzType<T>,
     where?: WhereClause<T>,
+    withDeleted?: boolean,
   ): Promise<number> {
-    return this.aggregate(entity, "COUNT", "*", where);
+    return this.aggregate(entity, "COUNT", "*", where, undefined, withDeleted);
   }
 
   async sum<T>(
     entity: ClazzType<T>,
     field: keyof T & string,
     where?: WhereClause<T>,
+    withDeleted?: boolean,
   ): Promise<number> {
-    return this.aggregate(entity, "SUM", field, where);
+    return this.aggregate(entity, "SUM", field, where, undefined, withDeleted);
   }
 
   async avg<T>(
     entity: ClazzType<T>,
     field: keyof T & string,
     where?: WhereClause<T>,
+    withDeleted?: boolean,
   ): Promise<number> {
-    return this.aggregate(entity, "AVG", field, where);
+    return this.aggregate(entity, "AVG", field, where, undefined, withDeleted);
   }
 
   async min<T>(
     entity: ClazzType<T>,
     field: keyof T & string,
     where?: WhereClause<T>,
+    withDeleted?: boolean,
   ): Promise<number> {
-    return this.aggregate(entity, "MIN", field, where);
+    return this.aggregate(entity, "MIN", field, where, undefined, withDeleted);
   }
 
   async max<T>(
     entity: ClazzType<T>,
     field: keyof T & string,
     where?: WhereClause<T>,
+    withDeleted?: boolean,
   ): Promise<number> {
-    return this.aggregate(entity, "MAX", field, where);
+    return this.aggregate(entity, "MAX", field, where, undefined, withDeleted);
   }
 }

--- a/src/core/AggregateQueryHandler.ts
+++ b/src/core/AggregateQueryHandler.ts
@@ -5,6 +5,7 @@ import { TransactionSessionManager } from "../dialects/TransactionSessionManager
 import sql, { Sql, join, raw } from "sql-template-tag";
 import { Conditions } from "./Conditions";
 import { resolveWhereClause } from "./WhereResolver";
+import { createDialectExpression } from "../dialects/DialectExpression";
 import { QueryResult } from "../types/QueryResult";
 import { EntityMetadataNotFoundError } from "../errors/EntityMetadataNotFoundError";
 import { RelationMetadataResolver } from "./RelationMetadataResolver";
@@ -41,13 +42,19 @@ export class AggregateQueryHandler {
 
     return executor(async (session) => {
       const tableName = metadata.name!;
-      const selectExpr = raw(
-        `${fn}(${field === "*" ? "*" : this.ctx.wrap(field)})`,
-      );
+
+      // Resolve property names to DB columns exactly like findInternal so the
+      // aggregate field and WHERE honor a NamingStrategy and FK shadow props.
+      const propToCol = this.ctx.buildPropertyToColumnMap(metadata);
+      const mappedField =
+        field === "*" ? "*" : this.ctx.wrap(propToCol.get(field) ?? field);
+      const selectExpr = raw(`${fn}(${mappedField})`);
 
       const whereMap: Sql[] = resolveWhereClause(where, {
         wrapColumn: (n) => this.ctx.wrap(n),
         dialect: this.ctx.getDialect(),
+        dialectExpression: createDialectExpression(this.ctx.getDialect()),
+        propertyToColumn: propToCol,
       });
 
       // If an @DeletedAt column exists, exclude soft-deleted rows by default,

--- a/src/core/BaseRepository.ts
+++ b/src/core/BaseRepository.ts
@@ -246,8 +246,8 @@ export class BaseRepository<T> {
   /**
    * Returns true if at least one entity matches the given where clause.
    */
-  async exists(where?: WhereClause<T>): Promise<boolean> {
-    return await this.em.exists<T>(this.entity, where);
+  async exists(where?: WhereClause<T>, withDeleted?: boolean): Promise<boolean> {
+    return await this.em.exists<T>(this.entity, where, withDeleted);
   }
 
   /**
@@ -268,8 +268,8 @@ export class BaseRepository<T> {
   /**
    * Returns the count of entities matching the given conditions.
    */
-  async count(where?: WhereClause<T>): Promise<number> {
-    return await this.em.count<T>(this.entity, where);
+  async count(where?: WhereClause<T>, withDeleted?: boolean): Promise<number> {
+    return await this.em.count<T>(this.entity, where, withDeleted);
   }
 
   /**
@@ -278,8 +278,9 @@ export class BaseRepository<T> {
   async sum(
     field: keyof T & string,
     where?: WhereClause<T>,
+    withDeleted?: boolean,
   ): Promise<number> {
-    return await this.em.sum<T>(this.entity, field, where);
+    return await this.em.sum<T>(this.entity, field, where, withDeleted);
   }
 
   /**
@@ -288,8 +289,9 @@ export class BaseRepository<T> {
   async avg(
     field: keyof T & string,
     where?: WhereClause<T>,
+    withDeleted?: boolean,
   ): Promise<number> {
-    return await this.em.avg<T>(this.entity, field, where);
+    return await this.em.avg<T>(this.entity, field, where, withDeleted);
   }
 
   /**
@@ -298,8 +300,9 @@ export class BaseRepository<T> {
   async min(
     field: keyof T & string,
     where?: WhereClause<T>,
+    withDeleted?: boolean,
   ): Promise<number> {
-    return await this.em.min<T>(this.entity, field, where);
+    return await this.em.min<T>(this.entity, field, where, withDeleted);
   }
 
   /**
@@ -308,8 +311,9 @@ export class BaseRepository<T> {
   async max(
     field: keyof T & string,
     where?: WhereClause<T>,
+    withDeleted?: boolean,
   ): Promise<number> {
-    return await this.em.max<T>(this.entity, field, where);
+    return await this.em.max<T>(this.entity, field, where, withDeleted);
   }
 
   /**

--- a/src/core/EntityManager.ts
+++ b/src/core/EntityManager.ts
@@ -4615,14 +4615,25 @@ export class EntityManager implements BaseEntityManager {
   // ── Utilities ──────────────────────────────────────────────
 
   private validateCriteriaKeys<T>(
-    metadata: { columns: ColumnMetadata[] },
+    metadata: { target?: ClazzType<any>; columns: ColumnMetadata[] },
     criteria: WhereClause<T>,
     entityName: string,
   ): void {
+    // Derive the valid key set from the SAME source the SQL builder uses
+    // (buildPropertyToColumnMap), so the guard accepts every key the builder
+    // can resolve and the two can never drift. This includes @Column property
+    // and DB names plus @ManyToOne/@OneToOne FK shadow properties (e.g.
+    // `userId` → `user_id`); without the FK entries, filtering a bulk
+    // update/delete by a relation FK threw "Unknown column" even though the
+    // builder resolves it fine (#353).
     const validNames = new Set<string>();
     for (const col of metadata.columns) {
       if (col.propertyKey) validNames.add(col.propertyKey);
       if (col.name) validNames.add(col.name);
+    }
+    for (const [prop, col] of this.buildPropertyToColumnMap(metadata)) {
+      validNames.add(prop);
+      if (col) validNames.add(col);
     }
     for (const key of Object.keys(criteria as object)) {
       const value = (criteria as any)[key];

--- a/src/core/EntityManager.ts
+++ b/src/core/EntityManager.ts
@@ -1996,7 +1996,7 @@ export class EntityManager implements BaseEntityManager {
     const readNode = this.getReadNode(findOption.useMaster);
     return this.executeReadOnly(async (session) => {
       const entities = await this.findInternal<T>(entity, findOption, session);
-      const totalCount = await this.aggregateHandler.aggregate<T>(entity, "COUNT", "*", findOption.where, session);
+      const totalCount = await this.aggregateHandler.aggregate<T>(entity, "COUNT", "*", findOption.where, session, findOption.withDeleted);
 
       return [entities as unknown as T[], totalCount];
     }, { readNodeOverride: readNode, timeout: findOption.timeout });
@@ -4490,8 +4490,9 @@ export class EntityManager implements BaseEntityManager {
   async exists<T>(
     entity: ClazzType<T>,
     where?: WhereClause<T>,
+    withDeleted?: boolean,
   ): Promise<boolean> {
-    const c = await this.aggregateHandler.count(entity, where);
+    const c = await this.aggregateHandler.count(entity, where, withDeleted);
     return c > 0;
   }
 
@@ -4560,40 +4561,45 @@ export class EntityManager implements BaseEntityManager {
   async count<T>(
     entity: ClazzType<T>,
     where?: WhereClause<T>,
+    withDeleted?: boolean,
   ): Promise<number> {
-    return this.aggregateHandler.count(entity, where);
+    return this.aggregateHandler.count(entity, where, withDeleted);
   }
 
   async sum<T>(
     entity: ClazzType<T>,
     field: keyof T & string,
     where?: WhereClause<T>,
+    withDeleted?: boolean,
   ): Promise<number> {
-    return this.aggregateHandler.sum(entity, field, where);
+    return this.aggregateHandler.sum(entity, field, where, withDeleted);
   }
 
   async avg<T>(
     entity: ClazzType<T>,
     field: keyof T & string,
     where?: WhereClause<T>,
+    withDeleted?: boolean,
   ): Promise<number> {
-    return this.aggregateHandler.avg(entity, field, where);
+    return this.aggregateHandler.avg(entity, field, where, withDeleted);
   }
 
   async min<T>(
     entity: ClazzType<T>,
     field: keyof T & string,
     where?: WhereClause<T>,
+    withDeleted?: boolean,
   ): Promise<number> {
-    return this.aggregateHandler.min(entity, field, where);
+    return this.aggregateHandler.min(entity, field, where, withDeleted);
   }
 
   async max<T>(
     entity: ClazzType<T>,
     field: keyof T & string,
     where?: WhereClause<T>,
+    withDeleted?: boolean,
   ): Promise<number> {
-    return this.aggregateHandler.max(entity, field, where);
+    return this.aggregateHandler.max(entity, field, where, withDeleted);
   }
 
   // ── EXPLAIN delegation ──────────────────────────────────────

--- a/src/core/EntityManager.ts
+++ b/src/core/EntityManager.ts
@@ -344,6 +344,7 @@ export class EntityManager implements BaseEntityManager {
     delete: (e, c) => this.delete(e, c),
     getTenantColumnConfig: () => this.tenantColumnConfig,
     buildTenantWhereClause: (e, alias) => this.buildTenantWhereClause(e, alias),
+    buildPropertyToColumnMap: (m) => this.buildPropertyToColumnMap(m),
   };
 
   private readonly cascadeHandler = new CascadeHandler(this.resolver, this._ctx);

--- a/src/core/EntityManagerInternals.ts
+++ b/src/core/EntityManagerInternals.ts
@@ -9,6 +9,7 @@ import { EntityResult } from "../types/EntityResult";
 import { ISelectOption } from "../dialects/ISelectOption";
 import { SchemaDialect } from "./generators/SchemaGenerator";
 import { SynchronizePolicy } from "./DatabaseClientOptions";
+import { ColumnMetadata } from "../scanner";
 
 /**
  * Interface that exposes EntityManager internals to extracted handler classes.
@@ -53,6 +54,18 @@ export interface EntityManagerInternals {
   getNameStrategy<T>(clazz: ClazzType<T>): string;
   resolveSelectColumns<T>(select: ISelectOption<T>): string[];
   markDirty(entity: any): void;
+
+  /**
+   * Builds the TypeScript-property → DB-column map for an entity, including
+   * `@ManyToOne`/`@OneToOne` FK shadow properties (e.g. `workspaceId` →
+   * `workspace_id`). Extracted handlers use this so their WHERE/field
+   * resolution matches `findInternal` under a `NamingStrategy`; without it,
+   * aggregate()/explain() emit raw camelCase property names verbatim.
+   */
+  buildPropertyToColumnMap(metadata: {
+    target?: ClazzType<any>;
+    columns: ColumnMetadata[];
+  }): Map<string, string>;
 
   /**
    * Tenant-column strategy configuration. Returns null when strategy is not

--- a/src/core/ExplainQueryHandler.ts
+++ b/src/core/ExplainQueryHandler.ts
@@ -4,6 +4,7 @@ import { FindOption } from "../dialects/FindOption";
 import sql, { Sql, raw } from "sql-template-tag";
 import { Conditions } from "./Conditions";
 import { resolveWhereClause } from "./WhereResolver";
+import { createDialectExpression } from "../dialects/DialectExpression";
 import { RawQueryBuilderFactory } from "./RawQueryBuilderFactory";
 import { ExplainResult } from "./ExplainResult";
 import { EntityMetadataNotFoundError } from "../errors/EntityMetadataNotFoundError";
@@ -94,12 +95,18 @@ export class ExplainQueryHandler {
       }
     }
 
+    // Map property names to DB columns (incl. FK shadow props) like
+    // findInternal, so a NamingStrategy WHERE resolves correctly.
+    const propToCol = this.ctx.buildPropertyToColumnMap(metadata);
+
     whereMap.push(
       ...resolveWhereClause(where, {
         wrapColumn: (n) => this.ctx.wrap(n),
         qualified: hasEagerJoins,
         tableName: hasEagerJoins ? tableName : undefined,
         dialect: this.ctx.getDialect(),
+        dialectExpression: createDialectExpression(this.ctx.getDialect()),
+        propertyToColumn: propToCol,
       }),
     );
 


### PR DESCRIPTION
## Summary

Three related `@stingerloom/orm` core fixes around **column/criteria resolution**, each kept as a separate commit and closing its own issue. All three were found by a codebase audit and reproduced before fixing.

| Commit | Issue | Fix |
|--------|-------|-----|
| `35dc4a0` | #351 | `aggregate()` never appended the `deletedAt IS NULL` filter that `findInternal` adds, so `count`/`exists`/`sum`/`avg`/`min`/`max` — and `findAndCount`'s count half — counted soft-deleted rows. `findAndCount` returned an inconsistent `[rows, count]` tuple. Now excluded by default, with a `withDeleted` opt-in. |
| `af90d10` | #352 | `aggregate()`/`explain()` resolved their WHERE without the `propertyToColumn` map (and `dialectExpression`) that `findInternal` passes, so under a `NamingStrategy` the WHERE emitted raw camelCase property names (`WHERE firstName = ?` → "unknown column"). The aggregate field had the same gap. Now both resolve via the shared `buildPropertyToColumnMap`. |
| `3818fb6` | #353 | `validateCriteriaKeys()` built its allow-list from `metadata.columns` only, rejecting `@ManyToOne`/`@OneToOne` FK shadow props (e.g. `userId`) that the SQL builder resolves fine — forcing consumers onto raw SQL. The guard now derives its allow-list from the same `buildPropertyToColumnMap`, so guard and builder can't drift. |

## Why one PR

All three share the same root area (`AggregateQueryHandler` / `ExplainQueryHandler` / `EntityManager` criteria resolution) and #352/#353 both build on exposing `buildPropertyToColumnMap` on `EntityManagerInternals`. Commits are split per-issue for review.

## Notable

- `examples/nestjs-linear-clone`: the raw-SQL `markAllRead()` workaround is replaced with the now-working typed `updateMany()` (the concrete payoff of #353).
- Aggregate API gains a `withDeleted` opt-in across `count`/`sum`/`avg`/`min`/`max`/`exists` and `BaseRepository`, mirroring `find`.

## Tests

- **Unit:** aggregate `@DeletedAt` + NamingStrategy describes, `findAndCount` tuple-consistency, new `criteria-fk-shadow-validation` suite (guard accepts FK shadow on delete/updateMany/softDelete/restore; still rejects unknown keys).
- **Integration (SQLite, runs in CI):** soft-delete `count`/`findAndCount` consistency, and `relations-advanced` filtering `updateMany`/`delete` by the real `@ManyToOne` FK shadow property.
- **Integration (MySQL/PG dual-driver):** snake-naming `count`/`sum`/`avg`/`exists`/`explain` cases (run on CI DB).
- Full unit suite: 4896 passed, 0 failures. `tsc --noEmit` clean for ORM and the example.

Closes #351
Closes #352
Closes #353
