### PR TITLE
fix(metadata): make MetadataLayer.clone() a true copy-on-write deep clone

### DIFF
--- a/__tests__/unit/metadata-layer-clone-cow.test.ts
+++ b/__tests__/unit/metadata-layer-clone-cow.test.ts
@@ -1,0 +1,169 @@
+import {
+  MetadataLayer,
+  deepCloneMetadata,
+} from "../../src/metadata/MetadataLayer";
+
+/**
+ * `MetadataLayer.clone()` is the copy-on-write primitive of the layered
+ * (OverlayFS-style) metadata model. A tenant overlay cloned from the public
+ * layer must NOT share mutable state with it — otherwise an in-place mutation
+ * of nested metadata (e.g. `meta.columns.push(...)`) on one layer leaks into
+ * the other and breaks tenant isolation.
+ *
+ * The clone must also preserve class constructors / functions BY REFERENCE,
+ * because the resolver and scanners compare them with `===` (cloning a class
+ * ref would break relation `target` identity checks).
+ */
+describe("MetadataLayer.clone() — copy-on-write isolation", () => {
+  it("does not leak in-place mutation of a nested array back to the source", () => {
+    const layer = new MetadataLayer("public");
+    layer.set("User", { columns: ["id", "name"], indexes: [] });
+
+    const cloned = layer.clone("tenant_a");
+    const clonedMeta = cloned.get<{ columns: string[] }>("User")!;
+    clonedMeta.columns.push("email");
+
+    // Source layer is untouched — isolation holds.
+    expect(layer.get<{ columns: string[] }>("User")!.columns).toEqual([
+      "id",
+      "name",
+    ]);
+    expect(clonedMeta.columns).toEqual(["id", "name", "email"]);
+  });
+
+  it("does not leak in-place mutation of a nested object", () => {
+    const layer = new MetadataLayer("public");
+    layer.set("User", { options: { nullable: false } });
+
+    const cloned = layer.clone("tenant_a");
+    cloned.get<{ options: { nullable: boolean } }>("User")!.options.nullable =
+      true;
+
+    expect(
+      layer.get<{ options: { nullable: boolean } }>("User")!.options.nullable,
+    ).toBe(false);
+  });
+
+  it("gives the clone fresh container instances (not shared references)", () => {
+    const layer = new MetadataLayer("public");
+    const cols: string[] = ["id"];
+    layer.set("User", { columns: cols });
+
+    const cloned = layer.clone("tenant_a");
+    const clonedCols = cloned.get<{ columns: string[] }>("User")!.columns;
+
+    expect(clonedCols).toEqual(["id"]); // structurally equal
+    expect(clonedCols).not.toBe(cols); // but a different array
+  });
+
+  it("preserves class constructors and functions by reference", () => {
+    class TargetEntity {}
+    const getMappingEntity = () => TargetEntity;
+
+    const layer = new MetadataLayer("public");
+    layer.set("rel", {
+      target: TargetEntity,
+      getMappingEntity,
+      columnName: "owner",
+      nested: { also: TargetEntity },
+    });
+
+    const cloned = layer
+      .clone("tenant_a")
+      .get<{
+        target: unknown;
+        getMappingEntity: unknown;
+        nested: { also: unknown };
+      }>("rel")!;
+
+    // Identity-critical refs are shared, not cloned.
+    expect(cloned.target).toBe(TargetEntity);
+    expect(cloned.getMappingEntity).toBe(getMappingEntity);
+    expect(cloned.nested.also).toBe(TargetEntity);
+  });
+
+  it("keeps the existing deep-equality contract for cloned values", () => {
+    const layer = new MetadataLayer("public");
+    layer.set("key1", { nested: "value" });
+
+    const cloned = layer.clone("cloned-layer");
+    expect(cloned.get("key1")).toEqual({ nested: "value" });
+  });
+});
+
+describe("deepCloneMetadata()", () => {
+  it("returns primitives, null, undefined, and symbols unchanged", () => {
+    const sym = Symbol("x");
+    expect(deepCloneMetadata(42)).toBe(42);
+    expect(deepCloneMetadata("s")).toBe("s");
+    expect(deepCloneMetadata(true)).toBe(true);
+    expect(deepCloneMetadata(null)).toBe(null);
+    expect(deepCloneMetadata(undefined)).toBe(undefined);
+    expect(deepCloneMetadata(sym)).toBe(sym);
+  });
+
+  it("returns functions and class constructors by reference", () => {
+    const fn = () => 1;
+    class C {}
+    expect(deepCloneMetadata(fn)).toBe(fn);
+    expect(deepCloneMetadata(C)).toBe(C);
+  });
+
+  it("clones Date and RegExp into independent equal instances", () => {
+    const d = new Date(123456789);
+    const clonedDate = deepCloneMetadata(d);
+    expect(clonedDate).not.toBe(d);
+    expect(clonedDate.getTime()).toBe(123456789);
+
+    const re = /abc/gi;
+    const clonedRe = deepCloneMetadata(re);
+    expect(clonedRe).not.toBe(re);
+    expect(clonedRe.source).toBe("abc");
+    expect(clonedRe.flags).toBe("gi");
+  });
+
+  it("deep-clones Map values while keeping key identity", () => {
+    const key = { id: 1 };
+    const map = new Map<object, { tag: string }>([[key, { tag: "a" }]]);
+
+    const cloned = deepCloneMetadata(map);
+    expect(cloned).not.toBe(map);
+    expect(cloned.has(key)).toBe(true); // same key identity
+    expect(cloned.get(key)).not.toBe(map.get(key)); // cloned value
+    cloned.get(key)!.tag = "b";
+    expect(map.get(key)!.tag).toBe("a"); // source untouched
+  });
+
+  it("deep-clones Set members", () => {
+    const member = { tag: "a" };
+    const set = new Set([member]);
+    const cloned = deepCloneMetadata(set);
+    expect(cloned).not.toBe(set);
+    expect(cloned.has(member)).toBe(false); // member was cloned, not shared
+    expect([...cloned][0]).toEqual({ tag: "a" });
+  });
+
+  it("shares non-plain class instances by reference (preserves behavior)", () => {
+    class Box {
+      constructor(public v: number) {}
+      double() {
+        return this.v * 2;
+      }
+    }
+    const box = new Box(21);
+    const wrapper = deepCloneMetadata({ box });
+    expect(wrapper.box).toBe(box); // shared
+    expect(wrapper.box.double()).toBe(42); // behavior intact
+  });
+
+  it("is cycle-safe and preserves intra-value shared references", () => {
+    const shared = { v: 1 };
+    const root: any = { a: shared, b: shared };
+    root.self = root;
+
+    const cloned = deepCloneMetadata(root);
+    expect(cloned.self).toBe(cloned); // cycle handled
+    expect(cloned.a).toBe(cloned.b); // shared ref preserved as a single clone
+    expect(cloned.a).not.toBe(shared); // but cloned, not the original
+  });
+});

