### PR TITLE
fix(core): pagination limit-0, subscriber dedupe, and getReference hydration

### DIFF
--- a/__tests__/integration/sqlite/lifecycle-hooks-queries.test.ts
+++ b/__tests__/integration/sqlite/lifecycle-hooks-queries.test.ts
@@ -364,6 +364,22 @@ describe("[Integration] SQLite: Complex Queries", () => {
     expect((results[2] as any).age).toBe(28);
   });
 
+  it("limit [offset, 0] should return an empty array (#364)", async () => {
+    // An explicit count of 0 means "no rows" (LIMIT 0); the validator permits
+    // it. Previously the count was silently rewritten to 1.
+    const none = await conn.em.find(QEntity, {
+      orderBy: { age: "ASC" } as any,
+      limit: [0, 0],
+    });
+    expect(none).toEqual([]);
+
+    const noneOffset = await conn.em.find(QEntity, {
+      orderBy: { age: "ASC" } as any,
+      limit: [5, 0],
+    });
+    expect(noneOffset).toEqual([]);
+  });
+
   // ─── orderBy ──────────────────────────────────────────
 
   it("orderBy ASC should sort in ascending order", async () => {

--- a/__tests__/unit/buffer-plugin.test.ts
+++ b/__tests__/unit/buffer-plugin.test.ts
@@ -3194,6 +3194,44 @@ describe("Buffer Plugin", () => {
 
       expect(() => buf.getReference(Ghost as any, 1)).toThrow(/not a registered entity/);
     });
+
+    it("findOne() after getReference() hydrates the stub from the DB (#365)", async () => {
+      const em = createExtendedEm(User);
+      const findOneSpy = jest.spyOn(em, "findOne").mockResolvedValue(
+        Object.assign(new User(), { id: 5, name: "Alice", email: "a@b.c" }),
+      );
+
+      const buf = em.buffer();
+
+      // Reference stub first — PK-only, non-PK fields undefined.
+      const ref = buf.getReference(User, 5);
+      expect((ref as any).name).toBeUndefined();
+
+      // findOne must NOT return the stub from the cache; it must query the DB
+      // and hydrate the same instance in place.
+      const loaded = await buf.findOne(User, { where: { id: 5 } as any });
+
+      expect(findOneSpy).toHaveBeenCalledTimes(1);   // DB was queried (not a cache hit)
+      expect(loaded).toBe(ref);                       // identity preserved
+      expect((loaded as any).name).toBe("Alice");     // stub hydrated
+      expect((ref as any).name).toBe("Alice");        // same instance, now populated
+    });
+
+    it("a second findOne() after hydration is served from the cache (#365)", async () => {
+      const em = createExtendedEm(User);
+      const findOneSpy = jest.spyOn(em, "findOne").mockResolvedValue(
+        Object.assign(new User(), { id: 9, name: "Bob", email: "b@b.c" }),
+      );
+
+      const buf = em.buffer();
+      buf.getReference(User, 9);
+
+      await buf.findOne(User, { where: { id: 9 } as any });   // hydrates → 1 DB call
+      const again = await buf.findOne(User, { where: { id: 9 } as any }); // cache hit
+
+      expect(findOneSpy).toHaveBeenCalledTimes(1);
+      expect((again as any).name).toBe("Bob");
+    });
   });
 
   describe("lazy relation proxies", () => {

--- a/__tests__/unit/entity-subscriber.test.ts
+++ b/__tests__/unit/entity-subscriber.test.ts
@@ -158,6 +158,15 @@ describe("EntitySubscriber", () => {
       em.addSubscriber(sub2);
       expect((em as any).subscribers).toHaveLength(2);
     });
+
+    it("should be idempotent — registering the same instance twice keeps one (#366)", () => {
+      const sub: EntitySubscriber<User> = { listenTo: () => User };
+
+      em.addSubscriber(sub);
+      em.addSubscriber(sub);
+
+      expect((em as any).subscribers).toHaveLength(1);
+    });
   });
 
   describe("save() — Insert path subscriber notifications", () => {
@@ -183,6 +192,22 @@ describe("EntitySubscriber", () => {
       const event: InsertEvent<User> = beforeInsertSpy.mock.calls[0][0];
       expect(event.entity).toEqual({ name: "Alice", email: "alice@test.com" });
       expect(event.manager).toBe(em);
+    });
+
+    it("should fire a re-registered subscriber only once per event (#366)", async () => {
+      const afterInsertSpy = jest.fn();
+      const sub: EntitySubscriber<User> = {
+        listenTo: () => User,
+        afterInsert: afterInsertSpy,
+      };
+
+      // Simulate a module re-init double-registering against the singleton EM.
+      em.addSubscriber(sub);
+      em.addSubscriber(sub);
+
+      await em.save(User, { name: "Dup", email: "dup@test.com" });
+
+      expect(afterInsertSpy).toHaveBeenCalledTimes(1);
     });
 
     it("should call afterInsert on matching subscriber", async () => {

--- a/src/core/EntityManager.ts
+++ b/src/core/EntityManager.ts
@@ -868,6 +868,12 @@ export class EntityManager implements BaseEntityManager {
   }
 
   addSubscriber(subscriber: EntitySubscriber<any>): void {
+    // Idempotent registration: the same subscriber instance must not fire
+    // twice. NestJS subscribers self-register in onModuleInit against the
+    // singleton EntityManager, so a module re-init (test re-bootstrap, HMR,
+    // or sharing one connection across modules) would otherwise double-register
+    // and emit duplicate notifications/audit rows.
+    if (this.subscribers.includes(subscriber)) return;
     this.subscribers.push(subscriber);
   }
 

--- a/src/core/EntityManager.ts
+++ b/src/core/EntityManager.ts
@@ -1614,7 +1614,9 @@ export class EntityManager implements BaseEntityManager {
 
       if (Array.isArray(limit)) {
         const [offset, count] = limit;
-        const effectiveCount = (take && take > 0) ? take : (count === 0 ? 1 : count);
+        // An explicit count of 0 means "no rows" (LIMIT 0); the validator
+        // permits it. Only a positive `take` overrides the tuple's count.
+        const effectiveCount = (take && take > 0) ? take : count;
         if (this.isMySqlFamily()) qb.setDatabaseType("mysql");
         qb.limit([offset, effectiveCount]);
       } else if (skip !== undefined || (take !== undefined && !limit)) {

--- a/src/core/ExplainQueryHandler.ts
+++ b/src/core/ExplainQueryHandler.ts
@@ -142,7 +142,7 @@ export class ExplainQueryHandler {
       let [offset, count] = limit;
       if (offset < 0) offset = 0;
       if (count < 0) count = 0;
-      if (count === 0) count = 1;
+      // An explicit count of 0 means LIMIT 0; only a positive `take` overrides it.
       if (take && take > 0) count = take;
       qb.limit([offset, count]);
     } else if (skip !== undefined || (take !== undefined && !limit)) {

--- a/src/core/plugin/buffer/WriteBuffer.ts
+++ b/src/core/plugin/buffer/WriteBuffer.ts
@@ -41,6 +41,10 @@ import type { EntityManager } from "../../EntityManager";
  */
 export class WriteBuffer {
   private readonly trackedEntries = new Map<any, TrackedEntry>();
+  // PK-only stubs created by getReference(): registered in the identity map but
+  // NOT yet hydrated. findOne() must treat a stub as a cache miss and load it
+  // from the DB (then hydrate it in place) instead of returning the stub.
+  private readonly referenceStubs = new WeakSet<object>();
   private readonly insertQueue: InsertEntry[] = [];
   private readonly deleteQueue: DeleteEntry[] = [];
   private readonly persistQueue: PersistEntry[] = [];
@@ -190,7 +194,9 @@ export class WriteBuffer {
       const cacheKey = this.idMap.tryBuildCacheKey(entity, option);
       if (cacheKey !== null) {
         const cached = this.idMap.identityMap.get(cacheKey);
-        if (cached) {
+        // A reference stub (getReference) is PK-only and not hydrated, so it is
+        // NOT a valid cache hit — fall through to the DB load, which hydrates it.
+        if (cached && !this.referenceStubs.has(cached)) {
           this.idMap.touch(cacheKey);
           await this.autoFlushIfNeeded();
           if (this.options.logging) {
@@ -277,9 +283,12 @@ export class WriteBuffer {
       return existing as T;
     }
 
-    // Register in identity map (not snapshot-tracked — reference only)
+    // Register in identity map (not snapshot-tracked — reference only).
+    // Mark it as a reference stub so a later findOne() hydrates it from the DB
+    // rather than returning the PK-only instance from the first-level cache.
     this.idMap.identityMap.set(key, instance);
     this.idMap.stateMap.set(instance, EntityState.MANAGED);
+    this.referenceStubs.add(instance);
     this.idMap.evictIfNeeded();
 
     // Inject lazy proxies for relation properties
@@ -1221,12 +1230,38 @@ export class WriteBuffer {
     const existing = this.idMap.identityMap.get(key);
     if (existing) {
       this.idMap.touch(key);
+      // If the mapped instance is an unhydrated getReference() stub, populate
+      // it in place from the freshly loaded row and promote it to a fully
+      // tracked entity — preserving identity for any FK references already
+      // pointing at the stub.
+      if (existing !== instance && this.referenceStubs.has(existing)) {
+        this.hydrateReference(entityClass, existing, instance);
+      }
       return existing;
     }
 
     this.track(instance);
     this.lazyInjector.injectLazyRelations(instance, entityClass);
     return instance;
+  }
+
+  /**
+   * Copies the column values from a freshly loaded row into an existing
+   * getReference() stub, clears its reference mark, and snapshot-tracks it so
+   * subsequent dirty-checking works. Relation properties keep their lazy
+   * proxies (only column values are copied).
+   */
+  private hydrateReference(
+    entityClass: ClazzType<any>,
+    stub: any,
+    loaded: any,
+  ): void {
+    const { columnNames } = this.idMap.getColumnInfo(entityClass);
+    for (const col of columnNames) {
+      stub[col] = loaded[col];
+    }
+    this.referenceStubs.delete(stub);
+    this.track(stub);
   }
 
   /**


### PR DESCRIPTION
## Summary

Three core `@stingerloom/orm` correctness fixes, one commit each, each closing its own issue. All were found in the codebase audit (#355–366) and reproduced with tests before fixing.

| Commit | Issue | Fix |
|--------|-------|-----|
| `ffd3c53` | #364 | The limit-tuple path rewrote a deliberate count of `0` to `1` (`count === 0 ? 1 : count`), so `find(E, { limit: [10, 0] })` returned one row instead of `[]`. The validator permits count `0`, so a zero-size page must return no rows. `ExplainQueryHandler` had the same rewrite. |
| `3759d5b` | #366 | `EntityManager.addSubscriber` was a bare push with no identity check. NestJS subscribers self-register in `onModuleInit` against the singleton EM, so a module re-init (test re-bootstrap, HMR, shared connection) double-registered the same instance and fired duplicate notifications/audit rows. Now idempotent. |
| `64222d1` | #365 | `getReference()` registers a PK-only stub in the identity map; a later `findOne({where:{id}})` hit the first-level cache and returned that stub **without** querying the DB (non-PK fields `undefined`). `findOne` now treats a stub as a miss, loads from the DB, and hydrates the stub in place — preserving identity for FK references already pointing at it. |

## Tests

- **#364:** SQLite integration — `limit [0,0]` and `[5,0]` return `[]`.
- **#366:** unit — double-registration keeps one entry and fires `afterInsert` exactly once per event.
- **#365:** unit — `getReference()` then `findOne()` queries the DB and returns a fully-hydrated entity with preserved identity; a second `findOne()` is a cache hit.
- Full unit suite: 4900 passed, 0 failures. `tsc --noEmit` clean.

Closes #364
Closes #365
Closes #366
