### PR TITLE
fix(query-builder): normalize neq(null)/neq(array) to IS NOT NULL / NOT IN

### DIFF
--- a/__tests__/unit/qdsl-neq-null-array.test.ts
+++ b/__tests__/unit/qdsl-neq-null-array.test.ts
@@ -1,0 +1,170 @@
+import "reflect-metadata";
+import {
+  ColumnCondition,
+  SelectQueryBuilder,
+} from "../../src/core/SelectQueryBuilder";
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  DeletedAt,
+} from "../../src/decorators";
+import { EntityManager } from "../../src/core/EntityManager";
+import { RelationMetadataResolver } from "../../src/core/RelationMetadataResolver";
+
+/**
+ * Regression tests for `.neq()` / `.eq()` null & array normalization.
+ *
+ * The `=` operator already rewrote `null` → `IS NULL` and arrays → `IN (...)`,
+ * but the `!=` / `<>` operators did not — so `.neq(null)` silently produced
+ * `col != NULL` (always UNKNOWN → matches nothing) and `.neq([...])` produced a
+ * malformed `col != (array)` instead of `NOT IN (...)`. These tests lock in the
+ * symmetric rewrite across both the QueryDSL (`ColumnCondition`) path and the
+ * explicit string-operator `where(col, op, value)` path.
+ */
+
+const resolve = (ref: string): string => {
+  if (!ref.includes(".")) return `"${ref}"`;
+  const [a, c] = ref.split(".");
+  return `"${a}"."${c}"`;
+};
+
+describe("QueryDSL ColumnCondition — null & array normalization", () => {
+  describe("not-equals with null → IS NOT NULL", () => {
+    it("neq(null) emits IS NOT NULL, not '!= NULL'", () => {
+      const r = new ColumnCondition("u.deletedAt", "!=", null).resolve(resolve);
+      expect(r.sql).toBe(`"u"."deletedAt" IS NOT NULL`);
+      expect(r.values).toEqual([]);
+    });
+
+    it("the '<>' alias also emits IS NOT NULL", () => {
+      const r = new ColumnCondition("u.deletedAt", "<>", null).resolve(resolve);
+      expect(r.sql).toBe(`"u"."deletedAt" IS NOT NULL`);
+      expect(r.values).toEqual([]);
+    });
+
+    it("eq(null) still emits IS NULL (unchanged, kept symmetric)", () => {
+      const r = new ColumnCondition("u.deletedAt", "=", null).resolve(resolve);
+      expect(r.sql).toBe(`"u"."deletedAt" IS NULL`);
+      expect(r.values).toEqual([]);
+    });
+  });
+
+  describe("not-equals with array → NOT IN", () => {
+    it("neq([...]) emits NOT IN (...)", () => {
+      const r = new ColumnCondition("u.status", "!=", ["a", "b"]).resolve(
+        resolve,
+      );
+      expect(r.sql).toBe(`"u"."status" NOT IN (?, ?)`);
+      expect(r.values).toEqual(["a", "b"]);
+    });
+
+    it("eq([...]) still emits IN (...) (unchanged, kept symmetric)", () => {
+      const r = new ColumnCondition("u.status", "=", ["a", "b"]).resolve(
+        resolve,
+      );
+      expect(r.sql).toBe(`"u"."status" IN (?, ?)`);
+      expect(r.values).toEqual(["a", "b"]);
+    });
+
+    it("neq([]) excludes nothing (1 = 1), mirroring Conditions.notIn", () => {
+      const r = new ColumnCondition("u.status", "!=", []).resolve(resolve);
+      expect(r.sql).toBe(`1 = 1`);
+    });
+
+    it("eq([]) matches nothing (1 = 0), mirroring Conditions.in", () => {
+      const r = new ColumnCondition("u.status", "=", []).resolve(resolve);
+      expect(r.sql).toBe(`1 = 0`);
+    });
+  });
+
+  describe("scalar not-equals is unchanged", () => {
+    it("neq(scalar) still emits '!= ?' with a bound param", () => {
+      const r = new ColumnCondition("u.status", "!=", "active").resolve(resolve);
+      expect(r.sql).toBe(`"u"."status" != ?`);
+      expect(r.values).toEqual(["active"]);
+    });
+  });
+});
+
+@Entity()
+class NullUser {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @Column({ type: "varchar", length: 50 })
+  status!: string;
+
+  @DeletedAt()
+  deletedAt!: Date | null;
+}
+
+function createMockEm(dbType: "mysql" | "postgresql" = "mysql") {
+  const resolver = new RelationMetadataResolver();
+  function wrap(col: string) {
+    return dbType === "mysql"
+      ? `\`${col.replace(/`/g, "``")}\``
+      : `"${col.replace(/"/g, '""')}"`;
+  }
+  const em = {
+    wrap,
+    wrapTable: (t: string) => wrap(t),
+    resolver,
+    _ctx: {
+      isMySqlFamily: () => dbType === "mysql",
+      isPostgres: () => dbType === "postgresql",
+      isSqlite: () => false,
+    },
+    async query<T>(): Promise<T[]> {
+      return [] as T[];
+    },
+    createQueryBuilder(entity: any, alias: string) {
+      const qb = new SelectQueryBuilder(entity, alias, em as any);
+      const meta = resolver.resolveEntityMetadata(entity);
+      if (meta) {
+        const map = new Map<string, string>();
+        for (const col of meta.columns) {
+          map.set((col as any).propertyKey ?? col.name!, col.name!);
+        }
+        qb.setPropertyToColumnMap(map);
+      }
+      return qb;
+    },
+  } as unknown as EntityManager;
+  return em;
+}
+
+describe("SelectQueryBuilder.where(col, op, null) — explicit operator path", () => {
+  it("where(col, '!=', null) rewrites to IS NOT NULL", () => {
+    const em = createMockEm("mysql");
+    const { text, values } = em
+      .createQueryBuilder(NullUser, "u")
+      .where("deletedAt", "!=", null)
+      .getSql();
+
+    expect(text).toContain("IS NOT NULL");
+    expect(text).not.toContain("!= NULL");
+    expect(values).not.toContain(null);
+  });
+
+  it("where(col, '<>', null) rewrites to IS NOT NULL", () => {
+    const em = createMockEm("mysql");
+    const { text } = em
+      .createQueryBuilder(NullUser, "u")
+      .where("deletedAt", "<>", null)
+      .getSql();
+
+    expect(text).toContain("IS NOT NULL");
+  });
+
+  it("where(col, '=', null) rewrites to IS NULL (matches two-arg shorthand)", () => {
+    const em = createMockEm("mysql");
+    const { text } = em
+      .createQueryBuilder(NullUser, "u")
+      .where("deletedAt", "=", null)
+      .getSql();
+
+    expect(text).toContain("IS NULL");
+    expect(text).not.toContain("= NULL");
+  });
+});

