### PR TITLE
fix(core): @Version batch-insert init under naming strategy + getCursor withDeleted

### DIFF
--- a/__tests__/integration/sqlite/getcursor-withdeleted.test.ts
+++ b/__tests__/integration/sqlite/getcursor-withdeleted.test.ts
@@ -1,0 +1,91 @@
+/**
+ * SQLite In-Memory: SelectQueryBuilder.getCursor() honors the `withDeleted`
+ * option.
+ *
+ * Regression: getCursor() accepted `withDeleted` in CursorPaginationOption but
+ * never applied it, so soft-deleted rows were always filtered out — diverging
+ * from EntityManager.findWithCursor(), which honors the same option.
+ */
+import "reflect-metadata";
+import {
+  createTestConnection,
+  type TestConnectionResult,
+} from "../helpers/test-connection";
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  DeletedAt,
+} from "../../../src";
+import { getScannerInstance } from "../../../src/scanner/ScannerContainer";
+import { ColumnScanner } from "../../../src/scanner";
+import { MetadataLayerRegistry } from "../../../src/scanner/MetadataScanner";
+
+describe("[Integration] SQLite: SelectQueryBuilder.getCursor() withDeleted", () => {
+  let conn: TestConnectionResult;
+  let Post: new () => { id: number; title: string };
+  let table: string;
+
+  beforeAll(async () => {
+    table = `cur_sd_${String(Date.now()).slice(-6)}`;
+
+    conn = await createTestConnection(
+      {
+        type: "sqlite",
+        database: ":memory:",
+        synchronize: true,
+        logging: false,
+      },
+      () => {
+        MetadataLayerRegistry.reset();
+        getScannerInstance(ColumnScanner).clear();
+
+        @Entity({ name: table })
+        class PostEntity {
+          @PrimaryGeneratedColumn() id!: number;
+          @Column() title!: string;
+          @DeletedAt() deletedAt!: Date | null;
+        }
+
+        Post = PostEntity;
+        return { entities: [PostEntity] };
+      },
+    );
+
+    await conn.em.saveMany(Post, [
+      { title: "a" },
+      { title: "b" },
+      { title: "c" },
+    ] as any);
+    // Soft-delete the middle row.
+    await conn.em.softDelete(Post, { title: "b" } as any);
+  });
+
+  afterAll(async () => {
+    await conn.cleanup();
+  });
+
+  it("excludes soft-deleted rows by default", async () => {
+    const res = await conn.em
+      .createQueryBuilder(Post, "p")
+      .getCursor({ take: 10, orderBy: "id" });
+    const titles = res.data.map((r: any) => r.title).sort();
+    expect(titles).toEqual(["a", "c"]);
+  });
+
+  it("includes soft-deleted rows when withDeleted: true is passed", async () => {
+    const res = await conn.em
+      .createQueryBuilder(Post, "p")
+      .getCursor({ take: 10, orderBy: "id", withDeleted: true });
+    const titles = res.data.map((r: any) => r.title).sort();
+    expect(titles).toEqual(["a", "b", "c"]);
+  });
+
+  it("still excludes soft-deleted rows when withDeleted is omitted (no leak)", async () => {
+    const res = await conn.em
+      .createQueryBuilder(Post, "p")
+      .getCursor({ take: 10, orderBy: "id", withDeleted: false });
+    const titles = res.data.map((r: any) => r.title).sort();
+    expect(titles).toEqual(["a", "c"]);
+  });
+});

