### PR TITLE
fix(core): warn when a @ManyToOne foreign key cannot be resolved

### DIFF
--- a/__tests__/unit/many-to-one-unresolved-fk-warning.test.ts
+++ b/__tests__/unit/many-to-one-unresolved-fk-warning.test.ts
@@ -1,0 +1,127 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import "reflect-metadata";
+import {
+  Entity,
+  Column,
+  ManyToOne,
+  RelationColumn,
+  PrimaryGeneratedColumn,
+} from "../../src/decorators";
+import { MANY_TO_ONE_TOKEN } from "../../src/decorators/ManyToOne";
+import { RelationMetadataResolver } from "../../src/core/RelationMetadataResolver";
+
+/**
+ * A @ManyToOne is always the owning side, so its foreign-key column must be
+ * resolvable from one of: @RelationColumn, an explicit `joinColumn` option, or
+ * a `{prop}Id` @Column. When none of those exist the FK is silently dropped on
+ * insert/update and the relation cannot be loaded. These tests lock in the
+ * one-time (deduplicated) warning that surfaces the misconfiguration instead of
+ * corrupting data quietly — and confirm correctly-backed relations stay quiet.
+ */
+
+@Entity()
+class FkTarget {
+  @PrimaryGeneratedColumn()
+  id!: number;
+}
+
+@Entity()
+class BareManyToOne {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  // No @RelationColumn, no joinColumn option, no `targetId` @Column.
+  @ManyToOne(() => FkTarget, () => undefined)
+  target!: FkTarget;
+}
+
+@Entity()
+class BackedByRelationColumn {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @ManyToOne(() => FkTarget, () => undefined)
+  @RelationColumn({ name: "target_ref" })
+  target!: FkTarget;
+}
+
+@Entity()
+class BackedByIdColumn {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @Column({ type: "int" })
+  targetId!: number;
+
+  @ManyToOne(() => FkTarget, () => undefined)
+  target!: FkTarget;
+}
+
+function relsOf(entity: any) {
+  return (Reflect.getMetadata(MANY_TO_ONE_TOKEN, entity) ?? []) as any[];
+}
+
+function spyWarn(resolver: RelationMetadataResolver) {
+  return jest
+    .spyOn((resolver as any).logger, "warn")
+    .mockImplementation(() => {});
+}
+
+describe("@ManyToOne unresolved foreign-key warning", () => {
+  it("warns and leaves joinColumn unset when no FK backing exists", () => {
+    const resolver = new RelationMetadataResolver();
+    const warn = spyWarn(resolver);
+
+    const resolved = resolver.resolveJoinColumnsFromColumnMeta(
+      BareManyToOne as any,
+      relsOf(BareManyToOne),
+    );
+
+    expect(resolved[0].joinColumn).toBeUndefined();
+    expect(warn).toHaveBeenCalledTimes(1);
+    const msg = warn.mock.calls[0][0] as string;
+    expect(msg).toContain("no resolvable foreign-key");
+    expect(msg).toContain("BareManyToOne");
+    expect(msg).toContain("targetId");
+  });
+
+  it("does NOT warn when @RelationColumn provides the FK name", () => {
+    const resolver = new RelationMetadataResolver();
+    const warn = spyWarn(resolver);
+
+    const resolved = resolver.resolveJoinColumnsFromColumnMeta(
+      BackedByRelationColumn as any,
+      relsOf(BackedByRelationColumn),
+    );
+
+    expect(resolved[0].joinColumn).toBe("target_ref");
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("does NOT warn when a `{prop}Id` @Column backs the relation", () => {
+    const resolver = new RelationMetadataResolver();
+    const warn = spyWarn(resolver);
+
+    const resolved = resolver.resolveJoinColumnsFromColumnMeta(
+      BackedByIdColumn as any,
+      relsOf(BackedByIdColumn),
+    );
+
+    expect(resolved[0].joinColumn).toBeDefined();
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("deduplicates the warning across repeated resolution of the same relation", () => {
+    const resolver = new RelationMetadataResolver();
+    const warn = spyWarn(resolver);
+
+    for (let i = 0; i < 5; i++) {
+      resolver.resolveJoinColumnsFromColumnMeta(
+        BareManyToOne as any,
+        relsOf(BareManyToOne),
+      );
+    }
+
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/docs/ko/relations.md
+++ b/docs/ko/relations.md
@@ -188,7 +188,7 @@ export class Cat {
 1. `@RelationColumn`이 프로퍼티에 부착된 경우 -> `name` 사용 (생략 시 `{propertyName}Id` 추론)
 2. `@ManyToOne`의 `joinColumn` 옵션이 지정된 경우 -> 그대로 사용
 3. 같은 엔티티에 `{propertyName}Id`인 `@Column`이 선언된 경우 -> 해당 `@Column`의 DB 컬럼명 사용
-4. 위 모두 없는 경우 -> `{propertyName}Id` 규칙으로 폴백
+4. 위 모두 없는 경우 -> FK 컬럼을 **해석할 수 없어요**. `@ManyToOne`은 항상 소유(owning) 측이므로, 이 경우 INSERT/UPDATE에서 FK가 **저장되지 않고** 관계도 로드할 수 없어요. 경고 로그가 출력되니 `@RelationColumn({ name: "..." })`(또는 `{propertyName}Id` `@Column`)을 추가해 해결하세요.
 
 `@Column`을 선언하면 엔티티에서 FK 값을 직접 읽고 쓸 수 있다는 장점도 있어요.
 

--- a/docs/relations.md
+++ b/docs/relations.md
@@ -188,7 +188,7 @@ The resolution priority is as follows.
 1. If `@RelationColumn` is attached to the property -> use its `name` (or infer `{propertyName}Id` if omitted)
 2. If `@ManyToOne`'s `joinColumn` option is specified -> use as-is
 3. If a `@Column` with `{propertyName}Id` is declared on the same entity -> use that `@Column`'s DB column name
-4. If none of the above -> fallback to `{propertyName}Id` convention
+4. If none of the above -> the FK column **cannot be resolved**. A `@ManyToOne` is always the owning side, so this means the FK is **not persisted** on insert/update and the relation cannot be loaded. A warning is logged; add `@RelationColumn({ name: "..." })` (or a `{propertyName}Id` `@Column`) to fix it.
 
 Declaring a `@Column` also has the advantage of being able to directly read and write FK values on the entity.
 

--- a/src/core/RelationMetadataResolver.ts
+++ b/src/core/RelationMetadataResolver.ts
@@ -38,6 +38,14 @@ export class RelationMetadataResolver {
   private readonly logger = new Logger(RelationMetadataResolver.name);
 
   /**
+   * Dedup keys (`${entity}.${property}`) for @ManyToOne relations whose
+   * foreign-key column could not be resolved. Keeps the
+   * "FK will not be persisted" warning to one emission per relation instead
+   * of one per query, since the resolver is not memoized.
+   */
+  private readonly warnedUnresolvedManyToOneFk = new Set<string>();
+
+  /**
    * Looks up entity metadata through the layered metadata system.
    *
    * Lookup priority:
@@ -204,23 +212,48 @@ export class RelationMetadataResolver {
       if (rel.joinColumn) return rel;
 
       // 3. Search for an @Column matching the `{propertyName}Id` pattern
-      if (columnsMeta.length === 0) return rel;
-
       const fkPropertyName = `${rel.columnName}Id`;
       const matchingColumn = columnsMeta.find(
         (col: ColumnMetadata) => col.propertyKey === fkPropertyName,
       );
 
-      if (!matchingColumn) return rel;
+      if (matchingColumn) {
+        // Use the @Column's actual DB name (name if provided, otherwise propertyKey)
+        return {
+          ...rel,
+          joinColumn: matchingColumn.name ?? fkPropertyName,
+        };
+      }
 
-      // Use the @Column's actual DB name (name if provided, otherwise propertyKey)
-      const resolvedJoinColumn = matchingColumn.name ?? fkPropertyName;
-
-      return {
-        ...rel,
-        joinColumn: resolvedJoinColumn,
-      };
+      // 4. None of the above resolved an FK column. A @ManyToOne is always the
+      //    owning side, so an unresolved joinColumn means the FK is silently
+      //    dropped on insert/update and the relation cannot be loaded — warn so
+      //    the misconfiguration is visible instead of corrupting data quietly.
+      this.warnUnresolvedManyToOneFk(entity, rel.columnName, fkPropertyName);
+      return rel;
     });
+  }
+
+  /**
+   * Emit a one-time warning that a @ManyToOne relation has no resolvable
+   * foreign-key column. Deduplicated per `entity.property` so a misconfigured
+   * relation on a hot entity does not flood the log on every query.
+   */
+  private warnUnresolvedManyToOneFk(
+    entity: ClazzType<any>,
+    property: string,
+    fkPropertyName: string,
+  ): void {
+    const key = `${entity.name}.${property}`;
+    if (this.warnedUnresolvedManyToOneFk.has(key)) return;
+    this.warnedUnresolvedManyToOneFk.add(key);
+    this.logger.warn(
+      `@ManyToOne '${property}' on ${entity.name} has no resolvable foreign-key ` +
+        `column: no @RelationColumn, no 'joinColumn' option, and no '${fkPropertyName}' ` +
+        `@Column was found. The FK will NOT be persisted on insert/update and the ` +
+        `relation cannot be loaded. Add @RelationColumn({ name: "..." }) to the ` +
+        `'${property}' property (or declare a '${fkPropertyName}' @Column).`,
+    );
   }
 
   /**


### PR DESCRIPTION
## Problem

A `@ManyToOne` is always the owning side, so its FK column must be resolvable from one of: `@RelationColumn`, an explicit `joinColumn` option, or a `{prop}Id` `@Column`. When none of those exist, `RelationMetadataResolver` left `joinColumn` unset, and `WriteExecutor`'s `if (!rel.joinColumn) continue;` guard **silently dropped the FK** on insert/update. The relation also could not be loaded. No error was thrown — just wrong/missing data.

This is not hit by any in-repo example (they all declare `@RelationColumn`), but a user who forgets the FK declaration currently gets silent data loss with no signal.

## Fix

- Emit a **deduplicated, one-time** warning (keyed per `entity.property`, since the resolver is not memoized) when a `@ManyToOne` FK cannot be resolved, pointing at the fix. Correctly-backed relations stay silent.
- Scoped to `@ManyToOne` only — `@OneToOne` can legitimately be the inverse side with no local FK, so it is intentionally untouched.

## Docs correction

The FK-resolution priority list claimed:

> 4. If none of the above -> fallback to `{propertyName}Id` convention

The code **never** implemented that fallback (verified via `git blame` back to the original commit) — `joinColumn` stays unresolved. Updated `relations.md` (en + ko) to describe the actual warn-and-require-declaration behavior.

## Tests

- 4 regression tests: the warning fires + leaves `joinColumn` unset for a bare relation; `@RelationColumn` and `{prop}Id` `@Column` backings stay silent; the warning deduplicates across repeated resolution.
- Full unit suite: 5346 passed, 21 skipped, 0 failures.

Generated with Claude Code