### PR TITLE
fix(query-builder): normalize eq(null)/ne(null) to IS NULL / IS NOT NULL

### DIFF
--- a/__tests__/unit/where-filter.test.ts
+++ b/__tests__/unit/where-filter.test.ts
@@ -140,6 +140,20 @@ describe("WhereResolver", () => {
       expect(result.values).toContain("deleted");
     });
 
+    it("eq: null → IS NULL (not `= NULL`)", () => {
+      const result = resolveSingle({ bio: { eq: null } as any });
+      expect(result.sql).toContain("`bio` IS NULL");
+      expect(result.sql).not.toContain("=");
+      expect(result.values).toHaveLength(0);
+    });
+
+    it("ne: null → IS NOT NULL (not `!= NULL`)", () => {
+      const result = resolveSingle({ bio: { ne: null } as any });
+      expect(result.sql).toContain("`bio` IS NOT NULL");
+      expect(result.sql).not.toContain("!=");
+      expect(result.values).toHaveLength(0);
+    });
+
     it("compound: gt + lte on same field", () => {
       const result = resolveSingle({ age: { gt: 18, lte: 65 } });
       expect(result.sql).toContain("`age` >");

--- a/src/core/WhereResolver.ts
+++ b/src/core/WhereResolver.ts
@@ -41,10 +41,22 @@ function resolveFilterObject(
   for (const [op, val] of Object.entries(filter)) {
     switch (op) {
       case "eq":
-        clauses.push(Conditions.equals(column, val));
+        // `eq: null` must become `IS NULL` — `col = NULL` is always UNKNOWN in
+        // SQL's three-valued logic and silently matches nothing. Mirrors the
+        // top-level `field: null` shorthand and `not: null` → IS NOT NULL.
+        clauses.push(
+          val === null
+            ? Conditions.isNull(column)
+            : Conditions.equals(column, val),
+        );
         break;
       case "ne":
-        clauses.push(Conditions.notEquals(column, val));
+        // `ne: null` must become `IS NOT NULL` for the same reason.
+        clauses.push(
+          val === null
+            ? Conditions.isNotNull(column)
+            : Conditions.notEquals(column, val),
+        );
         break;
       case "gt":
         clauses.push(Conditions.gt(column, val));


### PR DESCRIPTION
## Summary

Filter-operator objects sent `null` through the wrong code path:

- `{ field: { eq: null } }` produced `field = NULL`
- `{ field: { ne: null } }` produced `field != NULL`

Both expressions are always `UNKNOWN` under SQL three-valued logic, so they silently match **no rows** instead of behaving as `IS NULL` / `IS NOT NULL`. Since `WhereClause<T>` allows `eq`/`ne` of a nullable field type, this is reachable through the public `find()` / query-builder API.

This also made the operator set inconsistent: the top-level `{ field: null }` shorthand and the `{ not: null }` operator already resolved to `IS NULL` / `IS NOT NULL`, while `eq` / `ne` did not.

## Change

`resolveFilterObject` now emits:

| Input | Before | After |
|-------|--------|-------|
| `{ field: { eq: null } }` | `field = NULL` | `field IS NULL` |
| `{ field: { ne: null } }` | `field != NULL` | `field IS NOT NULL` |

Non-null values are unchanged. Matches Prisma semantics (`equals: null` to IS NULL, `not: null` to IS NOT NULL).

## Tests

- Added two regression tests in `__tests__/unit/where-filter.test.ts` asserting `IS NULL` / `IS NOT NULL` with zero bound parameters.
- Full unit suite: 5262 passed, 20 skipped, 0 failures.