### PR TITLE
fix(query-builder): unwrap column/expression operands in DSL comparisons

### DIFF
--- a/__tests__/unit/qdsl-column-comparison.test.ts
+++ b/__tests__/unit/qdsl-column-comparison.test.ts
@@ -1,0 +1,255 @@
+import "reflect-metadata";
+import { SelectQueryBuilder, qAlias } from "../../src/core/SelectQueryBuilder";
+import { Entity, PrimaryGeneratedColumn, Column } from "../../src/decorators";
+import { EntityManager } from "../../src/core/EntityManager";
+import { RelationMetadataResolver } from "../../src/core/RelationMetadataResolver";
+import { createDialectExpression } from "../../src/dialects/DialectExpression";
+
+@Entity()
+class Order {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @Column({ type: "int" })
+  price!: number;
+
+  @Column({ type: "int" })
+  cost!: number;
+
+  @Column({ type: "int" })
+  floorPrice!: number;
+
+  @Column({ type: "int" })
+  ceilingPrice!: number;
+
+  @Column({ type: "varchar", length: 50 })
+  status!: string;
+
+  @Column({ type: "varchar", length: 50 })
+  previousStatus!: string;
+}
+
+type DbType = "mysql" | "postgresql";
+
+function createQb(dbType: DbType = "postgresql") {
+  const resolver = new RelationMetadataResolver();
+  const wrap = (col: string) =>
+    dbType === "mysql"
+      ? `\`${col.replace(/`/g, "``")}\``
+      : `"${col.replace(/"/g, '""')}"`;
+  const em = {
+    wrap,
+    wrapTable: (t: string) => wrap(t),
+    resolver,
+    _ctx: {
+      isMySqlFamily: () => dbType === "mysql",
+      isPostgres: () => dbType === "postgresql",
+      isSqlite: () => false,
+      getDialect: () => (dbType === "mysql" ? "mysql" : "postgresql"),
+    },
+  } as unknown as EntityManager;
+  const qb = new SelectQueryBuilder<Order>(Order, "o", em);
+  const meta = resolver.resolveEntityMetadata(Order);
+  const map = new Map<string, string>();
+  for (const c of meta!.columns) {
+    map.set((c as any).propertyKey ?? c.name!, c.name!);
+  }
+  qb.setPropertyToColumnMap(map);
+  qb.setDialectExpression(
+    createDialectExpression(dbType === "mysql" ? "mysql" : "postgres"),
+  );
+  return qb;
+}
+
+describe("QueryDSL column-to-column comparison (ColumnExpression RHS)", () => {
+  it("eq against another column splices the reference, binds nothing", () => {
+    const qb = createQb();
+    const o = qAlias(Order, "o");
+    qb.where(o.price.eq(o.cost));
+    const { text, values } = qb.getSql();
+    expect(text).toContain(`WHERE "o"."price" = "o"."cost"`);
+    expect(values).toEqual([]);
+  });
+
+  it.each(["neq", "gt", "gte", "lt", "lte"] as const)(
+    "%s against another column binds nothing",
+    (method) => {
+      const qb = createQb();
+      const o = qAlias(Order, "o");
+      qb.where((o.price as any)[method](o.cost));
+      const { values } = qb.getSql();
+      expect(values).toEqual([]);
+    },
+  );
+
+  it("gt renders the comparison operator between two column refs", () => {
+    const qb = createQb();
+    const o = qAlias(Order, "o");
+    qb.where(o.price.gt(o.cost));
+    const { text } = qb.getSql();
+    expect(text).toContain(`"o"."price" > "o"."cost"`);
+  });
+
+  it("between with two column bounds binds nothing", () => {
+    const qb = createQb();
+    const o = qAlias(Order, "o");
+    qb.where(o.price.between(o.floorPrice, o.ceilingPrice));
+    const { text, values } = qb.getSql();
+    expect(text).toContain(
+      `"o"."price" BETWEEN "o"."floorPrice" AND "o"."ceilingPrice"`,
+    );
+    expect(values).toEqual([]);
+  });
+
+  it("between mixes a column bound with a literal bound", () => {
+    const qb = createQb();
+    const o = qAlias(Order, "o");
+    qb.where(o.price.between(o.floorPrice, 100));
+    const { text, values } = qb.getSql();
+    expect(text).toMatch(/"o"\."price" BETWEEN "o"\."floorPrice" AND \?/);
+    expect(values).toEqual([100]);
+  });
+
+  it("IN mixes a column reference with bound literals", () => {
+    const qb = createQb();
+    const o = qAlias(Order, "o");
+    qb.where(o.status.in([o.previousStatus, "draft"]));
+    const { text, values } = qb.getSql();
+    expect(text).toMatch(/"o"\."status" IN \("o"\."previousStatus", \?\)/);
+    expect(values).toEqual(["draft"]);
+  });
+
+  it("NOT IN mixes a column reference with bound literals", () => {
+    const qb = createQb();
+    const o = qAlias(Order, "o");
+    qb.where(o.status.notIn([o.previousStatus, "draft"]));
+    const { text, values } = qb.getSql();
+    expect(text).toMatch(/"o"\."status" NOT IN \("o"\."previousStatus", \?\)/);
+    expect(values).toEqual(["draft"]);
+  });
+
+  it("column operand is wrapped in the MySQL identifier quoting", () => {
+    const qb = createQb("mysql");
+    const o = qAlias(Order, "o");
+    qb.where(o.price.gt(o.cost));
+    const { text, values } = qb.getSql();
+    expect(text).toContain("`o`.`price` > `o`.`cost`");
+    expect(values).toEqual([]);
+  });
+
+  it("column operand resolves through the alias/naming registry", () => {
+    const qb = createQb();
+    // Simulate a snake-case naming strategy mapping.
+    qb.setPropertyToColumnMap(
+      new Map<string, string>([
+        ["price", "price"],
+        ["floorPrice", "floor_price"],
+        ["ceilingPrice", "ceiling_price"],
+      ]),
+    );
+    const o = qAlias(Order, "o");
+    qb.where(o.price.between(o.floorPrice, o.ceilingPrice));
+    const { text } = qb.getSql();
+    expect(text).toContain(
+      `"o"."price" BETWEEN "o"."floor_price" AND "o"."ceiling_price"`,
+    );
+  });
+});
+
+describe("QueryDSL scalar-to-column comparison (ScalarCondition RHS)", () => {
+  it("scalar expression compared against a column binds only the scalar arg", () => {
+    const qb = createQb();
+    const o = qAlias(Order, "o");
+    qb.where(o.price.mul(2).gt(o.cost));
+    const { text, values } = qb.getSql();
+    expect(text).toContain(`("o"."price" * ?) > "o"."cost"`);
+    expect(values).toEqual([2]);
+  });
+
+  it("scalar BETWEEN with column bounds binds only the scalar arg", () => {
+    const qb = createQb();
+    const o = qAlias(Order, "o");
+    qb.where(o.price.add(1).between(o.floorPrice, o.ceilingPrice));
+    const { text, values } = qb.getSql();
+    expect(text).toContain(
+      `("o"."price" + ?) BETWEEN "o"."floorPrice" AND "o"."ceilingPrice"`,
+    );
+    expect(values).toEqual([1]);
+  });
+
+  it("scalar IN mixes a column reference with a bound literal", () => {
+    const qb = createQb();
+    const o = qAlias(Order, "o");
+    qb.where(o.price.add(1).in([o.cost, 5]));
+    const { text, values } = qb.getSql();
+    expect(text).toMatch(/\("o"\."price" \+ \?\) IN \("o"\."cost", \?\)/);
+    expect(values).toEqual([1, 5]);
+  });
+
+  it("scalar compared against another scalar inlines both sides", () => {
+    const qb = createQb();
+    const o = qAlias(Order, "o");
+    qb.where(o.price.mul(2).gt(o.cost.add(1)));
+    const { text, values } = qb.getSql();
+    expect(text).toContain(`("o"."price" * ?) > ("o"."cost" + ?)`);
+    expect(values).toEqual([2, 1]);
+  });
+});
+
+describe("QueryDSL aggregate-to-aggregate comparison (AggregateCondition RHS)", () => {
+  it("HAVING relates two aggregates without binding either", () => {
+    const qb = createQb();
+    const o = qAlias(Order, "o");
+    qb.groupBy(["o.status"]).having(o.price.sum().gt(o.cost.sum()));
+    const { text, values } = qb.getSql();
+    expect(text).toContain(`HAVING SUM("o"."price") > SUM("o"."cost")`);
+    expect(values).toEqual([]);
+  });
+
+  it("HAVING compares an aggregate against a grouped column", () => {
+    const qb = createQb();
+    const o = qAlias(Order, "o");
+    qb.groupBy(["o.price"]).having(o.cost.max().lte(o.price));
+    const { text, values } = qb.getSql();
+    expect(text).toContain(`HAVING MAX("o"."cost") <= "o"."price"`);
+    expect(values).toEqual([]);
+  });
+
+  it("aggregate compared against a literal is still bound", () => {
+    const qb = createQb();
+    const o = qAlias(Order, "o");
+    qb.groupBy(["o.status"]).having(o.id.count().gt(10));
+    const { text, values } = qb.getSql();
+    expect(text).toMatch(/HAVING COUNT\("o"\."id"\) > \?/);
+    expect(values).toEqual([10]);
+  });
+});
+
+describe("QueryDSL comparison — literal RHS regression", () => {
+  it("primitive RHS is still bound as a parameter (ColumnExpression)", () => {
+    const qb = createQb();
+    const o = qAlias(Order, "o");
+    qb.where(o.price.gt(50));
+    const { text, values } = qb.getSql();
+    expect(text).toMatch(/"o"\."price" > \?/);
+    expect(values).toEqual([50]);
+  });
+
+  it("primitive IN list is still fully bound", () => {
+    const qb = createQb();
+    const o = qAlias(Order, "o");
+    qb.where(o.status.in(["a", "b"]));
+    const { text, values } = qb.getSql();
+    expect(text).toMatch(/"o"\."status" IN \(\?, \?\)/);
+    expect(values).toEqual(["a", "b"]);
+  });
+
+  it("primitive RHS is still bound as a parameter (ScalarCondition)", () => {
+    const qb = createQb();
+    const o = qAlias(Order, "o");
+    qb.where(o.price.add(1).eq(10));
+    const { text, values } = qb.getSql();
+    expect(text).toContain(`("o"."price" + ?) = ?`);
+    expect(values).toEqual([1, 10]);
+  });
+});

