### PR TITLE
fix(core): map findWithCursor orderBy property key to DB column

### DIFF
--- a/__tests__/unit/cursor-pagination.test.ts
+++ b/__tests__/unit/cursor-pagination.test.ts
@@ -698,6 +698,104 @@ describe("UUID PK cursor pagination", () => {
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
+// NamingStrategy (property key -> DB column) mapping for orderBy
+// ─────────────────────────────────────────────────────────────────────────────
+
+const SnakeEntity = class Article {} as any;
+
+// propertyKey (camelCase) differs from the DB column name (snake_case), as
+// produced by SnakeNamingStrategy.
+const snakeMetadata = {
+  name: "article",
+  target: SnakeEntity,
+  columns: [
+    { name: "id", propertyKey: "id", options: { primary: true, autoIncrement: true } },
+    { name: "title", propertyKey: "title", options: {} },
+    { name: "created_at", propertyKey: "createdAt", options: {} },
+  ],
+};
+
+function setupSnakeMocks(em: EntityManager): void {
+  jest.spyOn((em as any).resolver, "resolveEntityMetadata").mockReturnValue(snakeMetadata);
+  jest.spyOn((em as any).resolver, "getDeletedAtColumn").mockReturnValue(null);
+}
+
+describe("findWithCursor — orderBy property->column mapping (SnakeNamingStrategy)", () => {
+  let em: EntityManager;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    em = createTestEntityManager();
+    setupSnakeMocks(em);
+  });
+
+  it("should map a camelCase orderBy property key to its snake_case column in ORDER BY", async () => {
+    const rows = [
+      { id: 1, title: "a", created_at: "2024-01-01" },
+      { id: 2, title: "b", created_at: "2024-01-02" },
+    ];
+    mockQuery.mockResolvedValueOnce({ results: rows, fields: [] });
+
+    await em.findWithCursor(SnakeEntity, { take: 5, orderBy: "createdAt" as any });
+
+    const sqlCall = mockQuery.mock.calls[0][0];
+    const sqlText = sqlCall.sql ?? sqlCall.text ?? String(sqlCall);
+    // ORDER BY must reference the DB column, not the entity property key.
+    expect(sqlText).toContain("`created_at`");
+    expect(sqlText).not.toContain("`createdAt`");
+  });
+
+  it("should reference the snake_case column in the cursor WHERE clause", async () => {
+    const cursor = encodeCursor("2024-01-01");
+    const rows = [{ id: 2, title: "b", created_at: "2024-01-02" }];
+    mockQuery.mockResolvedValueOnce({ results: rows, fields: [] });
+
+    await em.findWithCursor(SnakeEntity, {
+      take: 5,
+      cursor,
+      orderBy: "createdAt" as any,
+    });
+
+    const sqlCall = mockQuery.mock.calls[0][0];
+    const sqlText = sqlCall.sql ?? sqlCall.text ?? String(sqlCall);
+    expect(sqlText).toContain("`created_at`");
+    expect(sqlText).toContain(">");
+  });
+
+  it("should encode nextCursor from the mapped column value (not undefined)", async () => {
+    // take=2 -> fetch 3 -> hasNextPage, last page item's created_at is the cursor
+    const rows = [
+      { id: 1, title: "a", created_at: "2024-01-01" },
+      { id: 2, title: "b", created_at: "2024-01-02" },
+      { id: 3, title: "c", created_at: "2024-01-03" },
+    ];
+    mockQuery.mockResolvedValueOnce({ results: rows, fields: [] });
+
+    const result = await em.findWithCursor(SnakeEntity, {
+      take: 2,
+      orderBy: "createdAt" as any,
+    });
+
+    expect(result.hasNextPage).toBe(true);
+    // Last item of the page (index 1) has created_at "2024-01-02".
+    expect(result.nextCursor).toBe(encodeCursor("2024-01-02"));
+    // Regression guard: a missing mapping would encode `undefined`.
+    expect(result.nextCursor).not.toBe(encodeCursor(undefined));
+  });
+
+  it("should still default to the PK column when orderBy is omitted", async () => {
+    const rows = [{ id: 1, title: "a", created_at: "2024-01-01" }];
+    mockQuery.mockResolvedValueOnce({ results: rows, fields: [] });
+
+    await em.findWithCursor(SnakeEntity, { take: 5 });
+
+    const sqlCall = mockQuery.mock.calls[0][0];
+    const sqlText = sqlCall.sql ?? sqlCall.text ?? String(sqlCall);
+    expect(sqlText).toContain("`id`");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Non-numeric PK warning tests
 // ─────────────────────────────────────────────────────────────────────────────
 

--- a/src/core/entity-manager/ReadExecutor.ts
+++ b/src/core/entity-manager/ReadExecutor.ts
@@ -909,11 +909,18 @@ export class ReadExecutor {
       }
       const selectMap = allColNames.map((name) => this.ctx.wrap(name));
 
+      // Map the orderBy property key to its DB column name so cursor pagination
+      // honors the naming strategy (e.g. SnakeNamingStrategy maps `createdAt`
+      // -> `created_at`). Mirrors the find() orderBy mapping. The default value
+      // is already a column name (pk.name), so it passes through unchanged.
+      const propToCol = this.ctx.buildPropertyToColumnMap(metadata);
+      const dbOrderByColumn = propToCol.get(orderByColumn) ?? orderByColumn;
+
       const whereMap: Sql[] = resolveWhereClause(where, {
         wrapColumn: (n) => this.ctx.wrap(n),
         dialect: this.ctx.getDialect(),
         dialectExpression: createDialectExpression(this.ctx.getDialect()),
-        propertyToColumn: this.ctx.buildPropertyToColumnMap(metadata),
+        propertyToColumn: propToCol,
       });
 
       const deletedAtColumn = this.resolver.getDeletedAtColumn(entity);
@@ -934,14 +941,14 @@ export class ReadExecutor {
         if (direction === "ASC") {
           // Include NULL rows that haven't been seen yet (NULLs sort last in ASC)
           whereMap.push(Conditions.or([
-            Conditions.gt(this.ctx.wrap(orderByColumn), cursorValue),
-            Conditions.isNull(this.ctx.wrap(orderByColumn)),
+            Conditions.gt(this.ctx.wrap(dbOrderByColumn), cursorValue),
+            Conditions.isNull(this.ctx.wrap(dbOrderByColumn)),
           ]));
         } else {
           // Include NULL rows that haven't been seen yet (NULLs sort first in DESC)
           whereMap.push(Conditions.or([
-            Conditions.lt(this.ctx.wrap(orderByColumn), cursorValue),
-            Conditions.isNull(this.ctx.wrap(orderByColumn)),
+            Conditions.lt(this.ctx.wrap(dbOrderByColumn), cursorValue),
+            Conditions.isNull(this.ctx.wrap(dbOrderByColumn)),
           ]));
         }
       }
@@ -949,7 +956,7 @@ export class ReadExecutor {
       qb.select(selectMap)
         .from(this.ctx.wrapTable(tableName))
         .where(whereMap)
-        .orderBy([{ column: this.ctx.wrap(orderByColumn), direction }]);
+        .orderBy([{ column: this.ctx.wrap(dbOrderByColumn), direction }]);
 
       qb.limit(pageSize + 1);
 
@@ -985,7 +992,8 @@ export class ReadExecutor {
       let nextCursor: string | null = null;
       if (hasNextPage && pageResults.length > 0) {
         const lastItem = pageResults[pageResults.length - 1];
-        const lastValue = lastItem[orderByColumn];
+        // Raw rows are keyed by DB column name, so read with the mapped column.
+        const lastValue = lastItem[dbOrderByColumn];
         nextCursor = encodeCursor(lastValue);
       }
 


### PR DESCRIPTION
## Summary

`findWithCursor()` did not apply the NamingStrategy's property-to-column mapping to the `orderBy` value, unlike `find()`. `CursorPaginationOption<T>.orderBy` is typed and documented as an entity **property key** (`keyof T & string`), but the cursor path used it verbatim in the `ORDER BY` clause, the keyset `WHERE` comparison, and when reading the cursor value off the raw result row.

With `SnakeNamingStrategy` (or any setup where the property name differs from the column name) plus a user-supplied `orderBy`, this caused:

- `ORDER BY "createdAt"` / `WHERE "createdAt" > ?` generated against a `created_at` column → **SQL error** on PostgreSQL/MySQL.
- `nextCursor` encoded from `row["createdAt"]`, which is `undefined` on raw rows keyed by `created_at` → broken pagination.

## Fix

In `ReadExecutor.findWithCursor()`, derive `dbOrderByColumn` via `buildPropertyToColumnMap` (mirroring `find()` at `ReadExecutor.ts:437`) and use it for:

- the `ORDER BY` clause,
- the keyset `>` / `<` / `IS NULL` cursor predicates,
- the raw-row cursor value extraction.

The default case (`orderBy` omitted → `pk.name`, already a column name) passes through the map unchanged, so existing behavior is preserved.

Verified the other cursor entry points need no change:
- `SelectQueryBuilder.getCursor` already maps correctly via `col()` and reads from deserialized entities (property-keyed).
- `MultiTenantEntityManager.findWithCursor` delegates to this path and inherits the fix.

## Tests

Adds 4 regression tests in `__tests__/unit/cursor-pagination.test.ts` (camelCase property → snake_case column) covering the `ORDER BY` mapping, the keyset `WHERE` clause, `nextCursor` encoding, and the default-PK fallback. Reverting the source fix fails the `ORDER BY` and `nextCursor` assertions; with the fix applied they pass.

Full unit suite: 5248 passed, 20 skipped, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)