--- a/docs/ko/query-builder-joins.md
+++ b/docs/ko/query-builder-joins.md
@@ -65,6 +65,13 @@ const posts = await em
 | `.isNotNull()` | `IS NOT NULL` | `u.email.isNotNull()` |
 | `.between(min, max)` | `BETWEEN ? AND ?` | `u.age.between(18, 65)` |
 
+`.eq()`와 `.neq()`는 피연산자를 정규화해서 항상 올바른 SQL을 만들어 줍니다.
+`null`은 `IS NULL` / `IS NOT NULL`로 바뀌고(항상 UNKNOWN이 되는 `= NULL`을
+절대 만들지 않습니다), 배열은 `IN (...)` / `NOT IN (...)`으로 바뀝니다. 즉
+`u.deletedAt.neq(null)`은 `IS NOT NULL`을, `u.role.neq(["a", "b"])`는
+`NOT IN (?, ?)`을 생성합니다. 명시적 연산자 형태인 `where(col, "!=", null)` /
+`where(col, "=", null)`에도 동일한 변환이 적용됩니다.
+
 전체 목록(집계 / CASE / 윈도우 / 날짜 등)은 [QueryDSL 표현식](./query-builder-querydsl.md)에 있어요.
 
 `qAlias()`는 `alias()`의 `.col()`도 지원하니 두 스타일을 섞어 써도 됩니다.

