### PR TITLE
fix(schema): honor createForeignKeyConstraints:false on @OneToOne owning side

### DIFF
--- a/__tests__/unit/schema-registrar-fk-column-type.test.ts
+++ b/__tests__/unit/schema-registrar-fk-column-type.test.ts
@@ -153,20 +153,20 @@ function makeO2OResolver(items: any[]): RelationMetadataResolver {
   } as unknown as RelationMetadataResolver;
 }
 
-function m2oItem(parent: any, joinColumn: string) {
+function m2oItem(parent: any, joinColumn: string, option: any = {}) {
   return {
     joinColumn,
     getMappingEntity: () => parent,
-    option: {},
+    option,
     references: undefined,
   };
 }
 
-function o2oItem(parent: any, joinColumn: string) {
+function o2oItem(parent: any, joinColumn: string, option: any = {}) {
   return {
     joinColumn,
     getRelatedEntity: () => parent,
-    option: {},
+    option,
   };
 }
 
@@ -273,5 +273,61 @@ describe("SchemaRegistrar.registerForeignKeys — M2O/O2O FK column type (#284)"
 
     expect(calls.addColumn).toHaveLength(1);
     expect(calls.addColumn[0].type).toBe("INT NULL");
+  });
+});
+
+// ──────────────────────────────────────────────
+// createForeignKeyConstraints: false — runtime ALTER path
+// (SchemaGenerator path is covered in referential-actions.test.ts; this
+//  guards the SchemaRegistrar.registerForeignKeys ALTER-based path, where
+//  the O2O branch previously ignored the flag.)
+// ──────────────────────────────────────────────
+
+describe("SchemaRegistrar.registerForeignKeys — createForeignKeyConstraints: false", () => {
+  it("skips the FK constraint and column for a ManyToOne when the flag is false", async () => {
+    const { driver, calls } = makeDriver();
+    const registrar = new SchemaRegistrar(
+      makeM2OResolver([
+        m2oItem(IntPkParent, "parent_id", {
+          createForeignKeyConstraints: false,
+        }),
+      ]),
+      makeCtx(driver),
+    );
+
+    await registrar.registerForeignKeys(IntChild, "int_child");
+
+    expect(calls.addForeignKey).toHaveLength(0);
+    expect(calls.addColumn).toHaveLength(0);
+  });
+
+  it("skips the FK constraint and column for a OneToOne owning side when the flag is false", async () => {
+    const { driver, calls } = makeDriver();
+    const registrar = new SchemaRegistrar(
+      makeO2OResolver([
+        o2oItem(IntPkParent, "profile_id", {
+          createForeignKeyConstraints: false,
+        }),
+      ]),
+      makeCtx(driver),
+    );
+
+    await registrar.registerForeignKeys(O2OChild, "o2o_child");
+
+    expect(calls.addForeignKey).toHaveLength(0);
+    expect(calls.addColumn).toHaveLength(0);
+  });
+
+  it("still creates the FK constraint for a OneToOne owning side when the flag is unset", async () => {
+    const { driver, calls } = makeDriver();
+    const registrar = new SchemaRegistrar(
+      makeO2OResolver([o2oItem(IntPkParent, "profile_id")]),
+      makeCtx(driver),
+    );
+
+    await registrar.registerForeignKeys(O2OChild, "o2o_child");
+
+    expect(calls.addForeignKey).toHaveLength(1);
+    expect(calls.addForeignKey[0].col).toBe("profile_id");
   });
 });

--- a/__tests__/unit/tenant-column-relations.test.ts
+++ b/__tests__/unit/tenant-column-relations.test.ts
@@ -187,11 +187,12 @@ describe("RelationLoader under tenant_column strategy", () => {
 
   // ── OneToOne inverse ─────────────────────────────────────────────────
 
-  // NOTE: OneToOne FK creation in SchemaRegistrar does not honor
-  // `createForeignKeyConstraints: false` at the time of writing, and SQLite
-  // cannot ALTER TABLE ADD FOREIGN KEY. Skip under SQLite; Phase 8 MySQL/PG
-  // integration tests cover inverse OneToOne tenant-scoping.
-  xdescribe("OneToOne (inverse) batched load", () => {
+  // OneToOne FK creation in SchemaRegistrar now honors
+  // `createForeignKeyConstraints: false`, so the owning Profile entity below
+  // declares its `accountId` column explicitly and no ALTER TABLE ADD FOREIGN
+  // KEY is attempted — which lets this run under SQLite. Phase 8 MySQL/PG
+  // integration tests still cover inverse OneToOne tenant-scoping with real FKs.
+  describe("OneToOne (inverse) batched load", () => {
     @Entity()
     class Account {
       @PrimaryGeneratedColumn() id!: number;

--- a/src/core/SchemaRegistrar.ts
+++ b/src/core/SchemaRegistrar.ts
@@ -1099,6 +1099,9 @@ export class SchemaRegistrar {
     for (const oneToOneItem of oneToOneItems) {
       const { joinColumn } = oneToOneItem;
       if (!joinColumn) continue; // Inverse side has no FK.
+      // Skip FK creation when createForeignKeyConstraints is false, mirroring
+      // the ManyToOne path above and SchemaGenerator.getForeignKeys().
+      if (oneToOneItem.option?.createForeignKeyConstraints === false) continue;
 
       const RelatedEntity = oneToOneItem.getRelatedEntity();
       if (!RelatedEntity) {


### PR DESCRIPTION
## Problem

The runtime FK-registration path `SchemaRegistrar.registerForeignKeys()` ignored `createForeignKeyConstraints: false` for `@OneToOne` owning sides, even though:

- the `@ManyToOne` loop directly above it honors the flag (`SchemaRegistrar.ts:1027`),
- the DDL-string generator honors it for both relation types (`SchemaGenerator.ts:777,800`),
- the decorator advertises the option (`OneToOne.ts:50`) and the docs state it "works on both `@ManyToOne` and `@OneToOne`".

As a result, a `@OneToOne` owning side with the flag set still received an `ALTER TABLE ... ADD FOREIGN KEY` during `synchronize`, breaking cross-database references, FK-less designs, and SQLite (which cannot `ALTER TABLE ADD FOREIGN KEY`).

## Fix

Add the same guard the `@ManyToOne` path already uses:

```ts
if (oneToOneItem.option?.createForeignKeyConstraints === false) continue;
```

## Why it slipped through

The existing `referential-actions` tests only covered the `SchemaGenerator` DDL-string path. The runtime `registerForeignKeys()` ALTER path had no coverage for this flag, which is exactly where the bug lived.

## Tests

- Added 3 regression tests in `schema-registrar-fk-column-type.test.ts` for the runtime ALTER path (ManyToOne skip, OneToOne skip, OneToOne-unset-still-creates). Verified red without the fix / green with it.
- Re-enabled the previously `xdescribe`'d "OneToOne (inverse) batched load" tenant-isolation test in `tenant-column-relations.test.ts`, whose skip note cited this exact bug. It now passes under SQLite.

## Verification

- Full unit suite: 5,244 passed, 20 skipped, 0 failures (was 5,240 passed / 21 skipped: net +4 passing, -1 skipped).
- Type check clean. No doc changes needed (docs already described the intended behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)