### PR TITLE
fix: correctness sweep across schema sync, batch inserts, lazy loading, and query builder

### DIFF
--- a/__tests__/integration/sqlite/insert-many-transformers.test.ts
+++ b/__tests__/integration/sqlite/insert-many-transformers.test.ts
@@ -1,0 +1,116 @@
+/**
+ * SQLite In-Memory: insertMany / insertManyAndReturn must apply write
+ * transformers.
+ *
+ * Regression: these two batch-insert paths read raw property values and bound
+ * them directly, skipping applyWriteTransform — unlike every sibling write path
+ * (saveInternal, saveManyBatchInsert, upsert, insertIgnore, batchUpsert). That
+ * meant the mandatory JSON stringify and any @Column({ transformer }) never ran,
+ * so a JS object bound to a JSON column threw under better-sqlite3 and custom
+ * transformer columns were stored raw while reads still applied transformer.from.
+ */
+
+import "reflect-metadata";
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+} from "../../../src";
+import { getScannerInstance } from "../../../src/scanner/ScannerContainer";
+import { ColumnScanner } from "../../../src/scanner";
+import {
+  createTestConnection,
+  type TestConnectionResult,
+} from "../helpers/test-connection";
+import { generateTableName } from "../helpers/create-test-entity";
+
+describe("[Integration] SQLite: insertMany/insertManyAndReturn apply write transformers", () => {
+  let conn: TestConnectionResult;
+  let tableName: string;
+  let EntityClass: new () => any;
+
+  beforeAll(async () => {
+    tableName = generateTableName("ins_xf");
+
+    conn = await createTestConnection(
+      {
+        type: "sqlite",
+        database: ":memory:",
+        synchronize: true,
+        logging: false,
+      },
+      () => {
+        getScannerInstance(ColumnScanner).clear();
+
+        const DynClass = class {} as any;
+        Object.defineProperty(DynClass, "name", {
+          value: tableName,
+          writable: false,
+        });
+
+        Reflect.defineMetadata("design:type", Number, DynClass.prototype, "id");
+        PrimaryGeneratedColumn()(DynClass.prototype, "id");
+
+        Reflect.defineMetadata("design:type", String, DynClass.prototype, "name");
+        Column()(DynClass.prototype, "name");
+
+        // JSON column — the write path must JSON.stringify the JS object.
+        Reflect.defineMetadata("design:type", Object, DynClass.prototype, "profile");
+        Column({ type: "json", nullable: true })(DynClass.prototype, "profile");
+
+        // Custom transformer column — array stored as a CSV string.
+        Reflect.defineMetadata("design:type", Object, DynClass.prototype, "tags");
+        Column({
+          type: "text",
+          nullable: true,
+          transformer: {
+            to: (v: string[] | null | undefined) =>
+              v && v.length ? v.join(",") : null,
+            from: (v: string | null) => (v ? v.split(",") : []),
+          },
+        })(DynClass.prototype, "tags");
+
+        Entity()(DynClass);
+        EntityClass = DynClass;
+        return { entities: [DynClass] };
+      },
+    );
+  });
+
+  afterAll(async () => {
+    await conn.cleanup();
+  });
+
+  it("insertMany() stringifies JSON columns and applies the custom transformer", async () => {
+    const { em } = conn;
+
+    await em.insertMany(EntityClass, [
+      { name: "alice", profile: { role: "admin", level: 3 }, tags: ["x", "y"] },
+      { name: "bob", profile: { role: "viewer" }, tags: ["z"] },
+    ]);
+
+    const alice = await em.findOne(EntityClass, { where: { name: "alice" } as any });
+    expect(alice).toBeDefined();
+    // JSON round-trips back to a parsed object, not "[object Object]".
+    expect(alice!.profile).toEqual({ role: "admin", level: 3 });
+    // Custom transformer round-trips the array.
+    expect(alice!.tags).toEqual(["x", "y"]);
+  });
+
+  it("insertManyAndReturn() applies the same transforms on the returned rows", async () => {
+    const { em } = conn;
+
+    const rows = await em.insertManyAndReturn(EntityClass, [
+      { name: "carol", profile: { role: "editor", flags: [1, 2] }, tags: ["a"] },
+    ]);
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].profile).toEqual({ role: "editor", flags: [1, 2] });
+    expect(rows[0].tags).toEqual(["a"]);
+
+    // And re-reading from the DB confirms it was persisted correctly.
+    const carol = await em.findOne(EntityClass, { where: { name: "carol" } as any });
+    expect(carol!.profile).toEqual({ role: "editor", flags: [1, 2] });
+    expect(carol!.tags).toEqual(["a"]);
+  });
+});