--- a/docs/ko/query-builder-querydsl.md
+++ b/docs/ko/query-builder-querydsl.md
@@ -116,6 +116,42 @@ function buildIssueQuery(sortField: string) {
 
 여기서부터는 `qAlias()`가 돌려주는 컬럼 참조로 할 수 있는 것들을 하나씩 정리합니다. 모든 예제는 동일한 두 가지 약속을 지킵니다. 컬럼 참조는 별칭 레지스트리를 통해 해석되고, 사용자 값은 전부 파라미터 바인딩으로 들어갑니다.
 
+## 다른 컬럼·표현식과 비교하기
+
+비교 메서드는 리터럴만 받는 게 아닙니다. 오른쪽 피연산자가 또 다른 `ColumnExpression`이거나 거기서 파생된 `ScalarExpression`이면, 파라미터로 바인딩되지 않고 **컬럼 참조**로 그대로 삽입됩니다. 한 행의 두 컬럼을 서로 비교하는 조건을 이렇게 표현합니다.
+
+```typescript
+const o = qAlias(Order, "o");
+
+qb.where(o.price.gt(o.cost));
+// WHERE "o"."price" > "o"."cost"
+
+qb.where(o.startDate.lt(o.endDate));
+// WHERE "o"."start_date" < "o"."end_date"
+
+qb.where(o.price.between(o.floorPrice, o.ceilingPrice));
+// WHERE "o"."price" BETWEEN "o"."floor_price" AND "o"."ceiling_price"
+```
+
+반대 방향도 마찬가지입니다. 파생 스칼라를 컬럼과 비교할 수 있어서 산술과 컬럼 참조를 자유롭게 섞을 수 있습니다.
+
+```typescript
+qb.where(o.price.mul(2).gt(o.cost));
+// WHERE ("o"."price" * $1) > "o"."cost"   -- $1 = 2
+
+qb.where(o.price.coalesce(0).gte(o.minimum));
+// WHERE COALESCE("o"."price", $1) >= "o"."minimum"
+```
+
+`IN` 목록에는 컬럼과 리터럴을 섞을 수 있고, 리터럴만 바인딩됩니다.
+
+```typescript
+qb.where(o.status.in([o.previousStatus, "draft"]));
+// WHERE "o"."status" IN ("o"."previous_status", $1)   -- $1 = "draft"
+```
+
+평범한 JavaScript 값은 그대로 파라미터 바인딩을 유지합니다. `o.price.gt(50)`은 여전히 `> $1`을 냅니다. 표현식 피연산자(컬럼, 스칼라, 집계)만 인라인되며, 이들은 별칭 레지스트리를 통해 해석되므로 네이밍 전략 변환이 그대로 적용되고 인젝션 위험도 없습니다.
+
 ## 정렬 — `.asc()` / `.desc()` / `.nullsFirst()` / `.nullsLast()`
 
 정렬 방향을 메서드로 씁니다.
@@ -154,7 +190,7 @@ await em.createQueryBuilder(User, "u")
   .getRawMany();
 ```
 
-핵심은 `const total = u.id.count()`로 만든 표현식을 **SELECT에도 넣고 HAVING 조건으로도 그대로 쓴다**는 점입니다. 같은 COUNT를 두 번 적지 않아도 돼요. 비교 메서드는 조건을 쓸 때와 똑같이 `.eq`, `.gt`, `.lt`, `.between` 전부 달려 있습니다.
+핵심은 `const total = u.id.count()`로 만든 표현식을 **SELECT에도 넣고 HAVING 조건으로도 그대로 쓴다**는 점입니다. 같은 COUNT를 두 번 적지 않아도 돼요. 비교 메서드는 조건을 쓸 때와 똑같이 `.eq`, `.gt`, `.lt`, `.between` 전부 달려 있습니다. 오른쪽 피연산자로 또 다른 집계나 그룹 컬럼을 넘길 수도 있어서 `o.revenue.sum().gt(o.cost.sum())`은 바인딩 없이 `HAVING SUM("o"."revenue") > SUM("o"."cost")`를 냅니다.
 
 SELECT에 넣을 때 `.as("total")`을 권장합니다. 생략하면 `agg_count_id` 같은 이름이 자동으로 붙는데, `getRawMany()`로 꺼낼 때 키 이름이 헷갈리기 쉬워요.
 
@@ -379,7 +415,7 @@ qb.select([exp.currentDate().as("today")]);
 // SELECT CURRENT_DATE AS "today"
 ```
 
-비교 메서드에 스칼라 표현식을 넘기면 파라미터 바인딩이 아니라 SQL 안에 직접 삽입됩니다. 그래서 `u.createdAt.lte(currentTimestamp())`처럼 써도 바인딩이 아니라 `CURRENT_TIMESTAMP` 그대로 쿼리에 박혀요.
+비교 메서드에 스칼라 표현식을 넘기면 파라미터 바인딩이 아니라 SQL 안에 직접 삽입됩니다. 그래서 `u.createdAt.lte(currentTimestamp())`처럼 써도 바인딩이 아니라 `CURRENT_TIMESTAMP` 그대로 쿼리에 박혀요. 컬럼 피연산자에도 똑같이 적용됩니다([다른 컬럼·표현식과 비교하기](#다른-컬럼표현식과-비교하기) 참고).
 
 ## 타입 변환 — `.stringValue()` / `.intValue()` / `.longValue()` / `.floatValue()` / `.booleanValue()`
 

--- a/docs/query-builder-querydsl.md
+++ b/docs/query-builder-querydsl.md
@@ -116,6 +116,49 @@ Both bypass TypeScript's keyof-narrowing for the property name, so the safety gu
 
 The rest of this page walks through what you can do with those column references. Two guarantees hold throughout: column references resolve through the alias registry (so naming-strategy translation always applies), and every user-supplied value — including LIKE escape characters — is a bound parameter.
 
+## Comparing against another column or expression
+
+Comparison methods accept more than literals. When the right-hand side is
+another `ColumnExpression` — or any derived `ScalarExpression` — it is
+spliced in as a **column reference**, not bound as a parameter. This is how
+you express predicates that relate two columns of the same row:
+
+```typescript
+const o = qAlias(Order, "o");
+
+qb.where(o.price.gt(o.cost));
+// WHERE "o"."price" > "o"."cost"
+
+qb.where(o.startDate.lt(o.endDate));
+// WHERE "o"."start_date" < "o"."end_date"
+
+qb.where(o.price.between(o.floorPrice, o.ceilingPrice));
+// WHERE "o"."price" BETWEEN "o"."floor_price" AND "o"."ceiling_price"
+```
+
+The same holds the other way round — a derived scalar can be compared
+against a column, so arithmetic and column references mix freely:
+
+```typescript
+qb.where(o.price.mul(2).gt(o.cost));
+// WHERE ("o"."price" * $1) > "o"."cost"   -- $1 = 2
+
+qb.where(o.price.coalesce(0).gte(o.minimum));
+// WHERE COALESCE("o"."price", $1) >= "o"."minimum"
+```
+
+`IN` lists may mix columns and literals; only the literals are bound:
+
+```typescript
+qb.where(o.status.in([o.previousStatus, "draft"]));
+// WHERE "o"."status" IN ("o"."previous_status", $1)   -- $1 = "draft"
+```
+
+Plain JavaScript values keep their parameter binding — `o.price.gt(50)`
+still emits `> $1`. Only expression operands (columns, scalars, aggregates)
+are inlined, and those resolve through the alias registry, so naming-strategy
+translation still applies and there is no injection surface.
+
 ## Ordering — `.asc()` / `.desc()` / `.nullsFirst()` / `.nullsLast()`
 
 ```typescript
@@ -162,7 +205,9 @@ that plays two roles:
 2. **In HAVING / WHERE.** Calling `.eq`, `.neq`, `.gt`, `.gte`, `.lt`,
    `.lte`, or `.between` on the aggregate produces an
    `AggregateCondition`, which can be passed to `having()`, `where()`,
-   or `andWhere()`.
+   or `andWhere()`. The right-hand side may be another aggregate or a
+   grouped column — `o.revenue.sum().gt(o.cost.sum())` emits
+   `HAVING SUM("o"."revenue") > SUM("o"."cost")` with nothing bound.
 
 Aggregates also participate in ORDER BY via `.asc()` / `.desc()`, mirroring
 the ColumnExpression surface.
@@ -307,10 +352,11 @@ qb.select([exp.currentDate().as("today")]);
 // SELECT CURRENT_DATE AS "today"
 ```
 
-`ColumnExpression` comparison methods now transparently unwrap a
-`ScalarExpression` operand — so `u.createdAt.lte(currentTimestamp())`
-emits an inline `CURRENT_TIMESTAMP` rather than binding the expression
-as a parameter.
+Comparison methods transparently unwrap a `ScalarExpression` operand — so
+`u.createdAt.lte(currentTimestamp())` emits an inline `CURRENT_TIMESTAMP`
+rather than binding the expression as a parameter. The same unwrapping
+applies to column operands (see [Comparing against another column or
+expression](#comparing-against-another-column-or-expression)).
 
 ## Type casts — `.stringValue()` / `.intValue()` / `.longValue()` / `.floatValue()` / `.booleanValue()`
 

--- a/src/core/SelectQueryBuilder.ts
+++ b/src/core/SelectQueryBuilder.ts
@@ -416,6 +416,16 @@ export class ColumnCondition implements ConditionLike {
     if (
       value !== null &&
       typeof value === "object" &&
+      (value as { __isColumnExpression?: unknown }).__isColumnExpression === true
+    ) {
+      // Another DSL column (e.g. `o.price.gt(o.cost)`) — splice its
+      // qualified identifier so it is compared as a column reference,
+      // not bound as a parameter object.
+      return raw(resolveColumn((value as { toString(): string }).toString()));
+    }
+    if (
+      value !== null &&
+      typeof value === "object" &&
       typeof (value as { toSql?: unknown }).toSql === "function" &&
       typeof (value as { getSql?: unknown }).getSql === "function"
     ) {
@@ -463,13 +473,23 @@ export class ColumnCondition implements ConditionLike {
           const sub = (this.value as { toSql(): Sql }).toSql();
           return sql`${raw(qualified)} IN (${sub})`;
         }
-        return Conditions.in(qualified, value as unknown[]);
+        return Conditions.in(
+          qualified,
+          (this.value as unknown[]).map((v) =>
+            this.resolveValue(v, resolveColumn, dialect),
+          ),
+        );
       case "NOT IN":
         if (this.value !== null && this.isSubqueryLike(this.value)) {
           const sub = (this.value as { toSql(): Sql }).toSql();
           return sql`${raw(qualified)} NOT IN (${sub})`;
         }
-        return Conditions.notIn(qualified, value as unknown[]);
+        return Conditions.notIn(
+          qualified,
+          (this.value as unknown[]).map((v) =>
+            this.resolveValue(v, resolveColumn, dialect),
+          ),
+        );
       case "IS NULL":
         return Conditions.isNull(qualified);
       case "IS NOT NULL":

--- a/src/core/expressions/AggregateExpression.ts
+++ b/src/core/expressions/AggregateExpression.ts
@@ -388,19 +388,43 @@ export class AggregateCondition implements ConditionLike {
   resolve(resolveColumn: ColumnResolver, dialect?: DialectExpression): Sql {
     const fn = this.aggregate.renderFunction(resolveColumn, dialect);
     const op = this.operator;
+    // Unwrap an expression operand on the right-hand side so a HAVING
+    // clause can relate two aggregates (`SUM(revenue) > SUM(cost)`) or
+    // compare an aggregate against a grouped column. Plain primitives
+    // stay bound as parameters.
+    const rhs = (v: unknown): Sql => {
+      if (v !== null && typeof v === "object") {
+        const marker = v as Record<string, unknown>;
+        if (marker.__isAggregateExpression === true) {
+          return (v as AggregateExpression).renderFunction(
+            resolveColumn,
+            dialect,
+          );
+        }
+        if (marker.__isScalarExpression === true) {
+          return (v as ScalarExpression).renderer(resolveColumn, dialect);
+        }
+        if (marker.__isColumnExpression === true) {
+          return sql`${raw(
+            resolveColumn((v as { toString(): string }).toString()),
+          )}`;
+        }
+      }
+      return sql`${v as any}`;
+    };
 
     if (op === "BETWEEN") {
       const [min, max] = this.value as [any, any];
-      return sql`${fn} BETWEEN ${min} AND ${max}`;
+      return sql`${fn} BETWEEN ${rhs(min)} AND ${rhs(max)}`;
     }
 
     if (Array.isArray(this.value) && (op === "IN" || op === "NOT IN")) {
       const values = this.value as any[];
-      const placeholders = values.map((v) => sql`${v}`);
+      const placeholders = values.map((v) => rhs(v));
       return sql`${fn} ${raw(op)} (${join(placeholders, ", ")})`;
     }
 
-    return sql`${fn} ${raw(op)} ${this.value}`;
+    return sql`${fn} ${raw(op)} ${rhs(this.value)}`;
   }
 
   /** Compose with another condition using AND (LogicalCondition). */

--- a/src/core/expressions/ScalarExpression.ts
+++ b/src/core/expressions/ScalarExpression.ts
@@ -483,22 +483,27 @@ export class ScalarCondition implements ConditionLike {
   resolve(resolveColumn: ColumnResolver, dialect?: DialectExpression): Sql {
     const expr = this.expression.renderer(resolveColumn, dialect);
     const op = this.operator;
+    // Unwrap any column / scalar expression on the right-hand side so
+    // `u.price.mul(2).gt(u.cost)` compares against the column reference
+    // instead of binding the expression object as a parameter. Plain
+    // primitives still flow through `sql` as bound parameters.
+    const rhs = (v: unknown) => renderArg(v, resolveColumn, dialect);
 
     if (op === "IS NULL") return sql`${expr} IS NULL`;
     if (op === "IS NOT NULL") return sql`${expr} IS NOT NULL`;
     if (op === "BETWEEN") {
       const [min, max] = this.value as [any, any];
-      return sql`${expr} BETWEEN ${min} AND ${max}`;
+      return sql`${expr} BETWEEN ${rhs(min)} AND ${rhs(max)}`;
     }
     if (op === "IN" || op === "NOT IN") {
       const values = (this.value as any[]) ?? [];
       if (values.length === 0) {
         return op === "IN" ? sql`1 = 0` : sql`1 = 1`;
       }
-      const placeholders = values.map((v) => sql`${v}`);
+      const placeholders = values.map((v) => rhs(v));
       return sql`${expr} ${raw(op)} (${join(placeholders, ", ")})`;
     }
-    return sql`${expr} ${raw(op)} ${this.value as any}`;
+    return sql`${expr} ${raw(op)} ${rhs(this.value)}`;
   }
 
   /** Compose with another condition using AND. */


### PR DESCRIPTION
## Problem

qAlias comparison methods bound an expression right-hand side as a parameter object instead of splicing it as a column reference, so predicates relating two columns produced broken SQL:

- `o.price.gt(o.cost)` produced `"price" > ?` with the `ColumnExpression` bound as a parameter object
- `o.price.between(o.lo, o.hi)` bound both bounds as objects
- `o.price.mul(2).gt(o.cost)` — `ScalarCondition` never unwrapped its RHS at all
- `o.revenue.sum().gt(o.cost.sum())` — `AggregateCondition` had the same gap in HAVING

Only `ScalarExpression` operands (e.g. `currentTimestamp()`) were unwrapped, so column-to-column comparisons silently failed — an inconsistency given `u.a.eq(u.b.trim())` worked but `u.a.eq(u.b)` did not.

## Fix

Unwrap `ColumnExpression` / `ScalarExpression` / `AggregateExpression` operands across `ColumnCondition`, `ScalarCondition`, and `AggregateCondition` so they render as identifiers resolved through the alias registry (naming-strategy aware, no injection surface). Plain JavaScript values still bind as parameters. `IN`/`NOT IN` lists now unwrap per element, so columns and literals can be mixed.

```ts
const o = qAlias(Order, "o");
qb.where(o.price.gt(o.cost));                       // WHERE "o"."price" > "o"."cost"
qb.where(o.price.between(o.floorPrice, o.ceiling)); // BETWEEN "o"."floor_price" AND ...
qb.where(o.status.in([o.previousStatus, "draft"])); // IN ("o"."previous_status", $1)
qb.having(o.revenue.sum().gt(o.cost.sum()));        // HAVING SUM(...) > SUM(...)
```

## Tests

- 23 new regression tests in `__tests__/unit/qdsl-column-comparison.test.ts` (PostgreSQL + MySQL; column/scalar/aggregate RHS; literal-binding regressions)
- Full unit suite: 5331 passed, 0 failures
- tsc CJS + ESM type-check clean

## Docs

- New "Comparing against another column or expression" section in the QueryDSL guide (en + ko)
- Aggregate-to-aggregate comparison note in the aggregates section