--- a/__tests__/integration/sqlite/version-batch-insert-snake-naming.test.ts
+++ b/__tests__/integration/sqlite/version-batch-insert-snake-naming.test.ts
@@ -1,0 +1,100 @@
+/**
+ * SQLite In-Memory: @Version auto-initialization on the BATCH insert paths
+ * under a transforming NamingStrategy.
+ *
+ * Regression: saveMany()/insertMany()/insertManyAndReturn() initialized the
+ * @Version column by writing `item[versionColumnName] = 1`. After
+ * applyNamingStrategyToEntities rewrites VERSION_TOKEN to the resolved DB column
+ * name, that column name no longer equals the property key — but the VALUES are
+ * bound from the property key, so the version landed as NULL (or violated a
+ * NOT NULL constraint). Single-word version properties happened to work because
+ * column name == property key; a multi-word property (rowVersion -> row_version)
+ * exposes the bug. The single-row save() path was already correct.
+ */
+import "reflect-metadata";
+import {
+  createTestConnection,
+  type TestConnectionResult,
+} from "../helpers/test-connection";
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  Version,
+} from "../../../src";
+import { SnakeNamingStrategy } from "../../../src/core/generators/SnakeNamingStrategy";
+import { getScannerInstance } from "../../../src/scanner/ScannerContainer";
+import { ColumnScanner } from "../../../src/scanner";
+import { MetadataLayerRegistry } from "../../../src/scanner/MetadataScanner";
+import { DatabaseClient } from "../../../src/DatabaseClient";
+
+describe("[Integration] SQLite: @Version batch-insert init under SnakeNamingStrategy", () => {
+  let conn: TestConnectionResult;
+  let Doc: any;
+  let tableName: string;
+
+  beforeAll(async () => {
+    tableName = `ver_snake_${String(Date.now()).slice(-6)}`;
+
+    conn = await createTestConnection(
+      {
+        type: "sqlite",
+        database: ":memory:",
+        synchronize: true,
+        logging: false,
+        namingStrategy: new SnakeNamingStrategy(),
+      },
+      () => {
+        MetadataLayerRegistry.reset();
+        getScannerInstance(ColumnScanner).clear();
+
+        @Entity({ name: tableName })
+        class DocEntity {
+          @PrimaryGeneratedColumn() id!: number;
+          @Column() title!: string;
+          // Multi-word property → snake_case column "row_version" (≠ propKey).
+          @Version() rowVersion!: number;
+        }
+
+        Doc = DocEntity;
+        return { entities: [DocEntity] };
+      },
+    );
+  });
+
+  afterAll(async () => {
+    await conn.cleanup();
+  });
+
+  /** Reads the raw `row_version` column straight from the DB (not the entity). */
+  async function readVersions(): Promise<unknown[]> {
+    const connector = DatabaseClient.getInstance().getConnection();
+    const rows = (await connector.query(
+      `SELECT "row_version" FROM "${tableName}" ORDER BY "id"`,
+    )) as any[];
+    return rows.map((r) => r.row_version);
+  }
+
+  it("saveMany() initializes the @Version column to 1 (not NULL)", async () => {
+    await conn.em.saveMany(Doc, [{ title: "a" }, { title: "b" }] as any);
+    expect(await readVersions()).toEqual([1, 1]);
+  });
+
+  it("insertMany() initializes the @Version column to 1", async () => {
+    const before = (await readVersions()).length;
+    await conn.em.insertMany(Doc, [{ title: "c" }] as any);
+    const versions = await readVersions();
+    expect(versions.length).toBe(before + 1);
+    expect(versions[versions.length - 1]).toBe(1);
+  });
+
+  it("insertManyAndReturn() returns rows with @Version = 1 and persists it", async () => {
+    const returned = (await conn.em.insertManyAndReturn(Doc, [
+      { title: "d" },
+    ] as any)) as any[];
+    expect(returned[0].rowVersion).toBe(1);
+
+    const versions = await readVersions();
+    expect(versions[versions.length - 1]).toBe(1);
+  });
+});

--- a/src/core/SelectQueryBuilder.ts
+++ b/src/core/SelectQueryBuilder.ts
@@ -5029,6 +5029,13 @@ export class SelectQueryBuilder<T, TResult = T> {
     // Operate on a clone so the source builder is untouched (as paginate() does).
     const paged = this.clone();
 
+    // Honor the `withDeleted` option so soft-deleted rows can be included,
+    // matching ReadExecutor.findWithCursor. A prior `.withDeleted()` on the
+    // builder is preserved by clone(); this also lets the option request it.
+    if (option.withDeleted) {
+      paged.withDeleted();
+    }
+
     // Append the keyset predicate, ANDed with the builder's existing WHERE /
     // JOIN / soft-delete / tenant clauses via the same andWhere() path. NULL
     // rows that have not been visited yet are included, matching findWithCursor.

--- a/src/core/entity-manager/WriteExecutor.ts
+++ b/src/core/entity-manager/WriteExecutor.ts
@@ -996,8 +996,16 @@ export class WriteExecutor {
           (item as any)[this.ctx.propKey(col)] = now;
         }
       }