--- a/__tests__/integration/sqlite/lazy-manytoone-relation-column.test.ts
+++ b/__tests__/integration/sqlite/lazy-manytoone-relation-column.test.ts
@@ -1,0 +1,146 @@
+/**
+ * SQLite In-Memory: lazy @ManyToOne backed by a snake_cased @RelationColumn FK.
+ *
+ * Regression: ReadExecutor injected the lazy proxy only when it could read the
+ * FK from the hydrated entity by the DB column name (`author_id`). But
+ * ResultTransformer remaps that column onto the shadow property (`authorId`),
+ * so the read returned undefined and the proxy was never injected — accessing
+ * `post.author` resolved to undefined even though the FK was present.
+ *
+ * The loader must read the shadow first (`authorId`) and fall back to the raw
+ * join column for plain @ManyToOne entities.
+ *
+ * SQLite has no ALTER TABLE ADD FOREIGN KEY → synchronize:false + manual DDL.
+ */
+
+import "reflect-metadata";
+import {
+  createTestConnection,
+  type TestConnectionResult,
+} from "../helpers/test-connection";
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  ManyToOne,
+  RelationColumn,
+} from "../../../src";
+import { getScannerInstance } from "../../../src/scanner/ScannerContainer";
+import {
+  ColumnScanner,
+  ManyToOneScanner,
+  OneToManyScanner,
+} from "../../../src/scanner";
+import { DatabaseClient } from "../../../src/DatabaseClient";
+
+function shortName(prefix: string): string {
+  return `${prefix}_${String(Date.now()).slice(-7)}`;
+}
+
+function clearScanners(): void {
+  getScannerInstance(ColumnScanner).clear();
+  getScannerInstance(ManyToOneScanner).clear();
+  getScannerInstance(OneToManyScanner).clear();
+}
+
+describe("[Integration] SQLite: lazy @ManyToOne via snake_cased @RelationColumn", () => {
+  let conn: TestConnectionResult;
+  let PostClass: new () => any;
+  let usersTable: string;
+  let postsTable: string;
+
+  beforeAll(async () => {
+    usersTable = shortName("lz_users");
+    postsTable = shortName("lz_posts");
+
+    let UC: any;
+
+    conn = await createTestConnection(
+      {
+        type: "sqlite",
+        database: ":memory:",
+        synchronize: false,
+        logging: false,
+      },
+      () => {
+        clearScanners();
+
+        UC = class {} as any;
+        Object.defineProperty(UC, "name", { value: usersTable });
+        Reflect.defineMetadata("design:type", Number, UC.prototype, "id");
+        PrimaryGeneratedColumn()(UC.prototype, "id");
+        Reflect.defineMetadata("design:type", String, UC.prototype, "name");
+        Column()(UC.prototype, "name");
+        Entity()(UC);
+
+        const PC = class {} as any;
+        Object.defineProperty(PC, "name", { value: postsTable });
+        Reflect.defineMetadata("design:type", Number, PC.prototype, "id");
+        PrimaryGeneratedColumn()(PC.prototype, "id");
+        Reflect.defineMetadata("design:type", String, PC.prototype, "title");
+        Column()(PC.prototype, "title");
+        // FK declared via @RelationColumn → the hydrated entity stores it under
+        // the `authorId` shadow, not `author_id`. The relation is lazy.
+        Reflect.defineMetadata("design:type", UC, PC.prototype, "author");
+        ManyToOne(() => UC, (u: any) => u.posts, { lazy: true })(
+          PC.prototype,
+          "author",
+        );
+        RelationColumn({ name: "author_id" })(PC.prototype, "author");
+        Entity()(PC);
+
+        PostClass = PC;
+        return { entities: [UC, PC] };
+      },
+    );
+
+    const connector = DatabaseClient.getInstance().getConnection();
+    await connector.query(`
+      CREATE TABLE IF NOT EXISTS "${usersTable}" (
+        "id" INTEGER PRIMARY KEY AUTOINCREMENT,
+        "name" TEXT NOT NULL DEFAULT ''
+      )
+    `);
+    await connector.query(`
+      CREATE TABLE IF NOT EXISTS "${postsTable}" (
+        "id" INTEGER PRIMARY KEY AUTOINCREMENT,
+        "title" TEXT NOT NULL DEFAULT '',
+        "author_id" INTEGER
+      )
+    `);
+
+    await connector.query(`INSERT INTO "${usersTable}" ("id","name") VALUES (1,'Alice')`);
+    await connector.query(`INSERT INTO "${postsTable}" ("id","title","author_id") VALUES (10,'A1',1)`);
+  });
+
+  afterAll(async () => {
+    await conn.cleanup();
+  });
+
+  it("injects a lazy proxy that resolves the parent via the FK shadow", async () => {
+    const { em } = conn;
+
+    const post = await em.findOne(PostClass, { where: { id: 10 } as any });
+    expect(post).toBeDefined();
+    // The FK is hydrated under the shadow property, not the raw column name.
+    expect((post as any).authorId).toBe(1);
+
+    // Accessing the lazy relation returns a promise that resolves the parent.
+    const author = await (post as any).author;
+    expect(author).toBeDefined();
+    expect(author.name).toBe("Alice");
+  });
+
+  it("leaves the relation unresolved (undefined) when the FK is null", async () => {
+    const { em } = conn;
+    const connector = DatabaseClient.getInstance().getConnection();
+    await connector.query(
+      `INSERT INTO "${postsTable}" ("id","title","author_id") VALUES (11,'orphan',NULL)`,
+    );
+
+    const post = await em.findOne(PostClass, { where: { id: 11 } as any });
+    expect(post).toBeDefined();
+    const author = await (post as any).author;
+    expect(author).toBeUndefined();
+  });
+});

