### PR TITLE
fix: cascade @RelationColumn FK write + MySQL MODIFY COLUMN nullability

### DIFF
--- a/__tests__/integration/sqlite/cascade-onetomany-relation-column.test.ts
+++ b/__tests__/integration/sqlite/cascade-onetomany-relation-column.test.ts
@@ -1,0 +1,166 @@
+/**
+ * SQLite In-Memory: cascade insert of a OneToMany whose child FK is declared
+ * via @RelationColumn WITHOUT a backing @Column (the documented nestjs-blog
+ * pattern).
+ *
+ * Regression for the CascadeHandler FK bug: cascadeSaveOneToMany wrote the
+ * parent PK onto the child under the raw joinColumn DB name (e.g.
+ * `child["author_id"]`), but the child's INSERT path only reads the FK from the
+ * relation object, the `${prop}Id` shadow, or `option.fkProperty`. With a pure
+ * @RelationColumn FK (no backing @Column named "author_id"), the FK was never
+ * written — cascade-inserted children landed with author_id = NULL.
+ *
+ * SQLite has no ALTER TABLE ADD FOREIGN KEY → synchronize:false + manual DDL.
+ */
+
+import "reflect-metadata";
+import {
+  createTestConnection,
+  type TestConnectionResult,
+} from "../helpers/test-connection";
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  ManyToOne,
+  OneToMany,
+  RelationColumn,
+} from "../../../src";
+import { getScannerInstance } from "../../../src/scanner/ScannerContainer";
+import {
+  ColumnScanner,
+  ManyToOneScanner,
+  OneToManyScanner,
+} from "../../../src/scanner";
+import { DatabaseClient } from "../../../src/DatabaseClient";
+
+function shortName(prefix: string): string {
+  return `${prefix}_${String(Date.now()).slice(-7)}`;
+}
+
+function clearScanners(): void {
+  getScannerInstance(ColumnScanner).clear();
+  getScannerInstance(ManyToOneScanner).clear();
+  getScannerInstance(OneToManyScanner).clear();
+}
+
+describe("[Integration] SQLite: cascade insert OneToMany via @RelationColumn FK", () => {
+  let conn: TestConnectionResult;
+  let UserClass: new () => any;
+  let usersTable: string;
+  let postsTable: string;
+
+  beforeAll(async () => {
+    usersTable = shortName("cc_users");
+    postsTable = shortName("cc_posts");
+
+    let UC: any;
+
+    conn = await createTestConnection(
+      {
+        type: "sqlite",
+        database: ":memory:",
+        synchronize: false,
+        logging: false,
+      },
+      () => {
+        clearScanners();
+
+        UC = class {} as any;
+        Object.defineProperty(UC, "name", { value: usersTable });
+        Reflect.defineMetadata("design:type", Number, UC.prototype, "id");
+        PrimaryGeneratedColumn()(UC.prototype, "id");
+        Reflect.defineMetadata("design:type", String, UC.prototype, "name");
+        Column()(UC.prototype, "name");
+        Reflect.defineMetadata("design:type", Array, UC.prototype, "posts");
+        // cascade insert: children are persisted together with the parent.
+        OneToMany(() => PC, { mappedBy: "author", cascade: ["insert"] })(
+          UC.prototype,
+          "posts",
+        );
+        Entity()(UC);
+
+        const PC = class {} as any;
+        Object.defineProperty(PC, "name", { value: postsTable });
+        Reflect.defineMetadata("design:type", Number, PC.prototype, "id");
+        PrimaryGeneratedColumn()(PC.prototype, "id");
+        Reflect.defineMetadata("design:type", String, PC.prototype, "title");
+        Column()(PC.prototype, "title");
+        // FK declared ONLY via @RelationColumn — there is no @Column("author_id").
+        Reflect.defineMetadata("design:type", UC, PC.prototype, "author");
+        ManyToOne(() => UC, (u: any) => u.posts)(PC.prototype, "author");
+        RelationColumn({ name: "author_id" })(PC.prototype, "author");
+        Entity()(PC);
+
+        UserClass = UC;
+        return { entities: [UC, PC] };
+      },
+    );
+
+    const connector = DatabaseClient.getInstance().getConnection();
+    await connector.query(`
+      CREATE TABLE IF NOT EXISTS "${usersTable}" (
+        "id" INTEGER PRIMARY KEY AUTOINCREMENT,
+        "name" TEXT NOT NULL DEFAULT ''
+      )
+    `);
+    await connector.query(`
+      CREATE TABLE IF NOT EXISTS "${postsTable}" (
+        "id" INTEGER PRIMARY KEY AUTOINCREMENT,
+        "title" TEXT NOT NULL DEFAULT '',
+        "author_id" INTEGER
+      )
+    `);
+  });
+
+  afterAll(async () => {
+    await conn.cleanup();
+  });
+
+  beforeEach(async () => {
+    const connector = DatabaseClient.getInstance().getConnection();
+    await connector.query(`DELETE FROM "${postsTable}"`);
+    await connector.query(`DELETE FROM "${usersTable}"`);
+  });
+
+  it("writes the parent PK to the child's @RelationColumn FK on cascade insert", async () => {
+    const { em } = conn;
+
+    const saved = await em.save(UserClass, {
+      name: "Alice",
+      posts: [{ title: "A1" }, { title: "A2" }],
+    } as any);
+
+    expect(saved.id).toBeDefined();
+
+    // The cascade-inserted children must carry the parent's PK in author_id —
+    // assert directly against the DB row, not the in-memory object.
+    const connector = DatabaseClient.getInstance().getConnection();
+    const rows = await connector.query(
+      `SELECT "title", "author_id" FROM "${postsTable}" ORDER BY "title" ASC`,
+    );
+
+    expect(rows).toHaveLength(2);
+    for (const row of rows as Array<{ title: string; author_id: number }>) {
+      expect(row.author_id).toBe(saved.id);
+    }
+  });
+
+  it("loads the cascade-inserted children back grouped under the parent", async () => {
+    const { em } = conn;
+
+    const saved = await em.save(UserClass, {
+      name: "Bob",
+      posts: [{ title: "B1" }],
+    } as any);
+
+    const reloaded = await em.findOne(UserClass, {
+      where: { id: saved.id } as any,
+      relations: ["posts"] as any,
+    });
+
+    expect(reloaded).toBeDefined();
+    expect(reloaded!.posts).toHaveLength(1);
+    expect(reloaded!.posts[0].title).toBe("B1");
+  });
+});

