### PR TITLE
fix(query-builder): defer aliased SELECT projections + selectRaw expression passthrough

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ Releases: https://github.com/biud436/stingerloom-orm/releases
 
 ---
 
+## [Unreleased]
+
+Query-builder fixes that let nested-set / self-join tree queries (the shape that previously forced `em.query` raw SQL) be written entirely through the typed builder. Both were surfaced porting a real Category service off raw SQL. Verified: full unit suite + SQLite integration green.
+
+### Fixed
+
+- **`select([alias.col.as(...)])` now resolves a JOIN alias referenced before the join is registered.** Aliased projections are rendered at build time instead of eagerly at `select()` call time, so a forward reference such as `select([parent.name.as("name")]).innerJoin(Category, "parent", ...)` resolves `parent.name` to its real column (`parent.CTGR_NM`) instead of leaving it unqualified. Select order no longer changes the generated SQL. (One internal behavioral note: a dialect guard on an unsupported aggregate — e.g. `percentile_cont` on MySQL — now fires when the SQL is assembled, not at the `select()` call.)
+- **`selectRaw([...])` passes raw SQL expressions through untouched.** A token is alias-qualified only when it is a bare column reference (`prop` or `alias.prop`); expressions like `COUNT(*)`, `MAX(p.views)`, or `1` are emitted verbatim instead of being mangled into `"alias"."COUNT(*)"`. This makes `selectRaw(["COUNT(*)"])` usable inside `addSelectSubquery()` correlated subqueries.
+
 ## [1.0.0] — 2026-06-20
 
 Insert/save correctness fixes and query-builder expressiveness (#368-#372). One behavioral note: `*AndSelect` + `getRawMany()` now returns `alias_column`-prefixed keys (the SELECT list is fully aliased to prevent column clobbering).

--- a/__tests__/integration/sqlite/select-query-builder-nested-set.test.ts
+++ b/__tests__/integration/sqlite/select-query-builder-nested-set.test.ts
@@ -1,0 +1,214 @@
+/**
+ * SQLite in-memory: nested-set (tree) queries expressed entirely through the
+ * query builder — no raw SQL. Models a real-world Category entity with custom
+ * column names (CTGR_SQ / CTGR_NM / LFT_NO / RGT_NO / CTGR_GRP_SQ) plus Post,
+ * the shape that previously forced `em.query` raw SQL in a consuming app.
+ *
+ * Exercises end-to-end (build + execute against a real driver):
+ *  - self-join via JoinOnBuilder.onBetween (range containment)
+ *  - aggregate arithmetic in SELECT (COUNT(name) - 1 AS depth)
+ *  - scalar arithmetic in SELECT (FLOOR((rgt - (lft + 1)) / 2) AS children)
+ *  - correlated scalar subquery in SELECT (addSelectSubquery + outer refs)
+ *  - operator-object DELETE criteria ({ between }) for subtree removal
+ *  - save() mapping a custom-named PK/columns back to entity property keys
+ *
+ * The breadcrumb + subtree-count cases double as regression guards for two QB
+ * fixes:
+ *  - deferred aliased-projection rendering (select() before innerJoin())
+ *  - selectRaw() raw-expression passthrough (COUNT(*) inside a subquery)
+ *
+ * Guarded by INTEGRATION_TEST=true (excluded from the default unit run).
+ */
+import "reflect-metadata";
+import {
+  createTestConnection,
+  rawQuery,
+  type TestConnectionResult,
+} from "../helpers/test-connection";
+import { Entity, Column, PrimaryGeneratedColumn, qAlias } from "../../../src";
+
+@Entity({ name: "category" })
+class Category {
+  @PrimaryGeneratedColumn({ name: "CTGR_SQ" })
+  id!: number;
+  @Column({ type: "varchar", length: 255, name: "CTGR_NM" })
+  name!: string;
+  @Column({ type: "int", name: "LFT_NO" })
+  left!: number;
+  @Column({ type: "int", name: "RGT_NO" })
+  right!: number;
+  @Column({ type: "int", name: "CTGR_GRP_SQ", default: 1 })
+  groupId!: number;
+}
+
+@Entity({ name: "post" })
+class Post {
+  @PrimaryGeneratedColumn()
+  id!: number;
+  @Column({ type: "int", name: "category_id" })
+  categoryId!: number;
+}
+
+describe("[Integration] SQLite In-Memory: nested-set tree via QueryBuilder", () => {
+  let conn: TestConnectionResult;
+  let em: any;
+
+  beforeAll(async () => {
+    conn = await createTestConnection(
+      { type: "sqlite", database: ":memory:", synchronize: false, logging: false },
+      () => ({ entities: [Category, Post] }),
+    );
+    em = conn.em;
+
+    await rawQuery(
+      `CREATE TABLE "category" (
+        "CTGR_SQ" INTEGER PRIMARY KEY AUTOINCREMENT,
+        "CTGR_NM" TEXT NOT NULL,
+        "LFT_NO" INTEGER NOT NULL,
+        "RGT_NO" INTEGER NOT NULL,
+        "CTGR_GRP_SQ" INTEGER NOT NULL DEFAULT 1
+      )`,
+    );
+    await rawQuery(
+      `CREATE TABLE "post" (
+        "id" INTEGER PRIMARY KEY AUTOINCREMENT,
+        "category_id" INTEGER NOT NULL
+      )`,
+    );
+
+    // Tree:  Root(1,10) → A(2,5) → A1(3,4) ; Root → B(6,9) → B1(7,8)
+    const repo = em.getRepository(Category);
+    await repo.save({ name: "Root", left: 1, right: 10, groupId: 1 });
+    await repo.save({ name: "A", left: 2, right: 5, groupId: 1 });
+    await repo.save({ name: "A1", left: 3, right: 4, groupId: 1 });
+    await repo.save({ name: "B", left: 6, right: 9, groupId: 1 });
+    await repo.save({ name: "B1", left: 7, right: 8, groupId: 1 });
+
+    // Posts: 2 in A1 (id 3), 1 in B (id 4)
+    const postRepo = em.getRepository(Post);
+    await postRepo.save({ categoryId: 3 });
+    await postRepo.save({ categoryId: 3 });
+    await postRepo.save({ categoryId: 4 });
+  });
+
+  afterAll(async () => {
+    await conn.cleanup();
+  });
+
+  it("save() maps custom-named columns back to entity property keys", async () => {
+    const repo = em.getRepository(Category);
+    const saved = await repo.save({ name: "Probe", left: 100, right: 101, groupId: 1 });
+
+    expect(saved.id).toBeGreaterThan(0);
+    expect(saved.name).toBe("Probe");
+    expect(saved.left).toBe(100);
+    // The raw DB column name must NOT leak onto the returned entity.
+    expect((saved as any).CTGR_SQ).toBeUndefined();
+
+    await repo.deleteMany([saved.id]);
+  });
+
+  it("computes depth via self-join + COUNT(name)-1 + GROUP BY", async () => {
+    const node = qAlias(Category, "node");
+    const repo = em.getRepository(Category);
+    const rows = await repo
+      .createQueryBuilder("node")
+      .select([
+        node.id.as("id"),
+        node.left.as("left"),
+        node.right.as("right"),
+        node.name.as("name"),
+        node.name.count().sub(1).as("depth"),
+      ])
+      .innerJoin(Category, "parent", (j: any) =>
+        j.onBetween("node.left", "parent.left", "parent.right"),
+      )
+      .groupBy(["node.left"])
+      .addOrderBy("node.left", "ASC")
+      .getRawMany();
+
+    const depthByName = Object.fromEntries(
+      rows.map((r: any) => [r.name, Number(r.depth)]),
+    );
+    expect(depthByName).toEqual({ Root: 0, A: 1, A1: 2, B: 1, B1: 2 });
+  });
+
+  it("builds a breadcrumb path via self-join (select before join)", async () => {
+    const node = qAlias(Category, "node");
+    const parent = qAlias(Category, "parent");
+    const repo = em.getRepository(Category);
+    const rows = await repo
+      .createQueryBuilder("node")
+      .select([parent.name.as("name")])
+      .innerJoin(Category, "parent", (j: any) =>
+        j.onBetween("node.left", "parent.left", "parent.right"),
+      )
+      .where(node.name.eq("A1"))
+      .addOrderBy("parent.left", "ASC")
+      .getRawMany();
+
+    expect(rows.map((r: any) => r.name).join(" > ")).toBe("Root > A > A1");
+  });
+
+  it("counts subtree posts via a correlated scalar subquery in SELECT", async () => {
+    const node = qAlias(Category, "node");
+    const a = qAlias(Category, "a");
+    const repo = em.getRepository(Category);
+    const rows = await repo
+      .createQueryBuilder("node")
+      .select([
+        node.id.as("id"),
+        node.name.as("name"),
+        node.right.sub(node.left.add(1)).div(2).floor().as("children"),
+        node.name.count().sub(1).as("depth"),
+      ])
+      .addSelectSubquery(
+        (outer: any) =>
+          em
+            .createQueryBuilder(Post, "post")
+            .selectRaw(["COUNT(*)"])
+            .innerJoin(Category, "a", (j: any) =>
+              j.on("post.categoryId", "=", "a.id"),
+            )
+            .where(a.left.between(outer("node.left"), outer("node.right"))),
+        "postCount",
+      )
+      .innerJoin(Category, "parent", (j: any) =>
+        j.onBetween("node.left", "parent.left", "parent.right"),
+      )
+      .groupBy(["node.left"])
+      .addOrderBy("node.left", "ASC")
+      .getRawMany();
+
+    const byName = Object.fromEntries(
+      rows.map((r: any) => [
+        r.name,
+        { children: Number(r.children), postCount: Number(r.postCount) },
+      ]),
+    );
+    // Root subtree owns all 3 posts; A subtree (A,A1) owns 2; A1 owns 2; B owns 1.
+    expect(byName.Root.postCount).toBe(3);
+    expect(byName.A.postCount).toBe(2);
+    expect(byName.A1.postCount).toBe(2);
+    expect(byName.B.postCount).toBe(1);
+    expect(byName.B1.postCount).toBe(0);
+    // children = (rgt - (lft + 1)) / 2
+    expect(byName.Root.children).toBe(4);
+    expect(byName.A.children).toBe(1);
+    expect(byName.A1.children).toBe(0);
+  });
+
+  it("removes a subtree via operator-object DELETE criteria ({ between })", async () => {
+    const repo = em.getRepository(Category);
+    await repo.save({ name: "tmp", left: 200, right: 201, groupId: 9 });
+
+    const res = await em.delete(Category, {
+      left: { between: [200, 201] },
+      groupId: 9,
+    });
+
+    expect(res.affected).toBe(1);
+    const remaining = await repo.findOne({ where: { groupId: 9 } });
+    expect(remaining).toBeNull();
+  });
+});

--- a/__tests__/unit/ordered-set-aggregate-sqb-integration.test.ts
+++ b/__tests__/unit/ordered-set-aggregate-sqb-integration.test.ts
@@ -128,13 +128,15 @@ describe("OrderedSetAggregate × SelectQueryBuilder integration", () => {
   it("rejects the same builder shape on MySQL with UNSUPPORTED_OPERATION", () => {
     const qb = createQb("mysql");
     const i = qAlias(Issue, "i");
-    // The AliasedExpression renderer runs eagerly inside select() so the
-    // dialect guard fires at projection-binding time, not at build time.
+    // `select([...])` projections are rendered at build time (deferred) so a
+    // projection may reference a JOIN alias registered after the select()
+    // call. The dialect guard therefore fires when the SQL is assembled,
+    // not at projection-binding time — select() itself does not throw.
+    qb.select([Expressions.percentileCont(0.5, i.id).as("p50")]);
+    expect(() => qb.getSql()).toThrow(OrmError);
     try {
-      qb.select([Expressions.percentileCont(0.5, i.id).as("p50")]);
-      fail("expected throw");
+      qb.getSql();
     } catch (e) {
-      expect(e).toBeInstanceOf(OrmError);
       expect((e as OrmError).code).toBe(OrmErrorCode.UNSUPPORTED_OPERATION);
       expect((e as OrmError).message).toMatch(/PostgreSQL/);
     }

--- a/__tests__/unit/select-query-builder-deferred-projection.test.ts
+++ b/__tests__/unit/select-query-builder-deferred-projection.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Deferred aliased-projection rendering + selectRaw expression passthrough.
+ *
+ * Two QB fixes motivated by porting a nested-set tree (self-join + custom
+ * column names) off raw SQL:
+ *
+ * 1. `select([alias.col.as(...)])` projections are rendered at BUILD time,
+ *    not eagerly at select() call time — so a projection may reference a
+ *    JOIN alias registered AFTER the select() call (forward reference).
+ *    Eager resolution left such columns unqualified/unmapped.
+ *
+ * 2. `selectRaw([...])` only alias-qualifies BARE column refs (`prop` /
+ *    `alias.prop`); raw SQL expressions (`COUNT(*)`, `MAX(p.views)`) pass
+ *    through untouched instead of being mangled into `"alias"."COUNT(*)"`.
+ */
+import "reflect-metadata";
+import { SelectQueryBuilder } from "../../src/core/SelectQueryBuilder";
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+} from "../../src/decorators";
+import { qAlias } from "../../src/core/SelectQueryBuilder";
+import { EntityManager } from "../../src/core/EntityManager";
+import { RelationMetadataResolver } from "../../src/core/RelationMetadataResolver";
+
+@Entity({ name: "category" })
+class TreeCat {
+  @PrimaryGeneratedColumn({ name: "CTGR_SQ" })
+  id!: number;
+  @Column({ type: "varchar", length: 255, name: "CTGR_NM" })
+  name!: string;
+  @Column({ type: "int", name: "LFT_NO" })
+  left!: number;
+  @Column({ type: "int", name: "RGT_NO" })
+  right!: number;
+}
+
+function createMockEm() {
+  const resolver = new RelationMetadataResolver();
+  const wrap = (col: string) => `\`${col.replace(/`/g, "``")}\``;
+  return {
+    wrap,
+    wrapTable: (t: string) => wrap(t),
+    resolver,
+    _ctx: {
+      isMySqlFamily: () => true,
+      isPostgres: () => false,
+      isSqlite: () => false,
+      getDialect: () => "mysql",
+    },
+  } as unknown as EntityManager;
+}
+
+function newQb() {
+  const em = createMockEm();
+  const qb = new SelectQueryBuilder<TreeCat>(TreeCat, "node", em);
+  // Wire the root alias's property→column map (as EntityManager.createQueryBuilder does).
+  qb.setPropertyToColumnMap(
+    new Map([
+      ["id", "CTGR_SQ"],
+      ["name", "CTGR_NM"],
+      ["left", "LFT_NO"],
+      ["right", "RGT_NO"],
+    ]),
+  );
+  return qb;
+}
+
+describe("deferred aliased projection (forward reference to JOIN alias)", () => {
+  it("resolves a joined alias's custom column when select() PRECEDES innerJoin()", () => {
+    const node = qAlias(TreeCat, "node");
+    const parent = qAlias(TreeCat, "parent");
+
+    const qb = newQb()
+      .select([parent.name.as("name")]) // referenced before "parent" is registered
+      .innerJoin(TreeCat, "parent", (j) =>
+        j.onBetween("node.left", "parent.left", "parent.right"),
+      )
+      .where(node.name.eq("A1"));
+
+    const { text } = qb.getSql();
+    // The forward-referenced column must be mapped + qualified, not left raw.
+    expect(text).toContain("`parent`.`CTGR_NM` AS `name`");
+    expect(text).not.toContain("`parent`.`name`");
+  });
+
+  it("produces identical SQL whether select() comes before or after the join", () => {
+    const parent = qAlias(TreeCat, "parent");
+
+    const before = newQb()
+      .select([parent.name.as("name")])
+      .innerJoin(TreeCat, "parent", (j) =>
+        j.onBetween("node.left", "parent.left", "parent.right"),
+      )
+      .getSql().text;
+
+    const after = newQb()
+      .innerJoin(TreeCat, "parent", (j) =>
+        j.onBetween("node.left", "parent.left", "parent.right"),
+      )
+      .select([parent.name.as("name")])
+      .getSql().text;
+
+    expect(before).toBe(after);
+  });
+
+  it("still maps the root alias's own custom columns + aggregate arithmetic", () => {
+    const node = qAlias(TreeCat, "node");
+    const qb = newQb()
+      .select([
+        node.id.as("id"),
+        node.name.count().sub(1).as("depth"),
+      ])
+      .innerJoin(TreeCat, "parent", (j) =>
+        j.onBetween("node.left", "parent.left", "parent.right"),
+      )
+      .groupBy(["node.left"]);
+
+    const { text } = qb.getSql();
+    expect(text).toContain("`node`.`CTGR_SQ` AS `id`");
+    expect(text).toMatch(/COUNT\(`node`\.`CTGR_NM`\)\s*-\s*\?\)?\s*AS `depth`/);
+    expect(text).toContain("GROUP BY `node`.`LFT_NO`");
+  });
+});
+
+describe("selectRaw expression passthrough", () => {
+  it("passes a COUNT(*) expression through raw (not alias-qualified)", () => {
+    const qb = newQb().selectRaw(["COUNT(*)"]);
+    const { text } = qb.getSql();
+    expect(text).toContain("COUNT(*)");
+    expect(text).not.toContain("`COUNT(*)`");
+    expect(text).not.toContain("`node`.`COUNT");
+  });
+
+  it("passes a function expression with a qualified arg through raw", () => {
+    const qb = newQb().selectRaw(["MAX(parent.RGT_NO)"]);
+    const { text } = qb.getSql();
+    expect(text).toContain("MAX(parent.RGT_NO)");
+    expect(text).not.toContain("`MAX(");
+  });
+
+  it("still resolves a bare alias.property reference to its mapped column", () => {
+    const qb = newQb().selectRaw(["node.name"]);
+    const { text } = qb.getSql();
+    expect(text).toContain("`node`.`CTGR_NM`");
+  });
+
+  it("still resolves a bare property reference on the root entity", () => {
+    const qb = newQb().selectRaw(["right"]);
+    const { text } = qb.getSql();
+    expect(text).toContain("`node`.`RGT_NO`");
+  });
+});

--- a/docs/ko/query-builder-patterns.md
+++ b/docs/ko/query-builder-patterns.md
@@ -223,7 +223,9 @@ const posts = await em
 `addSelectSubquery()`, `whereExistsSubquery()`, `whereNotExistsSubquery()`는 **팩토리** `(outer) => subQb`도 받습니다. `outer("alias.prop")` 리졸버는 외부 쿼리 컬럼의 escape된 식별자를 `Sql` 조각으로 돌려줘요. 덕분에 서브쿼리가 타입드 표면을 통해 외부 행을 참조할 수 있고 — `sql` 문자열에 다이얼렉트별 식별자를 손으로 박는 대신 — 상관 조건 안에서도 NamingStrategy와 `@Column({ name })` 매핑이 그대로 동작합니다.
 
 ```typescript
-import sql from "sql-template-tag";
+import { qAlias } from "@stingerloom/orm";
+
+const a = qAlias(Category, "a");
 
 // 중첩 집합 트리에서 노드별 하위 게시글 수
 const nodes = await em
@@ -233,12 +235,58 @@ const nodes = await em
       em.createQueryBuilder(Post, "p")
         .selectRaw(["COUNT(*)"])
         .innerJoin(Category, "a", (j) => j.on("p.categoryId", "=", "a.id"))
-        .where(sql`${outer("a.lft")} BETWEEN ${outer("node.lft")} AND ${outer("node.rgt")}`),
+        // `a.lft`는 서브쿼리 자신의 alias 레지스트리(그 `a` 조인)로 풀려서
+        // NamingStrategy / @Column({ name }) 매핑이 적용됩니다. `node.lft` /
+        // `node.rgt`는 외부 행에서 `outer()`로 가져옵니다 — 양쪽 모두 타입드.
+        .where(a.lft.between(outer("node.lft"), outer("node.rgt"))),
     "postCount",
   )
   .getRawMany();
-// outer("node.lft")는 외부 행 컬럼의 escape된 식별자로 렌더링됩니다
-// (예: "node"."lft" — @Column({ name: "LFT_NO" })라면 "node"."LFT_NO")
+// → (SELECT COUNT(*) FROM "post" AS "p" INNER JOIN "category" AS "a"
+//      ON "p"."category_id" = "a"."CTGR_SQ"
+//    WHERE "a"."LFT_NO" BETWEEN "node"."LFT_NO" AND "node"."RGT_NO") AS "postCount"
+```
+
+`outer()`는 `Sql` 조각을 돌려주므로 `.between()`(및 모든 조건 값)에 바로 꽂힙니다 — `sql` 템플릿이 필요 없어요. `outer()`는 **외부 행** 컬럼에만 쓰고, 서브쿼리 자신의 alias는 그 서브쿼리의 `qAlias`로 푸세요. 그래야 각 쪽이 올바른 레지스트리를 통해 매핑됩니다.
+
+### 중첩 집합 트리 — depth와 breadcrumb를 raw SQL 없이
+
+같은 `onBetween()` self-join에 SELECT 절의 집계 산술을 더하면, 고전적인 중첩 집합의 "depth = 조상 수 − 1" 쿼리를 타입드 빌더로 표현할 수 있습니다.
+
+```typescript
+const node = qAlias(Category, "node");
+
+// 모든 노드의 depth: COUNT(조상) - 1, 노드별 그룹화
+const tree = await em
+  .createQueryBuilder(Category, "node")
+  .select([
+    node.id.as("id"),
+    node.name.as("name"),
+    node.name.count().sub(1).as("depth"), // COUNT("node"."CTGR_NM") - 1
+  ])
+  .innerJoin(Category, "parent", (j) =>
+    j.onBetween("node.left", "parent.left", "parent.right"),
+  )
+  .groupBy(["node.left"])
+  .addOrderBy("node.left", "ASC")
+  .getRawMany();
+```
+
+breadcrumb 경로는 그 역 — **조상**(`parent`) 이름을 select 합니다. 조인된 alias를 참조하는 프로젝션은 빌드 시점에 해석되므로, `parent`를 등록하는 `innerJoin`보다 `select([parent.name.as(...)])`가 먼저 와도 됩니다.
+
+```typescript
+const parent = qAlias(Category, "parent");
+
+const crumbs = await em
+  .createQueryBuilder(Category, "node")
+  .select([parent.name.as("name")])
+  .innerJoin(Category, "parent", (j) =>
+    j.onBetween("node.left", "parent.left", "parent.right"),
+  )
+  .where(node.name.eq("A1"))
+  .addOrderBy("parent.left", "ASC")
+  .getRawMany();
+// crumbs.map((r) => r.name).join(" > ") → "Root > A > A1"
 ```
 
 같은 팩토리가 `EXISTS`에도 통합니다.

--- a/docs/query-builder-patterns.md
+++ b/docs/query-builder-patterns.md
@@ -221,7 +221,9 @@ const posts = await em
 `addSelectSubquery()`, `whereExistsSubquery()`, and `whereNotExistsSubquery()` also accept a **factory** `(outer) => subQb`. The `outer("alias.prop")` resolver returns the escaped identifier of an outer-query column as a `Sql` fragment, so the subquery can reference the outer row through the typed surface — NamingStrategy and `@Column({ name })` mappings keep working inside the correlation, instead of hand-writing dialect-specific identifiers in a `sql` string:
 
 ```typescript
-import sql from "sql-template-tag";
+import { qAlias } from "@stingerloom/orm";
+
+const a = qAlias(Category, "a");
 
 // Per-node descendant post count over a nested-set tree
 const nodes = await em
@@ -231,12 +233,67 @@ const nodes = await em
       em.createQueryBuilder(Post, "p")
         .selectRaw(["COUNT(*)"])
         .innerJoin(Category, "a", (j) => j.on("p.categoryId", "=", "a.id"))
-        .where(sql`${outer("a.lft")} BETWEEN ${outer("node.lft")} AND ${outer("node.rgt")}`),
+        // `a.lft` resolves through the subquery's OWN alias registry (its
+        // `a` join), so its NamingStrategy / @Column({ name }) mapping
+        // applies. `node.lft` / `node.rgt` come from the OUTER row via
+        // `outer()`. Both sides stay typed — no hand-written identifiers.
+        .where(a.lft.between(outer("node.lft"), outer("node.rgt"))),
     "postCount",
   )
   .getRawMany();
-// outer("node.lft") renders as the escaped column of the outer row
-// (e.g. "node"."lft" — or "node"."LFT_NO" with @Column({ name: "LFT_NO" }))
+// → (SELECT COUNT(*) FROM "post" AS "p" INNER JOIN "category" AS "a"
+//      ON "p"."category_id" = "a"."CTGR_SQ"
+//    WHERE "a"."LFT_NO" BETWEEN "node"."LFT_NO" AND "node"."RGT_NO") AS "postCount"
+```
+
+`outer()` returns a `Sql` fragment, so it slots into `.between()` (and any
+condition value) directly — no `sql` template needed. Reserve `outer()` for
+**outer-row** columns; resolve the subquery's own aliases through that
+subquery's `qAlias`, so each side maps through the correct registry.
+
+### Nested-Set Tree — Depth and Breadcrumbs Without Raw SQL
+
+The same `onBetween()` self-join, combined with aggregate arithmetic in the
+SELECT list, expresses the classic nested-set "depth = ancestor count − 1"
+query through the typed builder:
+
+```typescript
+const node = qAlias(Category, "node");
+
+// depth of every node: COUNT(ancestors) - 1, grouped by the node
+const tree = await em
+  .createQueryBuilder(Category, "node")
+  .select([
+    node.id.as("id"),
+    node.name.as("name"),
+    node.name.count().sub(1).as("depth"), // COUNT("node"."CTGR_NM") - 1
+  ])
+  .innerJoin(Category, "parent", (j) =>
+    j.onBetween("node.left", "parent.left", "parent.right"),
+  )
+  .groupBy(["node.left"])
+  .addOrderBy("node.left", "ASC")
+  .getRawMany();
+```
+
+A breadcrumb path is the inverse — select the **ancestor** (`parent`) names.
+Projections referencing a joined alias resolve at build time, so the
+`select([parent.name.as(...)])` may appear before the `innerJoin` that
+registers `parent`:
+
+```typescript
+const parent = qAlias(Category, "parent");
+
+const crumbs = await em
+  .createQueryBuilder(Category, "node")
+  .select([parent.name.as("name")])
+  .innerJoin(Category, "parent", (j) =>
+    j.onBetween("node.left", "parent.left", "parent.right"),
+  )
+  .where(node.name.eq("A1"))
+  .addOrderBy("parent.left", "ASC")
+  .getRawMany();
+// crumbs.map((r) => r.name).join(" > ") → "Root > A > A1"
 ```
 
 The same factory works for `EXISTS`:

--- a/src/core/SelectQueryBuilder.ts
+++ b/src/core/SelectQueryBuilder.ts
@@ -1612,14 +1612,25 @@ export class SelectQueryBuilder<T, TResult = T> {
   protected arrayValidatorFn: ArrayValidator<any> | undefined;
   protected selectedPropertyKeys: string[] | null = null;
   /**
-   * Parameterized SELECT list built from {@link AliasedExpression}s.
+   * Deferred SELECT projections built from {@link AliasedExpression}s /
+   * {@link AggregateExpression}s via `select([...])`.
    *
-   * When non-null, this takes precedence over both {@link selectColumns}
-   * and {@link selectExpressions} in the build path — the SELECT segment
-   * is emitted via `RawQueryBuilder.selectFragments()` so bound values
-   * (e.g. JSON path literals on MySQL) are preserved through execution.
+   * Stored unresolved and rendered at build time (see
+   * {@link renderAliasedProjections}) rather than eagerly at `select()` call
+   * time. Deferral lets a projection reference a JOIN alias that is
+   * registered *after* the `select()` call — e.g. a nested-set self-join
+   * where `select([parent.name.as(...)])` precedes
+   * `innerJoin(Category, "parent", ...)`. Eager resolution left such columns
+   * unqualified (`parent.name` instead of `parent.CTGR_NM`).
+   *
+   * When non-null, this takes precedence over both {@link selectColumns} and
+   * {@link selectExpressions} in the build path — the SELECT segment is
+   * emitted via `RawQueryBuilder.selectFragments()` so bound values (e.g.
+   * JSON path literals on MySQL) are preserved through execution.
    */
-  protected aliasedSelectList: Sql[] | null = null;
+  protected aliasedProjections:
+    | Array<AliasedExpression | AggregateExpression>
+    | null = null;
   protected indexHints: Array<{
     type: "USE" | "FORCE" | "IGNORE";
     indexName: string;
@@ -2159,11 +2170,11 @@ export class SelectQueryBuilder<T, TResult = T> {
     if (columns === "*") {
       this.selectColumns = "*";
       this.selectedPropertyKeys = null;
-      this.aliasedSelectList = null;
+      this.aliasedProjections = null;
     } else {
       this.selectColumns = (columns as string[]).map((c) => this.col(c));
       this.selectedPropertyKeys = columns as string[];
-      this.aliasedSelectList = null;
+      this.aliasedProjections = null;
     }
     return this as any;
   }
@@ -2204,27 +2215,44 @@ export class SelectQueryBuilder<T, TResult = T> {
     }
     this.selectColumns = fragments;
     this.selectedPropertyKeys = null;
-    this.aliasedSelectList = null;
+    this.aliasedProjections = null;
     return this;
   }
 
   /**
-   * @internal Replace the SELECT clause with parameterized alias
-   * fragments.
+   * @internal Record a parameterized alias projection for deferred rendering.
    *
    * Used when the projection contains an {@link AliasedExpression} —
-   * JSON path extractions encode path literals as bound parameters, so
-   * the list is rendered as a `Sql[]` (preserving those values) and
-   * handed to {@link RawQueryBuilder.selectFragments} at build time.
-   * Aggregates mixed in are rendered alongside so callers can freely
-   * combine `count().as()` with `col.as()`.
+   * JSON path extractions encode path literals as bound parameters, so the
+   * list is rendered as a `Sql[]` (preserving those values) at build time and
+   * handed to {@link RawQueryBuilder.selectFragments}. Aggregates mixed in are
+   * rendered alongside so callers can freely combine `count().as()` with
+   * `col.as()`.
+   *
+   * Projections are stored unresolved and resolved in
+   * {@link renderAliasedProjections} at build time — see
+   * {@link aliasedProjections} for why deferral matters (forward references
+   * to JOIN aliases registered after this call).
    */
   private selectAliased(
     projections: Array<AliasedExpression | AggregateExpression>,
   ): this {
+    this.aliasedProjections = projections;
+    this.selectColumns = "*";
+    this.selectedPropertyKeys = null;
+    return this;
+  }
+
+  /**
+   * @internal Render the deferred {@link aliasedProjections} into SELECT
+   * fragments. Called at build time (`toSql()`), after every JOIN alias has
+   * been registered, so projections referencing a later-joined alias resolve
+   * to the correct qualified column.
+   */
+  private renderAliasedProjections(): Sql[] {
     const fragments: Sql[] = [];
     const resolver: ColumnResolver = (ref) => this.resolveColumn(ref);
-    for (const p of projections) {
+    for (const p of this.aliasedProjections ?? []) {
       if (isAliasedExpression(p)) {
         const inner = p.renderer(resolver, this.dialectExpression);
         fragments.push(sql`${inner} AS ${raw(this.em.wrap(p.alias))}`);
@@ -2234,10 +2262,7 @@ export class SelectQueryBuilder<T, TResult = T> {
         fragments.push(sql`${fn} AS ${raw(this.em.wrap(resolvedAlias))}`);
       }
     }
-    this.aliasedSelectList = fragments;
-    this.selectColumns = "*";
-    this.selectedPropertyKeys = null;
-    return this;
+    return fragments;
   }
 
   /**
@@ -2261,9 +2286,26 @@ export class SelectQueryBuilder<T, TResult = T> {
    * ```
    */
   selectRaw(columns: string[]): this {
-    this.selectColumns = columns.map((c) => this.resolveColumn(c));
+    this.selectColumns = columns.map((c) => this.resolveRawSelectColumn(c));
     this.selectedPropertyKeys = null;
     return this;
+  }
+
+  /**
+   * @internal Resolve one `selectRaw()` token.
+   *
+   * A token is alias-resolved (property → DB column, alias qualification)
+   * only when it is a *bare column reference* — `property` or
+   * `alias.property`. Anything carrying SQL syntax (function calls like
+   * `COUNT(*)`, operators, `*`, whitespace, quotes) is a raw expression the
+   * caller wrote deliberately and passes through untouched. Routing such
+   * expressions through {@link resolveColumn} previously mangled them into
+   * `"alias"."COUNT(*)"`-style garbage.
+   */
+  private resolveRawSelectColumn(token: string): string {
+    const isBareColumnRef =
+      /^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)?$/.test(token.trim());
+    return isBareColumnRef ? this.resolveColumn(token) : token;
   }
 
   addSelect(expr: AggregateExpression): this;
@@ -4221,11 +4263,12 @@ export class SelectQueryBuilder<T, TResult = T> {
     else qb.setDatabaseType("postgresql");
 
     // SELECT — inheritance-aware
-    if (this.aliasedSelectList !== null) {
+    if (this.aliasedProjections !== null) {
       // Aliased-expression projection (may carry bound params for JSON
       // extract); bypass the string-based select() path to keep values
-      // attached to their placeholders.
-      qb.selectFragments(this.aliasedSelectList, this.distinct);
+      // attached to their placeholders. Resolved here (not at select() call
+      // time) so projections may reference JOIN aliases registered later.
+      qb.selectFragments(this.renderAliasedProjections(), this.distinct);
     } else if (this.selectColumns === "*") {
       // TPT child: use explicit column list from both tables
       if (this.tptSelectColumns) {
@@ -5820,8 +5863,8 @@ export class SelectQueryBuilder<T, TResult = T> {
     cloned.selectExpressions = [...this.selectExpressions];
     cloned.joinedSelections = [...this.joinedSelections];
     cloned.rootSelectExpanded = this.rootSelectExpanded;
-    cloned.aliasedSelectList = this.aliasedSelectList
-      ? [...this.aliasedSelectList]
+    cloned.aliasedProjections = this.aliasedProjections
+      ? [...this.aliasedProjections]
       : null;
     // Inheritance state
     cloned.inheritanceStrategy = this.inheritanceStrategy;


### PR DESCRIPTION
## What

Two query-builder fixes that let nested-set / self-join tree queries be written entirely through the typed builder — the shape that previously forced raw `em.query` SQL in consuming apps. Both were surfaced porting a real Category service off raw SQL.

## Fixes

- **Deferred aliased projections.** `select([alias.col.as(...)])` now renders at build time instead of eagerly at the `select()` call, so a projection may reference a JOIN alias registered *after* the `select()` call — e.g. `select([parent.name.as("name")]).innerJoin(Category, "parent", ...)`. Such forward references were previously left unqualified/unmapped (`parent.name` instead of `parent.CTGR_NM`); select order no longer changes the generated SQL. (A dialect guard on an unsupported aggregate now fires at build time rather than at the `select()` call.)
- **`selectRaw([...])` expression passthrough.** A token is alias-qualified only when it is a bare column reference (`prop` / `alias.prop`); raw expressions such as `COUNT(*)`, `MAX(p.views)`, or `1` pass through verbatim instead of being mangled into `"alias"."COUNT(*)"`. This makes `selectRaw(["COUNT(*)"])` usable inside `addSelectSubquery()` correlated subqueries.

## Tests and docs

- New `select-query-builder-deferred-projection` unit suite (7 tests) and `select-query-builder-nested-set` SQLite integration suite (5 tests: depth, breadcrumb, correlated subtree count, subtree delete, save() column mapping).
- `ordered-set-aggregate-sqb-integration` updated — the MySQL guard now asserts at build time.
- CHANGELOG + `query-builder-patterns` docs (EN/KO) updated.

Verified: unit 5,260 + SQLite integration 505 passed, 0 failures; `tsc` clean.