--- a/__tests__/unit/raw-query-builder.test.ts
+++ b/__tests__/unit/raw-query-builder.test.ts
@@ -65,6 +65,33 @@ describe("RawQueryBuilder", () => {
       expect(query.sql).toBe("SELECT * FROM users");
       expect(query.values).toEqual([]);
     });
+
+    it("빈 where([]) 다음의 whereNull은 dangling AND가 아닌 WHERE를 열어야 함", () => {
+      // Regression: where([]) used to mark hasWhereClause=true without
+      // emitting a WHERE, so the next smart predicate produced
+      // "... FROM users AND deleted_at IS NULL" (syntax error).
+      const query = RawQueryBuilderFactory.create()
+        .select("*")
+        .from("users")
+        .where([])
+        .whereNull("deleted_at")
+        .build();
+
+      expect(query.sql).toBe("SELECT * FROM users WHERE deleted_at IS NULL");
+      expect(query.values).toEqual([]);
+    });
+
+    it("빈 where([]) 다음의 whereIn은 WHERE를 열어야 함", () => {
+      const query = RawQueryBuilderFactory.create()
+        .select("*")
+        .from("users")
+        .where([])
+        .whereIn("id", [1, 2])
+        .build();
+
+      expect(query.sql).toBe("SELECT * FROM users WHERE id IN (?, ?)");
+      expect(query.values).toEqual([1, 2]);
+    });
   });
 
   describe("orderBy", () => {

--- a/__tests__/unit/schema-diff.test.ts
+++ b/__tests__/unit/schema-diff.test.ts
@@ -235,6 +235,31 @@ describe("SchemaDiff", () => {
     });
   });
 