--- a/src/metadata/MetadataLayer.ts
+++ b/src/metadata/MetadataLayer.ts
@@ -120,19 +120,25 @@ export class MetadataLayer {
   }
 
   /**
-   * Clone the current layer into a new layer.
-   * Values that cannot be deep-cloned (functions, class references, etc.)
-   * fall back to a shallow copy.
+   * Clone the current layer into a new, independent layer.
+   *
+   * This is the copy-on-write primitive of the layered (OverlayFS-style)
+   * metadata model: a tenant overlay cloned from the public layer must not
+   * share mutable state with it, or a later in-place mutation on one layer
+   * (e.g. `meta.columns.push(...)`) would leak into the other and break
+   * tenant isolation.
+   *
+   * `structuredClone` cannot be used because metadata holds class constructors
+   * and functions (e.g. a relation's `target` / `getMappingEntity`), which it
+   * rejects. Instead {@link deepCloneMetadata} deep-copies the mutable
+   * containers (arrays, plain objects, Map/Set) while preserving class refs and
+   * functions BY REFERENCE — cloning those would break `target ===` identity
+   * checks the resolver relies on.
    */
   clone(newName: string, readOnly = false): MetadataLayer {
     const clonedLayer = new MetadataLayer(newName, readOnly);
     for (const [key, value] of this.metadata.entries()) {
-      try {
-        clonedLayer.metadata.set(key, structuredClone(value));
-      } catch {
-        // structuredClone failed (functions, class references, etc.) — fall back to shallow copy
-        clonedLayer.metadata.set(key, { ...value });
-      }
+      clonedLayer.metadata.set(key, deepCloneMetadata(value));
     }
     return clonedLayer;
   }
@@ -146,4 +152,79 @@ export class MetadataLayer {
     }
     this.metadata.clear();
   }