--- a/__tests__/unit/schema-diff.test.ts
+++ b/__tests__/unit/schema-diff.test.ts
@@ -233,6 +233,54 @@ describe("SchemaDiff", () => {
       expect(bodyAlter).toBeDefined();
       expect(bodyAlter!.nullable).toBe(true);
     });
+
+    it("MySQL: generated MODIFY COLUMN keeps NOT NULL on a type alter (file + dryRun)", async () => {
+      const runner = createMockQueryRunner({
+        diff_user: [
+          { column_name: "id", data_type: "int", is_nullable: "NO" },
+          // entity: VARCHAR(255) NOT NULL, DB has TEXT → type alter
+          { column_name: "name", data_type: "text", is_nullable: "NO" },
+          { column_name: "age", data_type: "int", is_nullable: "NO" },
+          { column_name: "active", data_type: "tinyint", is_nullable: "NO" },
+        ],
+      });
+
+      const result = await schemaDiff.diff([DiffUser], runner, "mysql");
+      const gen = new SchemaDiffMigrationGenerator();
+
+      // File-content path (buildUpStatements): the MODIFY must keep NOT NULL.
+      const content = gen.generate(result, "mysql");
+      expect(content).toContain("MODIFY COLUMN");
+      expect(content).toContain("NOT NULL");
+
+      // Raw-SQL path (buildUpSql via dryRun): same.
+      const modifyLine = gen
+        .dryRun(result, "mysql")
+        .up.find((s) => s.includes("MODIFY COLUMN") && s.includes("name"));
+      expect(modifyLine).toBeDefined();
+      // Regression: previously emitted bare "... VARCHAR(255)" → dropped NOT NULL.
+      expect(modifyLine).toMatch(/VARCHAR\(255\) NOT NULL/);
+    });
+
+    it("MySQL: generated MODIFY COLUMN emits NULL (not NOT NULL) on a nullable type alter", async () => {
+      const runner = createMockQueryRunner({
+        diff_post: [
+          { column_name: "id", data_type: "int", is_nullable: "NO" },
+          { column_name: "title", data_type: "varchar", is_nullable: "NO" },
+          // entity: TEXT nullable:true, DB has VARCHAR → type alter
+          { column_name: "body", data_type: "varchar", is_nullable: "YES" },
+        ],
+      });
+
+      const result = await schemaDiff.diff([DiffPost], runner, "mysql");
+      const modifyLine = new SchemaDiffMigrationGenerator()
+        .dryRun(result, "mysql")
+        .up.find((s) => s.includes("MODIFY COLUMN") && s.includes("body"));
+
+      expect(modifyLine).toBeDefined();
+      expect(modifyLine).not.toContain("NOT NULL");
+      expect(modifyLine).toMatch(/TEXT NULL/);
+    });
   });
 
   describe("diff() — type-change alter carries length/precision", () => {

--- a/src/core/CascadeHandler.ts
+++ b/src/core/CascadeHandler.ts
@@ -88,9 +88,26 @@ export class CascadeHandler {
       );
       const fkColumn = matchingRelation?.joinColumn ?? rel.mappedBy;
 
+      // The child's INSERT/UPDATE path resolves the FK value from the relation
+      // object, the `${prop}Id` shadow accessor, or an explicit
+      // `option.fkProperty` — never from the raw joinColumn DB name. When the FK
+      // is declared via `@RelationColumn({ name })` with no backing `@Column`
+      // (the documented nestjs-blog pattern), writing only `child[joinColumn]`
+      // (e.g. `child["author_id"]`) left the FK unwritten — the cascade-inserted
+      // child got a NULL/omitted FK. Also set the shadow (and fkProperty, if
+      // configured) so the FK is actually persisted, while keeping the raw
+      // assignment for the legacy backing-`@Column` (column name == property
+      // key) setup.
+      const shadowKey = matchingRelation
+        ? `${matchingRelation.columnName}Id`
+        : undefined;
+      const fkPropertyKey = matchingRelation?.option?.fkProperty;
+
       for (const child of children) {
         // Set the FK to the parent's PK.
         (child as any)[fkColumn] = savedParentId;
+        if (shadowKey) (child as any)[shadowKey] = savedParentId;
+        if (fkPropertyKey) (child as any)[fkPropertyKey] = savedParentId;
         if (session) {
           await this.ctx.saveWithSession(RelatedEntity, child, session);
         } else {

--- a/src/core/generators/SchemaDiffMigrationGenerator.ts
+++ b/src/core/generators/SchemaDiffMigrationGenerator.ts
@@ -133,8 +133,13 @@ export class SchemaDiffMigrationGenerator {
       if (dialect === "sqlite") {
         // SQLite cannot alter column types — skip in SQL
       } else if (dialect === "mysql") {
+        // MySQL MODIFY COLUMN restates the whole column definition, so the
+        // declared nullability must be reattached — otherwise altering a
+        // NOT NULL column's type silently drops NOT NULL (mirrors the live
+        // SchemaRegistrar.buildAlterColumnDDL path).
+        const nullability = col.nullable === false ? " NOT NULL" : " NULL";
         sqls.push(
-          `ALTER TABLE ${this.escapeId(col.tableName, dialect)} MODIFY COLUMN ${this.escapeId(col.columnName, dialect)} ${typeStr}`,
+          `ALTER TABLE ${this.escapeId(col.tableName, dialect)} MODIFY COLUMN ${this.escapeId(col.columnName, dialect)} ${typeStr}${nullability}`,
         );
       } else {
         sqls.push(
@@ -260,9 +265,14 @@ export class SchemaDiffMigrationGenerator {
           `// TODO: SQLite does not support ALTER COLUMN TYPE for ${this.escapeId(col.tableName, dialect)}.${this.escapeId(col.columnName, dialect)} (${col.currentType} -> ${typeStr}). Recreate the table instead.`,
         );
       } else if (dialect === "mysql") {
+        // MySQL MODIFY COLUMN restates the whole column definition, so the
+        // declared nullability must be reattached — otherwise altering a
+        // NOT NULL column's type silently drops NOT NULL (mirrors the live
+        // SchemaRegistrar.buildAlterColumnDDL path).
+        const nullability = col.nullable === false ? " NOT NULL" : " NULL";
         stmts.push(
           this.wrapSqlInQuery(
-            `ALTER TABLE ${this.escapeId(col.tableName, dialect)} MODIFY COLUMN ${this.escapeId(col.columnName, dialect)} ${typeStr}`,
+            `ALTER TABLE ${this.escapeId(col.tableName, dialect)} MODIFY COLUMN ${this.escapeId(col.columnName, dialect)} ${typeStr}${nullability}`,
           ),
         );
       } else {


### PR DESCRIPTION
## Summary

Two verified correctness bugs, each with a regression test that fails without the fix and passes with it.

### 1. Cascade insert drops the child FK for a pure `@RelationColumn` FK

`@OneToMany({ cascade: ["insert"] })` with a child whose FK is declared via `@RelationColumn({ name })` and **no backing `@Column`** (the documented `nestjs-blog` pattern) silently lost the FK — cascade-inserted children landed with `author_id = NULL`.

- `CascadeHandler.cascadeSaveOneToMany` set the parent PK on `child[joinColumn]` (the raw DB column name, e.g. `child["author_id"]`).
- But the child's INSERT/UPDATE path (`WriteExecutor`) only resolves the FK from the relation object, the `${prop}Id` shadow, or `option.fkProperty` — never the raw joinColumn name. With no backing `@Column`, the FK was never bound.
- Fix: also set the shadow key (`${columnName}Id`) and `option.fkProperty`, while keeping the existing raw assignment for the legacy backing-`@Column` (column name == property key) setup. The cascade-update path reads the same shadow, so it is covered too.

### 2. Migration generator drops NOT NULL on a MySQL `MODIFY COLUMN`

`migrate:generate` for a type change on a NOT NULL column emitted `MODIFY COLUMN c <type>` with no nullability suffix, silently converting the column to nullable.

- The live sync path (`SchemaRegistrar.buildAlterColumnDDL`) already reattaches `NOT NULL`/`NULL`; the file generator did not.
- `ColumnChange.nullable` was already carried through the diff — it was simply unused by the generator.
- Fix: both `buildUpSql` and `buildUpStatements` now reattach the declared nullability, mirroring the live path.

## Tests

- `__tests__/integration/sqlite/cascade-onetomany-relation-column.test.ts` (new) — asserts the cascade-inserted child row carries the parent PK in `author_id`, verified directly against the DB row, plus a relation-reload check.
- `__tests__/unit/schema-diff.test.ts` — two generator-level regressions: NOT NULL alter keeps `NOT NULL` (file + dryRun paths), nullable alter emits `NULL` (not `NOT NULL`).

## Verification

- Unit: 5264 passed, 20 skipped, 0 failures
- SQLite integration: 507 passed, 0 failures
- `tsc --noEmit`: clean

Both fixes were confirmed by reverting each change and observing the new tests fail.