### PR TITLE
fix(schema): detect and apply column nullability drift in schema diff/sync

### DIFF
--- a/__tests__/integration/sqlite/schema-diff-sync.test.ts
+++ b/__tests__/integration/sqlite/schema-diff-sync.test.ts
@@ -290,6 +290,33 @@ function createEntityWithBooleanType(): new () => any {
   return DynClass;
 }
 
+/**
+ * Nullability-only change: `name` flips from NOT NULL (V1) to nullable, with
+ * the type/length unchanged.
+ */
+function createEntityWithNullableName(): new () => any {
+  getScannerInstance(ColumnScanner).clear();
+
+  const DynClass = class {} as any;
+  Object.defineProperty(DynClass, "name", {
+    value: TABLE_NAME,
+    writable: false,
+  });
+
+  Reflect.defineMetadata("design:type", Number, DynClass.prototype, "id");
+  PrimaryGeneratedColumn()(DynClass.prototype, "id");
+
+  // name: NOT NULL (V1) → nullable (same inferred varchar/255 type)
+  Reflect.defineMetadata("design:type", String, DynClass.prototype, "name");
+  Column({ nullable: true })(DynClass.prototype, "name");
+
+  Reflect.defineMetadata("design:type", Number, DynClass.prototype, "age");
+  Column({ type: "int" })(DynClass.prototype, "age");
+
+  Entity()(DynClass);
+  return DynClass;
+}
+
 // ─────────────────────────────────────────────────────────
 // Test suite
 // ─────────────────────────────────────────────────────────
@@ -553,6 +580,42 @@ describe("[Integration] SQLite In-Memory: SchemaDiff 동기화 후 감지 검증
       );
       expect(emailCol).toBeDefined();
       expect(emailCol!.nullable).toBe(true);
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────
+  // Nullability-only change detection (against a real SQLite schema)
+  // ─────────────────────────────────────────────────────────
+
+  describe("Nullability-only change detection", () => {
+    it("should detect a NOT NULL → nullable change as a nullability-only alter", async () => {
+      const nullableName = createEntityWithNullableName();
+      const result = await schemaDiff.diff(
+        [nullableName],
+        queryRunner,
+        "sqlite",
+      );
+
+      const nameChange = result.alterColumns.find(
+        (c) => c.columnName === "name",
+      );
+      expect(nameChange).toBeDefined();
+      expect(nameChange!.nullable).toBe(true);
+      expect(nameChange!.currentNullable).toBe(false);
+      // type/length unchanged — this is a pure nullability drift.
+      expect(nameChange!.typeChanged).toBe(false);
+    });
+
+    it("should NOT flag the INTEGER PRIMARY KEY (SQLite reports notnull=0)", async () => {
+      // SQLite's `INTEGER PRIMARY KEY` is reported as nullable; the PK must be
+      // excluded from nullability diffing so the baseline never drifts.
+      const nullableName = createEntityWithNullableName();
+      const result = await schemaDiff.diff(
+        [nullableName],
+        queryRunner,
+        "sqlite",
+      );
+      expect(result.alterColumns.some((c) => c.columnName === "id")).toBe(false);
     });
   });
 });

--- a/__tests__/unit/schema-diff.test.ts
+++ b/__tests__/unit/schema-diff.test.ts
@@ -308,6 +308,191 @@ describe("SchemaDiff", () => {
     });
   });
 