-      if (versionCol && (item as any)[versionCol] == null) {
-        (item as any)[versionCol] = 1;
+      if (versionCol) {
+        // `versionCol` is the DB column name (applyNamingStrategyToEntities
+        // rewrites VERSION_TOKEN to the resolved column name), but VALUES bind
+        // from the property key below — so initialize via propKey, mirroring the
+        // @CreateTimestamp/@UpdateTimestamp handling above. Setting item[colName]
+        // here would write a bogus property and leave the version NULL.
+        const versionColumn = insertableColumns.find((c) => c.name === versionCol);
+        if (versionColumn && (item as any)[this.ctx.propKey(versionColumn)] == null) {
+          (item as any)[this.ctx.propKey(versionColumn)] = 1;
+        }
       }
     }
 
@@ -1206,9 +1214,16 @@ export class WriteExecutor {
 
       const versionCol = this.resolver.getVersionColumn(entity);
       if (versionCol) {
-        for (const item of items) {
-          if ((item as any)[versionCol] == null) {
-            (item as any)[versionCol] = 1;
+        // `versionCol` is the resolved DB column name; the value binding reads
+        // the property key, so initialize via propKey (not the column name) or
+        // the version lands as NULL under a transforming naming strategy.
+        const versionColumn = metadata.columns.find((c) => c.name === versionCol);
+        if (versionColumn) {
+          const versionProp = this.ctx.propKey(versionColumn);
+          for (const item of items) {
+            if ((item as any)[versionProp] == null) {
+              (item as any)[versionProp] = 1;
+            }
           }
         }
       }
@@ -1369,9 +1384,16 @@ export class WriteExecutor {
 
       const versionCol = this.resolver.getVersionColumn(entity);
       if (versionCol) {
-        for (const item of items) {
-          if ((item as any)[versionCol] == null) {
-            (item as any)[versionCol] = 1;
+        // `versionCol` is the resolved DB column name; the value binding reads
+        // the property key, so initialize via propKey (not the column name) or
+        // the version lands as NULL under a transforming naming strategy.
+        const versionColumn = metadata.columns.find((c) => c.name === versionCol);
+        if (versionColumn) {
+          const versionProp = this.ctx.propKey(versionColumn);
+          for (const item of items) {
+            if ((item as any)[versionProp] == null) {
+              (item as any)[versionProp] = 1;
+            }
           }
         }
       }


### PR DESCRIPTION
## Two verified correctness bugs

### 1. @Version is dropped on batch inserts under a transforming NamingStrategy

The batch insert paths — `saveMany()`, `insertMany()`, `insertManyAndReturn()` — initialized the optimistic-lock column via `item[versionColumnName] = 1`. After `applyNamingStrategyToEntities` rewrites `VERSION_TOKEN` to the resolved DB column name, that name no longer equals the property key, but the `VALUES` are bound from the **property key**. So the version landed as `NULL` — or violated a `NOT NULL` constraint and aborted the insert — for any `@Version` column whose DB name differs from its property (e.g. `rowVersion` → `row_version` under `SnakeNamingStrategy`).

Single-word version properties worked by accident (column name == property key), as did the single-row `save()` path (it writes the positional values array directly). All three batch sites now resolve the column metadata and initialize via `propKey`, mirroring the existing `@CreateTimestamp`/`@UpdateTimestamp` handling a few lines above.

### 2. SelectQueryBuilder.getCursor() ignores the `withDeleted` option

`getCursor()` accepts `withDeleted` in `CursorPaginationOption` but never applied it, so soft-deleted rows were always filtered out — diverging from `EntityManager.findWithCursor()`, which honors the same option. The clone now calls `withDeleted()` when the option is set; a prior `.withDeleted()` on the builder is still preserved by `clone()`.

## Tests

Real-SQLite integration regressions (run in the SQLite CI job):

- `version-batch-insert-snake-naming.test.ts` — asserts the stored `row_version` directly (read back via raw SQL) across all three batch APIs under `SnakeNamingStrategy`.
- `getcursor-withdeleted.test.ts` — default excludes soft-deleted rows, `withDeleted: true` includes them, omitting the option keeps them excluded (no leak).

Each test was confirmed to fail when its corresponding fix is reverted (the version case fails with `NOT NULL constraint failed: row_version`).

Full unit suite **5280 passed / 1 skipped / 0 failures**; SQLite integration **515 passed**.