+}
+
+/**
+ * Structural deep clone tuned for decorator metadata, used by
+ * {@link MetadataLayer.clone}.
+ *
+ * @internal Exported only so the copy-on-write behavior can be unit-tested
+ * directly; not part of the supported public API.
+ *
+ * Deep-copies the mutable containers that tenant overlays must not share with
+ * the public layer — arrays, plain objects, `Map`, `Set`, `Date` — while
+ * returning everything that carries identity or behavior **by reference**:
+ * - primitives and `symbol`
+ * - functions and class constructors (`target`, `getMappingEntity`, …): cloning
+ *   them would break the `===` identity checks the resolver and scanners rely on
+ * - non-plain objects (class instances, etc.): generic cloning would drop their
+ *   prototype/behavior, so they are shared as-is
+ *
+ * A `WeakMap` of already-cloned objects makes it cycle-safe and preserves
+ * shared-reference structure within a single value.
+ */
+export function deepCloneMetadata<T>(value: T, seen = new WeakMap()): T {
+  // Primitives, null, undefined, symbols, and functions (incl. class refs).
+  if (value === null || typeof value !== "object") {
+    return value;
+  }
+
+  const existing = seen.get(value as object);
+  if (existing) return existing as T;
+
+  if (value instanceof Date) {
+    return new Date(value.getTime()) as unknown as T;
+  }
+  if (value instanceof RegExp) {
+    return new RegExp(value.source, value.flags) as unknown as T;
+  }
+
+  if (Array.isArray(value)) {
+    const arr: unknown[] = [];
+    seen.set(value as object, arr);
+    for (const item of value) arr.push(deepCloneMetadata(item, seen));
+    return arr as unknown as T;
+  }
+
+  if (value instanceof Map) {
+    const map = new Map();
+    seen.set(value as object, map);
+    // Keys keep their identity (Map lookups depend on it); only values are cloned.
+    for (const [k, v] of value) map.set(k, deepCloneMetadata(v, seen));
+    return map as unknown as T;
+  }
+
+  if (value instanceof Set) {
+    const set = new Set();
+    seen.set(value as object, set);
+    for (const v of value) set.add(deepCloneMetadata(v, seen));
+    return set as unknown as T;
+  }
+
+  // Only deep-clone plain objects. Class instances (non-plain prototype) carry
+  // behavior, so they are shared by reference rather than structurally copied.
+  const proto = Object.getPrototypeOf(value);
+  if (proto !== Object.prototype && proto !== null) {
+    return value;
+  }
+
+  const cloned: Record<string, unknown> = {};
+  seen.set(value as object, cloned);
+  for (const key of Object.keys(value as object)) {
+    cloned[key] = deepCloneMetadata(
+      (value as Record<string, unknown>)[key],
+      seen,
+    );
+  }
+  return cloned as T;
 }


### PR DESCRIPTION
## Problem

`MetadataLayer.clone()` is the copy-on-write primitive of the layered (OverlayFS-style) metadata model — a tenant overlay cloned from the public layer must not share mutable state with it. It used `structuredClone` with a `{ ...value }` shallow fallback:

```ts
try { clonedLayer.metadata.set(key, structuredClone(value)); }
catch { clonedLayer.metadata.set(key, { ...value }); }
```

Metadata always holds class constructors / functions (a relation's `target`, `getMappingEntity`), so `structuredClone` **always** throws and the shallow copy is **always** taken. Nested arrays (`columns`, `manyToOnes`, …) were therefore shared between the public and a cloned tenant layer — an in-place mutation on one (`meta.columns.push(...)`) leaked into the other, silently breaking tenant isolation (the project's core invariant).

> Note on reachability: `clone()`'s only caller, `copyLayer()`, is currently exercised by the deprecated `MultiTenantMetadataManager` / `LayeredMetadataScanner` and tests — `MultiTenantEntityManager` does not call it, and real tenant provisioning uses SQL schema cloning. This hardens the latent contract violation in the core isolation primitive before it can bite.

## Fix

`deepCloneMetadata` — a structural deep clone that:
- **deep-copies** the mutable containers tenant overlays must not share: arrays, plain objects, `Map`, `Set`, `Date`, `RegExp`
- returns **by reference** everything that carries identity/behavior: primitives, symbols, functions, class constructors, and non-plain class instances — cloning a class ref would break the `target ===` identity checks the resolver and scanners rely on
- is **WeakMap-backed**, so it is cycle-safe and preserves intra-value shared references

Marked `@internal` (exported only for direct unit testing; not public API).

**No behavior change for correct usage** — cloned metadata is structurally identical with the same class refs; only the previously-shared mutable containers are now independent.

## Tests

- 12 regression tests: CoW isolation (nested array/object mutation does not leak), class/function identity preservation, fresh container instances, `Date`/`RegExp`/`Map`/`Set` handling, non-plain instance sharing, cycle safety + shared-ref preservation. The existing `clone()` deep-equality test still passes.
- Full unit suite: 5358 passed, 21 skipped, 0 failures. CJS + ESM build clean.

Generated with Claude Code