+  describe("diff() — nullability-only alter detection", () => {
+    // name: VARCHAR(255) NOT NULL in the entity. DB has the same type but is
+    // NULLABLE → a tightening (nullable → NOT NULL) nullability-only alter.
+    it("MySQL: detects a tightening (NULL → NOT NULL) nullability-only change", async () => {
+      const runner = createMockQueryRunner({
+        diff_user: [
+          { column_name: "id", data_type: "int", is_nullable: "NO" },
+          {
+            column_name: "name",
+            data_type: "varchar",
+            character_maximum_length: 255,
+            is_nullable: "YES",
+          },
+          { column_name: "age", data_type: "int", is_nullable: "NO" },
+          { column_name: "active", data_type: "tinyint", is_nullable: "NO" },
+        ],
+      });
+
+      const result = await schemaDiff.diff([DiffUser], runner, "mysql");
+      expect(result.alterColumns).toHaveLength(1);
+      const nameAlter = result.alterColumns[0];
+      expect(nameAlter.columnName).toBe("name");
+      expect(nameAlter.nullable).toBe(false);
+      expect(nameAlter.currentNullable).toBe(true);
+      // type & length are unchanged — only the nullability flips.
+      expect(nameAlter.typeChanged).toBe(false);
+    });
+
+    // body: TEXT nullable:true in the entity. DB has the same type but is NOT
+    // NULL → a loosening (NOT NULL → nullable) nullability-only alter.
+    it("PostgreSQL: detects a loosening (NOT NULL → NULL) nullability-only change", async () => {
+      const runner = createMockQueryRunner({
+        diff_post: [
+          { column_name: "id", data_type: "integer", is_nullable: "NO" },
+          {
+            column_name: "title",
+            data_type: "varchar",
+            character_maximum_length: 255,
+            is_nullable: "NO",
+          },
+          { column_name: "body", data_type: "text", is_nullable: "NO" },
+        ],
+      });
+
+      const result = await schemaDiff.diff(
+        [DiffPost],
+        runner,
+        "postgres",
+        "public",
+      );
+      expect(result.alterColumns).toHaveLength(1);
+      const bodyAlter = result.alterColumns[0];
+      expect(bodyAlter.columnName).toBe("body");
+      expect(bodyAlter.nullable).toBe(true);
+      expect(bodyAlter.currentNullable).toBe(false);
+      expect(bodyAlter.typeChanged).toBe(false);
+    });
+
+    it("does NOT flag a primary-key column whose DB nullability differs (SQLite quirk-safe)", async () => {
+      // SQLite reports `INTEGER PRIMARY KEY` as notnull=0 / is_nullable="YES".
+      // The PK's nullability is structurally fixed, so it must never produce an
+      // alter even when the DB disagrees with the entity.
+      const runner = createMockQueryRunner({
+        diff_user: [
+          { column_name: "id", data_type: "int", is_nullable: "YES" },
+          {
+            column_name: "name",
+            data_type: "varchar",
+            character_maximum_length: 255,
+            is_nullable: "NO",
+          },
+          { column_name: "age", data_type: "int", is_nullable: "NO" },
+          { column_name: "active", data_type: "tinyint", is_nullable: "NO" },
+        ],
+      });
+
+      const result = await schemaDiff.diff([DiffUser], runner, "mysql");
+      expect(
+        result.alterColumns.some((c) => c.columnName === "id"),
+      ).toBe(false);
+    });
+
+    it("does NOT alter when nullability already matches", async () => {
+      const runner = createMockQueryRunner({
+        diff_user: [
+          { column_name: "id", data_type: "int", is_nullable: "NO" },
+          {
+            column_name: "name",
+            data_type: "varchar",
+            character_maximum_length: 255,
+            is_nullable: "NO",
+          },
+          { column_name: "age", data_type: "int", is_nullable: "NO" },
+          { column_name: "active", data_type: "tinyint", is_nullable: "NO" },
+        ],
+      });
+
+      const result = await schemaDiff.diff([DiffUser], runner, "mysql");
+      expect(result.alterColumns).toHaveLength(0);
+    });
+  });
+
+  describe("generator — nullability-only ALTER SQL", () => {
+    const tighten: SchemaDiffResult = {
+      addTables: [],
+      dropTables: [],
+      addColumns: [],
+      dropColumns: [],
+      alterColumns: [
+        {
+          tableName: "users",
+          columnName: "name",
+          columnType: "VARCHAR",
+          currentType: "varchar",
+          nullable: false,
+          currentNullable: true,
+          typeChanged: false,
+          expectedLength: 255,
+        },
+      ],
+    };
+
+    it("PostgreSQL: emits SET NOT NULL and NOT a TYPE rewrite", () => {
+      const { up } = new SchemaDiffMigrationGenerator().dryRun(tighten, "postgres");
+      expect(up).toHaveLength(1);
+      expect(up[0]).toContain("SET NOT NULL");
+      expect(up[0]).not.toContain("TYPE");
+    });
+
+    it("PostgreSQL: down reverses SET NOT NULL with DROP NOT NULL", () => {
+      const { down } = new SchemaDiffMigrationGenerator().dryRun(tighten, "postgres");
+      expect(down).toHaveLength(1);
+      expect(down[0]).toContain("DROP NOT NULL");
+    });
+
+    it("PostgreSQL: a loosening change emits DROP NOT NULL", () => {
+      const loosen: SchemaDiffResult = {
+        ...tighten,
+        alterColumns: [
+          {
+            ...tighten.alterColumns[0],
+            nullable: true,
+            currentNullable: false,
+          },
+        ],
+      };
+      const { up } = new SchemaDiffMigrationGenerator().dryRun(loosen, "postgres");
+      expect(up[0]).toContain("DROP NOT NULL");
+    });
+
+    it("MySQL: restates the column via MODIFY COLUMN ... NOT NULL", () => {
+      const { up } = new SchemaDiffMigrationGenerator().dryRun(tighten, "mysql");
+      expect(up).toHaveLength(1);
+      expect(up[0]).toContain("MODIFY COLUMN");
+      expect(up[0]).toContain("VARCHAR(255)");
+      expect(up[0]).toContain("NOT NULL");
+    });
+
+    it("SQLite: emits a nullability-specific TODO comment (no crash)", () => {
+      const content = new SchemaDiffMigrationGenerator().generate(tighten, "sqlite");
+      expect(content).toContain("does not support altering column nullability");
+    });
+
+    it("PostgreSQL: a combined type + nullability change emits both actions", () => {
+      const combined: SchemaDiffResult = {
+        ...tighten,
+        alterColumns: [
+          {
+            tableName: "users",
+            columnName: "name",
+            columnType: "TEXT",
+            currentType: "varchar",
+            nullable: false,
+            currentNullable: true,
+            // typeChanged omitted → defaults to a real type alter
+            expectedLength: null,
+          },
+        ],
+      };
+      const { up } = new SchemaDiffMigrationGenerator().dryRun(combined, "postgres");
+      expect(up.some((s) => s.includes("TYPE TEXT"))).toBe(true);
+      expect(up.some((s) => s.includes("SET NOT NULL"))).toBe(true);
+    });
+  });
+
   describe("diff() — timestamptz handling", () => {
     it("MySQL: timestamptz matches a DATETIME column (no spurious/invalid ALTER)", async () => {
       const runner = createMockQueryRunner({
@@ -1089,7 +1274,10 @@ describe("SchemaDiff — Phase 2 improvements", () => {
       const runner = createMockQueryRunner({
         json_entity: [
           { column_name: "id", data_type: "integer", is_nullable: "NO" },
-          { column_name: "data", data_type: "json", is_nullable: "NO" },
+          // `data!: any` infers nullable:true (design:type Object), so the
+          // column the ORM creates is NULLABLE — the fixture must match, else a
+          // (correct) nullability-only alter would be reported.
+          { column_name: "data", data_type: "json", is_nullable: "YES" },
         ],
       });
 

--- a/__tests__/unit/schema-registrar-synchronize-policy.test.ts
+++ b/__tests__/unit/schema-registrar-synchronize-policy.test.ts
@@ -256,6 +256,65 @@ describe("SchemaRegistrar: synchronize policy", () => {
       await expect(callApplyDiff(policy, diff)).resolves.toBeUndefined();
     });
 
+    it("throws on a tightening nullability ALTER (NULL → NOT NULL) when failOnDestructiveChange=true", async () => {
+      const diff = {
+        addTables: [],
+        dropTables: [],
+        addColumns: [],
+        dropColumns: [],
+        alterColumns: [
+          {
+            tableName: "t",
+            columnName: "email",
+            columnType: "VARCHAR",
+            currentType: "varchar",
+            nullable: false,
+            currentNullable: true,
+            typeChanged: false,
+            expectedLength: 255,
+          },
+        ],
+      };
+      const policy: SynchronizePolicy = {
+        mode: true,
+        continueOnError: true,
+        failOnDestructiveChange: true,
+        logDDL: false,
+      };
+
+      await expect(callApplyDiff(policy, diff)).rejects.toMatchObject({
+        code: OrmErrorCode.SCHEMA_SYNC_DESTRUCTIVE_CHANGE,
+      });
+    });
+
+    it("does not throw on a loosening nullability ALTER (NOT NULL → NULL)", async () => {
+      const diff = {
+        addTables: [],
+        dropTables: [],
+        addColumns: [],
+        dropColumns: [],
+        alterColumns: [
+          {
+            tableName: "t",
+            columnName: "bio",
+            columnType: "TEXT",
+            currentType: "text",
+            nullable: true,
+            currentNullable: false,
+            typeChanged: false,
+          },
+        ],
+      };
+      const policy: SynchronizePolicy = {
+        mode: true,
+        continueOnError: true,
+        failOnDestructiveChange: true,
+        logDDL: false,
+      };
+
+      await expect(callApplyDiff(policy, diff)).resolves.toBeUndefined();
+    });
+
     it("does not throw on DROP COLUMN when failOnDestructiveChange=false (default)", async () => {
       const diff = {
         addTables: [],
@@ -274,6 +333,80 @@ describe("SchemaRegistrar: synchronize policy", () => {
       };
 
       await expect(callApplyDiff(policy, diff)).resolves.toBeUndefined();
+    });
+  });
+
+  describe("buildAlterColumnDDL — nullability (PostgreSQL)", () => {
+    function buildDDL(col: any, dialect: "postgres" | "mysql" = "postgres"): string | null {
+      const policy: SynchronizePolicy = {
+        mode: true,
+        continueOnError: true,
+        failOnDestructiveChange: false,
+        logDDL: false,
+      };
+      const registrar = new SchemaRegistrar(
+        {} as RelationMetadataResolver,
+        makeCtxWithPolicy(policy),
+      );
+      return (registrar as any).buildAlterColumnDDL(col, dialect);
+    }
+
+    it("emits SET NOT NULL without a TYPE rewrite for a nullability-only tighten", () => {
+      const ddl = buildDDL({
+        tableName: "t",
+        columnName: "email",
+        columnType: "VARCHAR",
+        currentType: "varchar",
+        nullable: false,
+        currentNullable: true,
+        typeChanged: false,
+        expectedLength: 255,
+      });
+      expect(ddl).toContain("SET NOT NULL");
+      expect(ddl).not.toContain("TYPE");
+    });
+
+    it("emits DROP NOT NULL for a nullability-only loosen", () => {
+      const ddl = buildDDL({
+        tableName: "t",
+        columnName: "bio",
+        columnType: "TEXT",
+        currentType: "text",
+        nullable: true,
+        currentNullable: false,
+        typeChanged: false,
+      });
+      expect(ddl).toContain("DROP NOT NULL");
+    });
+
+    it("combines a TYPE rewrite and a nullability action in a single ALTER TABLE", () => {
+      const ddl = buildDDL({
+        tableName: "t",
+        columnName: "email",
+        columnType: "TEXT",
+        currentType: "varchar",
+        nullable: false,
+        currentNullable: true,
+        // typeChanged omitted → real type alter
+      });
+      expect(ddl).toContain("TYPE TEXT");
+      expect(ddl).toContain("SET NOT NULL");
+      // a single statement, not two
+      expect((ddl ?? "").match(/ALTER TABLE/g)).toHaveLength(1);
+    });
+
+    it("returns null when neither type nor nullability changed", () => {
+      const ddl = buildDDL({
+        tableName: "t",
+        columnName: "name",
+        columnType: "VARCHAR",
+        currentType: "varchar",
+        nullable: false,
+        currentNullable: false,
+        typeChanged: false,
+        expectedLength: 255,
+      });
+      expect(ddl).toBeNull();
     });
   });
 

--- a/src/core/SchemaRegistrar.ts
+++ b/src/core/SchemaRegistrar.ts
@@ -148,6 +148,13 @@ export class SchemaRegistrar {
    * (text-family → numeric, larger varchar → smaller varchar, etc.).
    */
   private isNarrowingAlter(col: ColumnChange): boolean {
+    // Tightening a column to NOT NULL is destructive: it fails outright when any
+    // existing row holds NULL. Gate it behind failOnDestructiveChange like the
+    // other narrowing cases.
+    if (col.currentNullable === true && col.nullable === false) {
+      return true;
+    }
+
     const cur = (col.currentType ?? "").toUpperCase();
     const next = (col.columnType ?? "").toUpperCase();
     if (!cur || !next) return false;
@@ -612,11 +619,15 @@ export class SchemaRegistrar {
             policy,
           );
         }
+        const change =
+          col.typeChanged === false
+            ? `nullability ${col.currentNullable ? "NULL" : "NOT NULL"} → ${col.nullable === false ? "NOT NULL" : "NULL"}`
+            : `${col.currentType} → ${col.columnType}`;
         if (isDryRun) {
           this.logger.info(`[dry-run] ${ddl}`);
         } else {
           this.logger.warn(
-            `[sync] Altering column ${col.tableName}.${col.columnName}: ${col.currentType} → ${col.columnType}`,
+            `[sync] Altering column ${col.tableName}.${col.columnName}: ${change}`,
           );
           this.logDdl(`[sync] ${ddl}`, policy);
           try {
@@ -794,20 +805,40 @@ export class SchemaRegistrar {
     const columnName = this.ctx.wrap(col.columnName);
 
     if (dialect === "sqlite") {
-      this.logger.warn(
-        `[sync] SQLite does not support ALTER COLUMN TYPE for ${col.tableName}.${col.columnName} ` +
-          `(${col.currentType} → ${typeExpr}). Skipping.`,
-      );
+      const what =
+        col.typeChanged === false
+          ? `column nullability for ${col.tableName}.${col.columnName}`
+          : `ALTER COLUMN TYPE for ${col.tableName}.${col.columnName} (${col.currentType} → ${typeExpr})`;
+      this.logger.warn(`[sync] SQLite does not support ${what}. Skipping.`);
       return null;
     }
 
     if (dialect === "mysql") {
+      // MODIFY COLUMN restates the whole definition, so it carries both the
+      // type and the declared nullability — covering a type change, a
+      // nullability-only change, or both at once.
       const nullable = col.nullable === false ? "NOT NULL" : "NULL";
       return `ALTER TABLE ${tableName} MODIFY COLUMN ${columnName} ${typeExpr} ${nullable}`;
     }
 
-    // PostgreSQL
-    return `ALTER TABLE ${tableName} ALTER COLUMN ${columnName} TYPE ${typeExpr}`;
+    // PostgreSQL: TYPE and nullability are independent ALTER actions and a
+    // single ALTER TABLE may carry both. A nullability-only change
+    // (typeChanged === false) skips the TYPE rewrite — `ALTER COLUMN ... TYPE`
+    // forces a full table rewrite even when the type is unchanged.
+    const actions: string[] = [];
+    if (col.typeChanged !== false) {
+      actions.push(`ALTER COLUMN ${columnName} TYPE ${typeExpr}`);
+    }
+    const targetNullable = col.nullable !== false;
+    if (col.currentNullable !== undefined && col.currentNullable !== targetNullable) {
+      actions.push(
+        targetNullable
+          ? `ALTER COLUMN ${columnName} DROP NOT NULL`
+          : `ALTER COLUMN ${columnName} SET NOT NULL`,
+      );
+    }
+    if (actions.length === 0) return null;
+    return `ALTER TABLE ${tableName} ${actions.join(", ")}`;
   }
 
   /**

--- a/src/core/generators/SchemaDiff.ts
+++ b/src/core/generators/SchemaDiff.ts
@@ -30,6 +30,20 @@ export interface ColumnChange {
   columnType?: string;
   currentType?: string;
   nullable?: boolean;
+  /**
+   * The DB column's current nullability (`is_nullable = "YES"`). Set on
+   * alterColumns so the ALTER generators can (a) emit a PostgreSQL
+   * `SET/DROP NOT NULL` action and (b) reverse it in a `down` migration.
+   * Undefined on add/drop paths and on hand-built diffs (backward compatible).
+   */
+  currentNullable?: boolean;
+  /**
+   * `false` when the alter carries ONLY a nullability change (type and length
+   * are unchanged) — generators then skip the `TYPE` rewrite, which on
+   * PostgreSQL would force an unnecessary, possibly expensive, table rewrite.
+   * Treated as a type/length alter when omitted (backward compatible).
+   */
+  typeChanged?: boolean;
   expectedLength?: number | null;
   actualLength?: number | null;
   expectedPrecision?: number | null;
@@ -185,6 +199,15 @@ export class SchemaDiff {
           );
           const actualType = dbCol.data_type.toUpperCase();
 
+          // Expected nullability mirrors the CREATE path exactly
+          // (BaseColumnDefinitionBuilder: `option.nullable ? NULL : NOT NULL`),
+          // so a schema freshly created by this ORM never reports a spurious
+          // nullability diff. `is_nullable` is normalized to "YES"/"NO" across
+          // all three dialects by getDbColumns().
+          const expectedNullable = col.options?.nullable ?? false;
+          const dbNullable =
+            (dbCol.is_nullable ?? "").toString().toUpperCase() === "YES";
+
           if (!this.typesMatch(expectedType, actualType, dialect)) {
             result.alterColumns.push({
               tableName,
@@ -193,7 +216,8 @@ export class SchemaDiff {
               currentType: dbCol.data_type,
               // Carry the declared nullability — MySQL's MODIFY COLUMN restates
               // the whole definition, so omitting this silently drops NOT NULL.
-              nullable: col.options?.nullable ?? false,
+              nullable: expectedNullable,
+              currentNullable: dbNullable,
               // Carry length/precision/scale too: castType emits a bare type
               // (e.g. "VARCHAR", "DECIMAL"), so without these the generated
               // ALTER becomes "MODIFY ... VARCHAR" — a MySQL 1064 syntax error
@@ -213,7 +237,35 @@ export class SchemaDiff {
               columnName: colName,
               columnType: expectedType,
               currentType: dbCol.data_type,
-              nullable: col.options?.nullable ?? false,
+              nullable: expectedNullable,
+              currentNullable: dbNullable,
+              expectedLength: col.options?.length ?? null,
+              actualLength: dbCol.character_maximum_length ?? null,
+              expectedPrecision: col.options?.precision ?? null,
+              actualPrecision: dbCol.numeric_precision ?? null,
+              expectedScale: col.options?.scale ?? null,
+              actualScale: dbCol.numeric_scale ?? null,
+              enumValues: col.options?.enumValues,
+            });
+          } else if (
+            expectedNullable !== dbNullable &&
+            !col.options?.primary
+          ) {
+            // Type and length match, but nullability drifted — emit a
+            // nullability-only alter. Primary-key columns are skipped: their
+            // nullability is structurally fixed and dialect-quirky (SQLite's
+            // `INTEGER PRIMARY KEY` reports notnull=0 / is_nullable="YES").
+            // `typeChanged: false` tells the generators to skip the TYPE rewrite
+            // and emit only `SET/DROP NOT NULL` (Postgres) or restate the column
+            // via `MODIFY COLUMN` (MySQL).
+            result.alterColumns.push({
+              tableName,
+              columnName: colName,
+              columnType: expectedType,
+              currentType: dbCol.data_type,
+              nullable: expectedNullable,
+              currentNullable: dbNullable,
+              typeChanged: false,
               expectedLength: col.options?.length ?? null,
               actualLength: dbCol.character_maximum_length ?? null,
               expectedPrecision: col.options?.precision ?? null,

--- a/src/core/generators/SchemaDiffMigrationGenerator.ts
+++ b/src/core/generators/SchemaDiffMigrationGenerator.ts
@@ -127,25 +127,9 @@ export class SchemaDiffMigrationGenerator {
       );
     }
 
-    // Alter columns
+    // Alter columns (type and/or nullability; SQLite cannot alter — skipped)
     for (const col of diff.alterColumns) {
-      const typeStr = this.renderColumnType(col, dialect);
-      if (dialect === "sqlite") {
-        // SQLite cannot alter column types — skip in SQL
-      } else if (dialect === "mysql") {
-        // MySQL MODIFY COLUMN restates the whole column definition, so the
-        // declared nullability must be reattached — otherwise altering a
-        // NOT NULL column's type silently drops NOT NULL (mirrors the live
-        // SchemaRegistrar.buildAlterColumnDDL path).
-        const nullability = col.nullable === false ? " NOT NULL" : " NULL";
-        sqls.push(
-          `ALTER TABLE ${this.escapeId(col.tableName, dialect)} MODIFY COLUMN ${this.escapeId(col.columnName, dialect)} ${typeStr}${nullability}`,
-        );
-      } else {
-        sqls.push(
-          `ALTER TABLE ${this.escapeId(col.tableName, dialect)} ALTER COLUMN ${this.escapeId(col.columnName, dialect)} TYPE ${typeStr}`,
-        );
-      }
+      sqls.push(...this.alterColumnUpSql(col, dialect));
     }
 
     // Rename columns
@@ -179,18 +163,9 @@ export class SchemaDiffMigrationGenerator {
       );
     }
 
-    // Reverse of alter columns
+    // Reverse of alter columns — restore previous type and nullability
     for (const col of diff.alterColumns) {
-      const typeStr = col.currentType ?? "VARCHAR(255)";
-      if (dialect === "mysql") {
-        sqls.push(
-          `ALTER TABLE ${this.escapeId(col.tableName, dialect)} MODIFY COLUMN ${this.escapeId(col.columnName, dialect)} ${typeStr}`,
-        );
-      } else if (dialect !== "sqlite") {
-        sqls.push(
-          `ALTER TABLE ${this.escapeId(col.tableName, dialect)} ALTER COLUMN ${this.escapeId(col.columnName, dialect)} TYPE ${typeStr}`,
-        );
-      }
+      sqls.push(...this.alterColumnDownSql(col, dialect));
     }
 
     // Reverse of renames
@@ -257,30 +232,19 @@ export class SchemaDiffMigrationGenerator {
       );
     }
 
-    // Alter columns (type change)
+    // Alter columns (type and/or nullability)
     for (const col of diff.alterColumns) {
-      const typeStr = this.renderColumnType(col, dialect);
       if (dialect === "sqlite") {
+        const where = `${this.escapeId(col.tableName, dialect)}.${this.escapeId(col.columnName, dialect)}`;
         stmts.push(
-          `// TODO: SQLite does not support ALTER COLUMN TYPE for ${this.escapeId(col.tableName, dialect)}.${this.escapeId(col.columnName, dialect)} (${col.currentType} -> ${typeStr}). Recreate the table instead.`,
+          col.typeChanged === false
+            ? `// TODO: SQLite does not support altering column nullability for ${where}. Recreate the table instead.`
+            : `// TODO: SQLite does not support ALTER COLUMN TYPE for ${where} (${col.currentType} -> ${this.renderColumnType(col, dialect)}). Recreate the table instead.`,
         );
-      } else if (dialect === "mysql") {
-        // MySQL MODIFY COLUMN restates the whole column definition, so the
-        // declared nullability must be reattached — otherwise altering a
-        // NOT NULL column's type silently drops NOT NULL (mirrors the live
-        // SchemaRegistrar.buildAlterColumnDDL path).
-        const nullability = col.nullable === false ? " NOT NULL" : " NULL";
-        stmts.push(
-          this.wrapSqlInQuery(
-            `ALTER TABLE ${this.escapeId(col.tableName, dialect)} MODIFY COLUMN ${this.escapeId(col.columnName, dialect)} ${typeStr}${nullability}`,
-          ),
-        );
-      } else {
-        stmts.push(
-          this.wrapSqlInQuery(
-            `ALTER TABLE ${this.escapeId(col.tableName, dialect)} ALTER COLUMN ${this.escapeId(col.columnName, dialect)} TYPE ${typeStr}`,
-          ),
-        );
+        continue;
+      }
+      for (const s of this.alterColumnUpSql(col, dialect)) {
+        stmts.push(this.wrapSqlInQuery(s));
       }
     }
 
@@ -332,21 +296,10 @@ export class SchemaDiffMigrationGenerator {
       );
     }
 
-    // Reverse of alter columns — restore old type
+    // Reverse of alter columns — restore previous type and nullability
     for (const col of diff.alterColumns) {
-      const typeStr = col.currentType ?? "VARCHAR(255)";
-      if (dialect === "mysql") {
-        stmts.push(
-          this.wrapSqlInQuery(
-            `ALTER TABLE ${this.escapeId(col.tableName, dialect)} MODIFY COLUMN ${this.escapeId(col.columnName, dialect)} ${typeStr}`,
-          ),
-        );
-      } else if (dialect !== "sqlite") {
-        stmts.push(
-          this.wrapSqlInQuery(
-            `ALTER TABLE ${this.escapeId(col.tableName, dialect)} ALTER COLUMN ${this.escapeId(col.columnName, dialect)} TYPE ${typeStr}`,
-          ),
-        );
+      for (const s of this.alterColumnDownSql(col, dialect)) {
+        stmts.push(this.wrapSqlInQuery(s));
       }
     }
 
@@ -507,6 +460,94 @@ export class SchemaDiffMigrationGenerator {
     }
 
     return type;
+  }
+
+  /**
+   * Forward (up) ALTER statement(s) for a single column change. Returns raw SQL
+   * (no `await query(...)` wrapper); SQLite returns `[]` since it cannot alter
+   * columns (callers emit their own skip/comment). On PostgreSQL a TYPE change
+   * and a nullability change are independent actions — a nullability-only
+   * change (`typeChanged === false`) skips the TYPE rewrite, which would force
+   * an unnecessary full table rewrite. MySQL restates the whole column via
+   * MODIFY COLUMN, which carries type and nullability together.
+   */
+  private alterColumnUpSql(col: ColumnChange, dialect: SchemaDialect): string[] {
+    if (dialect === "sqlite") return [];
+    const table = this.escapeId(col.tableName, dialect);
+    const column = this.escapeId(col.columnName, dialect);
+
+    if (dialect === "mysql") {
+      const typeStr = this.renderColumnType(col, dialect);
+      const nullability = col.nullable === false ? " NOT NULL" : " NULL";
+      return [`ALTER TABLE ${table} MODIFY COLUMN ${column} ${typeStr}${nullability}`];
+    }
+
+    // PostgreSQL
+    const out: string[] = [];
+    if (col.typeChanged !== false) {
+      const typeStr = this.renderColumnType(col, dialect);
+      out.push(`ALTER TABLE ${table} ALTER COLUMN ${column} TYPE ${typeStr}`);
+    }
+    const targetNullable = col.nullable !== false;
+    if (
+      col.currentNullable !== undefined &&
+      col.currentNullable !== targetNullable
+    ) {
+      out.push(
+        targetNullable
+          ? `ALTER TABLE ${table} ALTER COLUMN ${column} DROP NOT NULL`
+          : `ALTER TABLE ${table} ALTER COLUMN ${column} SET NOT NULL`,
+      );
+    }
+    return out;
+  }
+
+  /**
+   * Reverse (down) ALTER statement(s) restoring the previous DB state of a
+   * single column change. SQLite returns `[]`. The previous nullability is
+   * reattached when known (`currentNullable`), so a nullability change round-
+   * trips cleanly.
+   */
+  private alterColumnDownSql(col: ColumnChange, dialect: SchemaDialect): string[] {
+    if (dialect === "sqlite") return [];
+    const table = this.escapeId(col.tableName, dialect);
+    const column = this.escapeId(col.columnName, dialect);
+
+    if (dialect === "mysql") {
+      // For a nullability-only change the type is unchanged (restate the
+      // declared type with length); for a type change restore the previous
+      // type. Reattach the previous nullability when known.
+      const typeStr =
+        col.typeChanged === false
+          ? this.renderColumnType(col, dialect)
+          : (col.currentType ?? "VARCHAR(255)");
+      const nullability =
+        col.currentNullable === true
+          ? " NULL"
+          : col.currentNullable === false
+            ? " NOT NULL"
+            : "";
+      return [`ALTER TABLE ${table} MODIFY COLUMN ${column} ${typeStr}${nullability}`];
+    }
+
+    // PostgreSQL
+    const out: string[] = [];
+    if (col.typeChanged !== false) {
+      const typeStr = col.currentType ?? "VARCHAR(255)";
+      out.push(`ALTER TABLE ${table} ALTER COLUMN ${column} TYPE ${typeStr}`);
+    }
+    const targetNullable = col.nullable !== false;
+    if (
+      col.currentNullable !== undefined &&
+      col.currentNullable !== targetNullable
+    ) {
+      out.push(
+        col.currentNullable
+          ? `ALTER TABLE ${table} ALTER COLUMN ${column} DROP NOT NULL`
+          : `ALTER TABLE ${table} ALTER COLUMN ${column} SET NOT NULL`,
+      );
+    }
+    return out;
   }
 
   /**


### PR DESCRIPTION
## Problem

`SchemaDiff` compared column **type** and **length** but never compared **nullability**. As a result, a `@Column({ nullable })` change — or any NOT NULL / NULL drift between an entity and the live DB — was silently ignored: `synchronize` and `migrate:generate` produced no ALTER and the schema stayed divergent.

The recent #388 fix only made a *type alter* carry the declared nullability (so MySQL MODIFY COLUMN wouldn't drop NOT NULL). Detecting a **nullability-only** change was still missing, and PostgreSQL had no `SET/DROP NOT NULL` path at all.

## Changes

- **Detection (`SchemaDiff`)** — emits a nullability-only alter when type and length match but nullability differs. Expected nullability mirrors the CREATE path exactly (`option.nullable ? NULL : NOT NULL`), so a schema freshly created by this ORM never reports a spurious diff. Primary-key columns are excluded: their nullability is structurally fixed and dialect-quirky (SQLite reports `INTEGER PRIMARY KEY` as notnull=0 / is_nullable="YES"). `ColumnChange` gains `currentNullable` (DB state) and `typeChanged`.
- **Live path (`SchemaRegistrar.buildAlterColumnDDL`)** — PostgreSQL emits `SET/DROP NOT NULL`, combined with a TYPE action in a single `ALTER TABLE` when both changed; a nullability-only change skips the TYPE rewrite (which on PostgreSQL forces an unnecessary, possibly expensive, full table rewrite). MySQL restates the column via MODIFY COLUMN. Tightening a column to NOT NULL is treated as destructive and gated behind `failOnDestructiveChange`.
- **Migration-file path (`SchemaDiffMigrationGenerator`)** — up/down for both MySQL and PostgreSQL mirror the live path; the previous nullability is reattached on `down` so the change round-trips. SQLite emits a nullability-specific TODO comment.

Hand-built `SchemaDiffResult`s (without the new fields) behave exactly as before — the new behavior only activates on diffs produced by `SchemaDiff`.

## Tests

- `schema-diff.test.ts` — detection (MySQL tighten / PG loosen), PG `SET`/`DROP NOT NULL` without a TYPE rewrite, combined type+nullability, PK exclusion, no-op when nullability matches.
- `schema-registrar-synchronize-policy.test.ts` — destructive guard for NULL→NOT NULL, and direct `buildAlterColumnDDL` coverage (single combined statement, null when nothing changed).
- `schema-diff-sync.test.ts` (real SQLite) — nullability-only detection end-to-end; the existing zero-diff baseline now also validates the PK quirk guard.
- One unrealistic JSON fixture (`is_nullable: "NO"` for a column the ORM creates nullable) was corrected to match what the ORM actually creates — the new code correctly flagged it.

Full unit suite **5280 passed / 1 skipped / 0 failures**; SQLite integration **509 passed**.