--- a/docs/query-builder-joins.md
+++ b/docs/query-builder-joins.md
@@ -83,6 +83,13 @@ The full operator reference lives on the
 | `.isNotNull()` | `IS NOT NULL` | `u.email.isNotNull()` |
 | `.between(min, max)` | `BETWEEN ? AND ?` | `u.age.between(18, 65)` |
 
+`.eq()` and `.neq()` normalize their operand so the generated SQL is always
+sound: a `null` becomes `IS NULL` / `IS NOT NULL` (never `= NULL`, which always
+yields UNKNOWN), and an array becomes `IN (...)` / `NOT IN (...)`. So
+`u.deletedAt.neq(null)` emits `IS NOT NULL` and `u.role.neq(["a", "b"])` emits
+`NOT IN (?, ?)`. The same rewrite applies to the explicit
+`where(col, "!=", null)` / `where(col, "=", null)` operator form.
+
 Each method returns a `ColumnCondition` that the query builder resolves
 through its alias registry — SnakeNamingStrategy is fully supported.
 

--- a/src/core/SelectQueryBuilder.ts
+++ b/src/core/SelectQueryBuilder.ts
@@ -455,6 +455,8 @@ export class ColumnCondition implements ConditionLike {
         return Conditions.equals(qualified, value);
       case "!=":
       case "<>":
+        if (value === null) return Conditions.isNotNull(qualified);
+        if (Array.isArray(value)) return Conditions.notIn(qualified, value);
         return Conditions.notEquals(qualified, value);
       case ">":
         return Conditions.gt(qualified, value);
@@ -6049,9 +6051,13 @@ export class SelectQueryBuilder<T, TResult = T> {
 
     switch (normalizedOp) {
       case "=":
+        // `col = NULL` is always UNKNOWN; rewrite to IS NULL so the explicit
+        // operator form matches the two-arg `where(col, null)` shorthand.
+        if (value === null) return Conditions.isNull(qualified);
         return Conditions.equals(qualified, value);
       case "!=":
       case "<>":
+        if (value === null) return Conditions.isNotNull(qualified);
         return Conditions.notEquals(qualified, value);
       case ">":
         return Conditions.gt(qualified, value);


### PR DESCRIPTION
## Problem

`ColumnCondition.resolve()` (the QueryDSL `.eq()`/`.neq()` path) rewrote the `=` operator's operand for safety — `null` became `IS NULL` and an array became `IN (...)` — but the `!=` / `<>` cases had no equivalent branch. As a result:

| Input | Before (buggy) | After |
|-------|----------------|-------|
| `u.deletedAt.neq(null)` | `!= NULL` (always UNKNOWN, matches nothing) | `IS NOT NULL` |
| `u.role.neq(["a","b"])` | `!= (array)` (malformed SQL) | `NOT IN (?, ?)` |

The most dangerous part is that it fails silently with wrong results — e.g. the common `deletedAt.neq(null)` filter to exclude soft-deleted rows matched zero rows instead.

The explicit string-operator form `where(col, "!=", null)` had the same `col != NULL` footgun, while the two-arg shorthand `where(col, null)` already rewrote to `IS NULL`.

## Fix

- Mirror the `=` branch in the `!=` / `<>` case of `ColumnCondition.resolve()`: `null` to `IS NOT NULL`, array to `NOT IN (...)`.
- Apply null normalization to the explicit `where(col, "=" | "!=", null)` operator path so it matches the two-arg shorthand.

## Tests

- 11 new regression tests in `qdsl-neq-null-array.test.ts` covering both the QueryDSL `ColumnCondition` path and the string-operator path (null, array, empty array, scalar).
- Full unit suite: 5342 passed, 21 skipped, 0 failures.

## Docs

- Documented the now-symmetric null/array normalization in `query-builder-joins.md` (en + ko).

Generated with Claude Code