+  describe("diff() — type-change alter carries length/precision", () => {
+    it("MySQL: int→varchar type change carries expectedLength so DDL is VARCHAR(255)", async () => {
+      const runner = createMockQueryRunner({
+        diff_user: [
+          { column_name: "id", data_type: "int", is_nullable: "NO" },
+          // entity: VARCHAR(255), DB has INT → type alter
+          { column_name: "name", data_type: "int", is_nullable: "NO" },
+          { column_name: "age", data_type: "int", is_nullable: "NO" },
+          { column_name: "active", data_type: "tinyint", is_nullable: "NO" },
+        ],
+      });
+
+      const result = await schemaDiff.diff([DiffUser], runner, "mysql");
+      const nameAlter = result.alterColumns.find((c) => c.columnName === "name");
+      expect(nameAlter).toBeDefined();
+      expect(nameAlter!.columnType).toBe("VARCHAR");
+      // Regression: previously omitted → DDL emitted bare "VARCHAR" (MySQL 1064).
+      expect(nameAlter!.expectedLength).toBe(255);
+
+      // End-to-end: the generated migration must include the length.
+      const content = new SchemaDiffMigrationGenerator().generate(result, "mysql");
+      expect(content).toContain("VARCHAR(255)");
+    });
+  });
+
   describe("diff() — timestamptz handling", () => {
     it("MySQL: timestamptz matches a DATETIME column (no spurious/invalid ALTER)", async () => {
       const runner = createMockQueryRunner({

--- a/__tests__/unit/schema-registrar-index-sqlite.test.ts
+++ b/__tests__/unit/schema-registrar-index-sqlite.test.ts
@@ -1,0 +1,107 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import "reflect-metadata";
+
+jest.mock("../../src/scanner/ScannerContainer", () => ({
+  getScannerInstance: jest.fn(() => ({
+    scan: () => undefined,
+  })),
+}));
+
+import { INDEX_TOKEN, IndexMetadata } from "../../src/decorators/Indexer";
+import { COLUMN_TOKEN } from "../../src/decorators/Column";
+import { ColumnMetadata } from "../../src/scanner";
+import { SchemaRegistrar } from "../../src/core/SchemaRegistrar";
+import type { RelationMetadataResolver } from "../../src/core/RelationMetadataResolver";
+import type { EntityManagerInternals } from "../../src/core/EntityManagerInternals";
+
+// ──────────────────────────────────────────────
+// Fixture: an entity with a single-column @Index() on `email`.
+// ──────────────────────────────────────────────
+class IndexedUser {}
+
+beforeAll(() => {
+  Reflect.defineMetadata(
+    INDEX_TOKEN,
+    [{ target: IndexedUser, name: "email", type: undefined }] as IndexMetadata[],
+    IndexedUser.prototype,
+  );
+  Reflect.defineMetadata(
+    COLUMN_TOKEN,
+    [{ propertyKey: "email", name: "email" }] as ColumnMetadata[],
+    IndexedUser.prototype,
+  );
+});
+
+function makeSqliteDriver(opts: { existingIndexNames?: string[] }) {
+  const calls = { getIndexes: [] as string[], addIndex: [] as any[] };
+
+  // SQLite's PRAGMA index_list exposes the index name under `name`
+  // (not MySQL's `Key_name` / PostgreSQL's `Field`).
+  const indexRows = (opts.existingIndexNames ?? []).map((n) => ({ name: n }));
+
+  const driver = {
+    getIndexes: jest.fn(async (table: string) => {
+      calls.getIndexes.push(table);
+      return indexRows;
+    }),
+    addIndex: jest.fn(async (table: string, column: string, name: string) => {
+      calls.addIndex.push({ table, column, name });
+    }),
+  } as any;
+
+  return { driver, calls };
+}
+
+function makeSqliteCtx(driver: any): EntityManagerInternals {
+  return {
+    wrap: (c: string) => `"${c}"`,
+    wrapTable: (t: string) => `"${t}"`,
+    isMySqlFamily: () => false,
+    isPostgres: () => false,
+    isSqlite: () => true,
+    getDriver: () => driver,
+    getSynchronize: () => true,
+    getDialect: () => "sqlite",
+    getSchema: () => undefined,
+    getConnection: () => undefined,
+    getEntities: () => [],
+    getNameStrategy: (e: any) => e.name,
+  } as unknown as EntityManagerInternals;
+}
+
+const noopResolver: RelationMetadataResolver = {
+  resolveManyToOneMetadata: () => [],
+  resolveOneToOneMetadata: () => [],
+} as unknown as RelationMetadataResolver;
+
+describe("SchemaRegistrar.registerIndex — SQLite idempotency", () => {
+  it("creates the index when none exists", async () => {
+    const { driver, calls } = makeSqliteDriver({});
+    const registrar = new SchemaRegistrar(noopResolver, makeSqliteCtx(driver));
+
+    await registrar.registerIndex(IndexedUser, "indexed_user");
+
+    expect(calls.addIndex).toHaveLength(1);
+    expect(calls.addIndex[0]).toEqual({
+      table: "indexed_user",
+      column: "email",
+      name: "INDEX_indexed_user_email",
+    });
+  });
+
+  it("detects an existing SQLite index (PRAGMA index_list `name`) and does not re-create it", async () => {
+    // Regression: the existence check used Key_name ?? Field only, so SQLite
+    // index rows (keyed by `name`) never matched and addIndex re-ran every
+    // boot — and SQLite's CREATE INDEX has no IF NOT EXISTS, throwing on the
+    // second start.
+    const { driver, calls } = makeSqliteDriver({
+      existingIndexNames: ["INDEX_indexed_user_email"],
+    });
+    const registrar = new SchemaRegistrar(noopResolver, makeSqliteCtx(driver));
+
+    await registrar.registerIndex(IndexedUser, "indexed_user");
+
+    expect(calls.getIndexes).toEqual(["indexed_user"]);
+    expect(calls.addIndex).toHaveLength(0);
+  });
+});

--- a/src/core/RawQueryBuilder.ts
+++ b/src/core/RawQueryBuilder.ts
@@ -139,8 +139,9 @@ export class RawQueryBuilder implements BaseRawQueryBuilder {
    */
   where(conditions: Sql[]): RawQueryBuilder {
     if (conditions.length === 0) {
-      // No conditions: skip WHERE clause entirely (matches all rows)
-      this.hasWhereClause = true;
+      // No conditions: skip the WHERE clause entirely (matches all rows).
+      // Leave hasWhereClause false so a subsequent whereIn/whereNull/etc.
+      // opens a fresh WHERE rather than emitting a dangling "AND".
       return this;
     }
     this.sqlQuerySegments.push(sql`WHERE ${join(conditions, " AND ")}`);

--- a/src/core/SchemaRegistrar.ts
+++ b/src/core/SchemaRegistrar.ts
@@ -1187,8 +1187,13 @@ export class SchemaRegistrar {
 
         let isExist = false;
         for (const idx of indexes || []) {
-          // MySQL uses "Key_name"; PostgreSQL uses "Field" (aliased from indexname).
-          const existingIndexName = idx["Key_name"] ?? idx["Field"];
+          // MySQL uses "Key_name"; PostgreSQL uses "Field" (aliased from
+          // indexname); SQLite's PRAGMA index_list exposes it as "name".
+          // Without the "name" fallback the existence check never matches on
+          // SQLite, so addIndex (CREATE INDEX, no IF NOT EXISTS) re-runs every
+          // boot and throws "index already exists" on the second start.
+          const existingIndexName =
+            idx["Key_name"] ?? idx["Field"] ?? idx["name"];
           if (existingIndexName === indexName) {
             isExist = true;
             break;

--- a/src/core/entity-manager/ReadExecutor.ts
+++ b/src/core/entity-manager/ReadExecutor.ts
@@ -797,10 +797,17 @@ export class ReadExecutor {
 
         for (const rel of lazyRelations) {
           const joinColumn = rel.joinColumn ?? rel.columnName;
+          // ResultTransformer remaps an @RelationColumn / snake_case FK column
+          // onto its shadow property (e.g. user_id -> userId), so the hydrated
+          // entity carries the FK value under the shadow, not under joinColumn.
+          // Read the shadow first, then fall back to the raw join column for
+          // plain @ManyToOne entities whose FK stays under the DB column name.
+          const fkShadow = rel.option?.fkProperty ?? `${rel.columnName}Id`;
           const RelatedEntity = rel.getMappingEntity() as ClazzType<any>;
 
           for (const item of entities) {
-            const fkValue = (item as any)[joinColumn];
+            const fkValue =
+              (item as any)[fkShadow] ?? (item as any)[joinColumn];
             if (fkValue === undefined || fkValue === null) continue;
 
             const relatedMetadata = this.resolver.resolveEntityMetadata(RelatedEntity);

--- a/src/core/entity-manager/WriteExecutor.ts
+++ b/src/core/entity-manager/WriteExecutor.ts
@@ -1249,9 +1249,16 @@ export class WriteExecutor {
       }
 
       const valueRows = items.map((item) => {
-        const rowValues = insertableColumns.map(
-          (column: ColumnMetadata) => (item as any)[this.ctx.propKey(column)],
-        );
+        const rowValues = insertableColumns.map((column: ColumnMetadata) => {
+          // Mirror saveManyBatchInsert: write transformers (@Column transformer.to,
+          // registered ColumnType transformers, and the mandatory JSON stringify)
+          // must run on this path too, otherwise JSON/transformer columns are bound
+          // raw while reads still apply transformer.from.
+          const rawValue = (item as any)[this.ctx.propKey(column)];
+          const transformed = this.ctx.applyWriteTransform(column, rawValue);
+          if (transformed instanceof Date) return formatDateTimeForSQL(transformed);
+          return transformed;
+        });
         for (const fk of fkColumns) {
           const relatedValue = (item as any)[fk.propertyName];
           const idPropValue = (item as any)[`${fk.propertyName}Id`];
@@ -1405,9 +1412,16 @@ export class WriteExecutor {
       }
 
       const valueRows = items.map((item) => {
-        const rowValues = insertableColumns.map(
-          (column: ColumnMetadata) => (item as any)[this.ctx.propKey(column)],
-        );
+        const rowValues = insertableColumns.map((column: ColumnMetadata) => {
+          // Mirror saveManyBatchInsert: write transformers (@Column transformer.to,
+          // registered ColumnType transformers, and the mandatory JSON stringify)
+          // must run on this path too, otherwise JSON/transformer columns are bound
+          // raw while reads still apply transformer.from.
+          const rawValue = (item as any)[this.ctx.propKey(column)];
+          const transformed = this.ctx.applyWriteTransform(column, rawValue);
+          if (transformed instanceof Date) return formatDateTimeForSQL(transformed);
+          return transformed;
+        });
         for (const fk of fkColumns) {
           const relatedValue = (item as any)[fk.propertyName];
           const idPropValue = (item as any)[`${fk.propertyName}Id`];

--- a/src/core/generators/SchemaDiff.ts
+++ b/src/core/generators/SchemaDiff.ts
@@ -194,6 +194,16 @@ export class SchemaDiff {
               // Carry the declared nullability — MySQL's MODIFY COLUMN restates
               // the whole definition, so omitting this silently drops NOT NULL.
               nullable: col.options?.nullable ?? false,
+              // Carry length/precision/scale too: castType emits a bare type
+              // (e.g. "VARCHAR", "DECIMAL"), so without these the generated
+              // ALTER becomes "MODIFY ... VARCHAR" — a MySQL 1064 syntax error
+              // — and DECIMAL would silently lose its precision/scale.
+              expectedLength: col.options?.length ?? null,
+              actualLength: dbCol.character_maximum_length ?? null,
+              expectedPrecision: col.options?.precision ?? null,
+              actualPrecision: dbCol.numeric_precision ?? null,
+              expectedScale: col.options?.scale ?? null,
+              actualScale: dbCol.numeric_scale ?? null,
               enumValues: col.options?.enumValues,
             });
           } else if (!this.lengthsMatch(col.options, dbCol)) {

--- a/src/core/generators/SchemaDiffMigrationGenerator.ts
+++ b/src/core/generators/SchemaDiffMigrationGenerator.ts
@@ -129,7 +129,7 @@ export class SchemaDiffMigrationGenerator {
 
     // Alter columns
     for (const col of diff.alterColumns) {
-      const typeStr = col.columnType ?? "VARCHAR(255)";
+      const typeStr = this.renderColumnType(col, dialect);
       if (dialect === "sqlite") {
         // SQLite cannot alter column types — skip in SQL
       } else if (dialect === "mysql") {
@@ -254,7 +254,7 @@ export class SchemaDiffMigrationGenerator {
 
     // Alter columns (type change)
     for (const col of diff.alterColumns) {
-      const typeStr = col.columnType ?? "VARCHAR(255)";
+      const typeStr = this.renderColumnType(col, dialect);
       if (dialect === "sqlite") {
         stmts.push(
           `// TODO: SQLite does not support ALTER COLUMN TYPE for ${this.escapeId(col.tableName, dialect)}.${this.escapeId(col.columnName, dialect)} (${col.currentType} -> ${typeStr}). Recreate the table instead.`,
@@ -472,7 +472,31 @@ export class SchemaDiffMigrationGenerator {
   }
 
   private renderColumnType(col: ColumnChange, _dialect: SchemaDialect): string {
-    return col.columnType ?? "VARCHAR(255)";
+    let type = col.columnType ?? "VARCHAR(255)";
+
+    // castType emits bare types (e.g. "VARCHAR", "DECIMAL"), so the declared
+    // length/precision/scale must be reattached here — otherwise the generated
+    // ALTER/ADD becomes "... VARCHAR" (MySQL 1064) and DECIMAL loses its scale.
+    if (type.toUpperCase().startsWith("ENUM") && col.enumValues?.length) {
+      const values = col.enumValues
+        .map((v) => `'${escapeEnumValue(v)}'`)
+        .join(",");
+      type = `ENUM(${values})`;
+    }
+
+    if (!type.includes("(")) {
+      if (col.expectedLength) {
+        type = `${type}(${col.expectedLength})`;
+      } else if (col.expectedPrecision) {
+        const scale =
+          col.expectedScale !== undefined && col.expectedScale !== null
+            ? `,${col.expectedScale}`
+            : "";
+        type = `${type}(${col.expectedPrecision}${scale})`;
+      }
+    }
+
+    return type;
   }
 
   /**

--- a/src/core/plugin/buffer/LazyRelationInjector.ts
+++ b/src/core/plugin/buffer/LazyRelationInjector.ts
@@ -64,9 +64,12 @@ export class LazyRelationInjector {
       // Skip if already loaded (not undefined)
       if (instance[rel.columnName] !== undefined) continue;
 
-      // FK column: explicit joinColumn or fallback to columnName
-      const fkProp = rel.joinColumn ?? rel.columnName;
-      const fkValue = instance[fkProp];
+      // FK value: a hydrated entity stores an @RelationColumn / snake_case FK
+      // under its shadow property (e.g. user_id -> userId), so read the shadow
+      // first and fall back to the raw join column for plain @ManyToOne FKs.
+      const fkShadow = rel.option?.fkProperty ?? `${rel.columnName}Id`;
+      const fkColumn = rel.joinColumn ?? rel.columnName;
+      const fkValue = instance[fkShadow] ?? instance[fkColumn];
       if (fkValue === undefined || fkValue === null) continue;
 
       const RelatedEntity = rel.getMappingEntity() as any as ClazzType<any>;


### PR DESCRIPTION
## Summary

Five independent, verified correctness bugs surfaced by an audit of the query builder, schema generation/diff, and result/relation mapping. Each fix is a focused commit with a regression test that was confirmed to fail without the fix and pass with it. Several target the snake_case / `@RelationColumn` (multi-tenant) configuration, where column-name vs property-name divergence hides bugs that default naming masks.

## Fixes

**1. `fix(schema)` — detect existing SQLite indexes**
`SchemaRegistrar.registerIndex` resolved an existing index name from `Key_name ?? Field` (MySQL/PostgreSQL), but SQLite's `PRAGMA index_list` returns it under `name`. The check never matched, so `addIndex` re-ran every boot — and `SqliteDriver.addIndex` uses `CREATE INDEX` with no `IF NOT EXISTS`, throwing "index already exists" on the second start. Now includes the `name` fallback, matching the sibling unique/full-text index methods.

**2. `fix(core)` — write transformers in `insertMany` / `insertManyAndReturn`**
Both batch paths bound raw property values, skipping `applyWriteTransform` (the mandatory JSON stringify and `@Column({ transformer })`) that every other write path runs. A JS object bound to a JSON column threw under better-sqlite3, and transformer columns were stored raw while reads still applied `transformer.from`. Both paths now mirror `saveManyBatchInsert`.

**3. `fix(core)` — read lazy `@ManyToOne` FK from the shadow property**
`ReadExecutor` and the buffer-plugin `LazyRelationInjector` read the FK by DB column name (`user_id`), but under `@RelationColumn` / `SnakeNamingStrategy` the hydrated entity stores it on the shadow (`userId`). The read returned undefined, so the lazy proxy was never injected and the relation resolved to undefined. Both sites now read the shadow first, falling back to the join column for plain `@ManyToOne`.

**4. `fix(query-builder)` — `RawQueryBuilder.where([])` dangling AND**
`where([])` adds no WHERE clause but set `hasWhereClause = true`, so a following `whereIn` / `whereNull` / `whereBetween` emitted `AND` instead of `WHERE`, producing `... FROM t AND <cond>` (syntax error). The empty branch no longer sets the flag.

**5. `fix(schema)` — keep length/precision on a type-change ALTER**
The SchemaDiff type-mismatch branch dropped `expectedLength` / `expectedPrecision` / `expectedScale` (the length-mismatch branch already carried them). Since `castType` emits bare types, a type change generated `MODIFY COLUMN ... VARCHAR` (MySQL 1064) and DECIMAL lost its scale. The diff now carries them, and `SchemaDiffMigrationGenerator.renderColumnType` centralizes type composition (enum + length + precision/scale) for both the live sync path and generated migrations.

## Testing

- 3 new test files + 2 extended; each new case verified to fail on reverted source.
- `tsc --noEmit` clean.
- Full unit + SQLite integration suite: 315 suites, 5753 passed, 0 failures.

MySQL/PostgreSQL integration suites were not run locally (require live servers); the changes are dialect-aware and covered by unit tests for the SQL they generate.