### PR TITLE
feat(schema): decorator-free lifecycle hooks for defineEntity + comprehensive docs

### DIFF
--- a/__tests__/integration/sqlite/define-entity-e2e.test.ts
+++ b/__tests__/integration/sqlite/define-entity-e2e.test.ts
@@ -110,4 +110,71 @@ describe("[Integration] SQLite: defineEntity builder e2e", () => {
       await (accEm as unknown as { destroy?: () => Promise<void> }).destroy?.();
     }
   });
+
+  it("fires a decorator-free lifecycle hook on a saved instance", async () => {
+    const Article = defineEntity(
+      "dee_articles",
+      {
+        id: t.int().primary().generated(),
+        title: t.varchar(200),
+        slug: t.varchar(200).nullable(),
+      },
+      {
+        hooks: {
+          beforeInsert(e) {
+            if (!e.slug) {
+              e.slug = e.title.toLowerCase().replace(/\s+/g, "-");
+            }
+          },
+        },
+      },
+    );
+    const artEm = await createTestEntityManager({ entities: [Article] });
+    try {
+      // The constructor accepts a partial → the instance carries the hook.
+      const saved = await artEm.save(Article, new Article({ title: "Hello World" }));
+      expect(saved.slug).toBe("hello-world");
+
+      const found = await artEm.findOne(Article, { where: { id: saved.id } });
+      expect(found!.slug).toBe("hello-world");
+    } finally {
+      await (artEm as unknown as { destroy?: () => Promise<void> }).destroy?.();
+    }
+  });
+
+  it("excludes a t.computed() column from the INSERT column list", async () => {
+    // Computed columns are rendered into DDL by the migration generator
+    // (SchemaGenerator), not the runtime `synchronize` path — same as the
+    // decorator `@ComputedColumn`. Here we verify the write-path contract:
+    // `save()` never writes the computed column (doing so would error), so a
+    // plain table standing in for the generated one accepts the INSERT.
+    const Person = defineEntity("dee_people", {
+      id: t.int().primary().generated(),
+      firstName: t.varchar(80).name("first_name"),
+      lastName: t.varchar(80).name("last_name"),
+      fullName: t.computed<string>("first_name || ' ' || last_name", {
+        stored: true,
+        type: "varchar",
+        nullable: true,
+      }),
+    });
+    const pplEm = await createTestEntityManager({ entities: [Person] });
+    try {
+      const saved = await pplEm.save(Person, {
+        firstName: "Ada",
+        lastName: "Lovelace",
+      } as Partial<InferEntity<typeof Person>>);
+      expect(saved.id).toBeGreaterThan(0);
+
+      // The computed column is not a stored column, so it is absent from DDL
+      // here, and the INSERT succeeded precisely because it was excluded.
+      const rows = (await pplEm.query(
+        "SELECT first_name, last_name FROM dee_people WHERE id = ?",
+        [saved.id],
+      )) as Array<{ first_name: string; last_name: string }>;
+      expect(rows[0]).toEqual({ first_name: "Ada", last_name: "Lovelace" });
+    } finally {
+      await (pplEm as unknown as { destroy?: () => Promise<void> }).destroy?.();
+    }
+  });
 });

--- a/__tests__/unit/define-entity.test.ts
+++ b/__tests__/unit/define-entity.test.ts
@@ -13,6 +13,12 @@ import { VERSION_TOKEN } from "../../src/decorators/Version";
 import { CREATE_TIMESTAMP_TOKEN } from "../../src/decorators/CreateTimestamp";
 import { UPDATE_TIMESTAMP_TOKEN } from "../../src/decorators/UpdateTimestamp";
 import { DELETED_AT_TOKEN } from "../../src/decorators/DeletedAt";
+import { HOOK_TOKEN, HookMetadata } from "../../src/decorators/Hooks";
+import {
+  COMPUTED_COLUMN_TOKEN,
+  ComputedColumnMetadata,
+} from "../../src/decorators/ComputedColumn";
+import { SchemaGenerator } from "../../src/core/generators/SchemaGenerator";
 import { ReflectManager } from "../../src/utils/ReflectManager";
 import {
   EntityScanner,
@@ -328,6 +334,150 @@ describe("defineEntity — computed columns", () => {
     expect(columns.map((c) => c.propertyKey)).toEqual(
       expect.arrayContaining(["id", "firstName", "lastName"]),
     );
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 5b. Lifecycle hooks (decorator-free)
+// ═══════════════════════════════════════════════════════════════════════════
+describe("defineEntity — lifecycle hooks", () => {
+  it("attaches an inline hook function and registers HOOK_TOKEN", () => {
+    const Article = defineEntity(
+      "de_hook_article",
+      {
+        id: t.int().primary().generated(),
+        title: t.varchar(200),
+        slug: t.varchar(200).nullable(),
+      },
+      {
+        hooks: {
+          beforeInsert(e) {
+            if (!e.slug) {
+              e.slug = e.title.toLowerCase().replace(/\s+/g, "-");
+            }
+          },
+        },
+      },
+    );
+
+    const hooks: HookMetadata[] = Reflect.getMetadata(HOOK_TOKEN, Article);
+    expect(hooks).toHaveLength(1);
+    expect(hooks[0].event).toBe("beforeInsert");
+
+    // The resolved hook is a real, callable method on the prototype.
+    const method = (Article.prototype as any)[hooks[0].methodName];
+    expect(typeof method).toBe("function");
+  });
+
+  it("fires the hook (as runHooks does) on an instance built from the constructor", () => {
+    const Article = defineEntity(
+      "de_hook_fire",
+      {
+        id: t.int().primary().generated(),
+        title: t.varchar(200),
+        slug: t.varchar(200).nullable(),
+      },
+      {
+        hooks: {
+          beforeInsert(e) {
+            e.slug = e.title.toLowerCase().replace(/\s+/g, "-");
+          },
+        },
+      },
+    );
+
+    const hooks: HookMetadata[] = Reflect.getMetadata(HOOK_TOKEN, Article);
+    const instance: any = new Article({ title: "Hello World" });
+    // Mirror CascadeHandler.runHooks: method.call(item, item).
+    instance[hooks[0].methodName].call(instance, instance);
+    expect(instance.slug).toBe("hello-world");
+  });
+
+  it("supports a string handler naming a prototype method", () => {
+    const Base = defineEntity(
+      "de_hook_string",
+      { id: t.int().primary().generated() },
+      { hooks: { afterInsert: "log" } },
+    );
+    (Base.prototype as any).log = function log() {
+      return "ok";
+    };
+
+    const hooks: HookMetadata[] = Reflect.getMetadata(HOOK_TOKEN, Base);
+    expect(hooks).toEqual([{ methodName: "log", event: "afterInsert" }]);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 5c. Constructor initializer
+// ═══════════════════════════════════════════════════════════════════════════
+describe("defineEntity — constructor initializer", () => {
+  it("copies a partial initializer onto the instance", () => {
+    const User = defineEntity("de_ctor_user", {
+      id: t.int().primary().generated(),
+      name: t.varchar(120),
+    });
+
+    const u: any = new User({ id: 7, name: "Ada" });
+    expect(u.id).toBe(7);
+    expect(u.name).toBe("Ada");
+    expect(u).toBeInstanceOf(User);
+  });
+
+  it("still constructs with no arguments", () => {
+    const User = defineEntity("de_ctor_empty", {
+      id: t.int().primary().generated(),
+    });
+    expect(() => new User()).not.toThrow();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 5d. Computed column options pass-through
+// ═══════════════════════════════════════════════════════════════════════════
+describe("defineEntity — computed column options", () => {
+  it("forwards stored / type / length / nullable to the computed metadata", () => {
+    const Person = defineEntity("de_computed_opts", {
+      id: t.int().primary().generated(),
+      firstName: t.varchar(80).name("first_name"),
+      lastName: t.varchar(80).name("last_name"),
+      fullName: t.computed<string>("first_name || ' ' || last_name", {
+        stored: true,
+        type: "varchar",
+        length: 511,
+        nullable: true,
+      }),
+    });
+
+    const computed: ComputedColumnMetadata[] = Reflect.getMetadata(
+      COMPUTED_COLUMN_TOKEN,
+      Person.prototype,
+    );
+    const full = computed.find((c) => c.propertyKey === "fullName")!;
+    expect(full.options.stored).toBe(true);
+    expect(full.options.type).toBe("varchar");
+    expect(full.options.length).toBe(511);
+    expect(full.options.nullable).toBe(true);
+  });
+
+  it("renders the same GENERATED ALWAYS AS DDL the decorator produces", () => {
+    const Person = defineEntity("de_computed_ddl", {
+      id: t.int().primary().generated(),
+      firstName: t.varchar(80).name("first_name"),
+      lastName: t.varchar(80).name("last_name"),
+      fullName: t.computed<string>("first_name || ' ' || last_name", {
+        stored: true,
+        type: "varchar",
+        length: 511,
+      }),
+    });
+
+    const ddl = new SchemaGenerator({ dialect: "postgres" }).generateCreateTableDDL(
+      Person,
+    );
+    expect(ddl).toContain("GENERATED ALWAYS AS");
+    expect(ddl).toContain("first_name || ' ' || last_name");
+    expect(ddl).toContain("STORED");
   });
 });
 

--- a/docs/define-entity.md
+++ b/docs/define-entity.md
@@ -21,14 +21,72 @@ export type User = InferEntity<typeof User>;
 `User` is a real runtime class — use it everywhere the ORM expects an entity (`em.getRepository(User)`, `em.findOne(User, …)`, relation targets). `InferEntity<typeof User>` recovers the row type, so the same name doubles as a type.
 
 ::: tip Prefer decorators?
-The decorator API (`@Entity`, `@Column`, …) is fully supported and produces identical metadata — see [Entities & Columns (Decorators)](./entities.md). The two styles interoperate freely in the same project. This page is the recommended default for new code.
+The decorator API (`@Entity`, `@Column`, …) is fully supported and produces identical metadata — see [Entities & Columns (Decorators)](./entities.md). The two styles interoperate freely in the same project. This page is the recommended default for new code, and it covers the **same ground** as the decorator guide: every feature you can express with a decorator has a builder here.
 :::
 
 ## Why code-first
 
+Without an ORM, you describe a table three or four times: the `CREATE TABLE`, the `INSERT`, the `SELECT`, and the TypeScript type. Add a column and you edit all of them. Decorator ORMs collapse that to one class, but they lean on the `emitDecoratorMetadata` compiler flag to read your property types — a flag that esbuild, SWC, Vite's default transformer, and the TypeScript 5 *standard* decorators do not emit. When the metadata is missing, a `@Column()` silently loses its type.
+
+`defineEntity` removes that dependency entirely:
+
 - **One source of truth.** The column builder fixes both the database type *and* the TypeScript type. `t.int()` is a `number`; you cannot accidentally annotate it as a `string`. With a hand-written class plus a separate schema, those two can silently drift.
 - **Type inference, no codegen.** `InferEntity` reads the builders directly. There is no generate step and no watch process — the type updates the instant you edit the schema.
 - **No decorator toolchain.** Works under strict mode and ESM with esbuild, swc, Vite, or Bun without `experimentalDecorators` / `emitDecoratorMetadata`. Nothing to misconfigure.
+
+Internally, `defineEntity` converts the builders into the exact same metadata the decorators register, then hands it to the `EntitySchema` bridge. The rest of the ORM — EntityManager, SchemaGenerator, QueryBuilder, WriteBuffer — cannot tell the difference between a builder entity, a decorated entity, and a hand-written `EntitySchema`.
+
+## Creating Your First Entity
+
+Suppose you want to store users. The simplest entity is two columns:
+
+```typescript
+// user.entity.ts
+import { defineEntity, t, InferEntity } from "@stingerloom/orm";
+
+export const User = defineEntity("users", {
+  id:   t.int().primary().generated(),
+  name: t.varchar(255),
+});
+
+export type User = InferEntity<typeof User>; // { id: number; name: string }
+```
+
+The first argument (`"users"`) is the table name. With just this, Stingerloom creates a `users` table with an auto-increment primary key and a `VARCHAR(255)` `name` column. Here is the exact DDL it generates.
+
+**PostgreSQL:**
+
+```sql
+CREATE TABLE "users" (
+  "id" SERIAL PRIMARY KEY,
+  "name" VARCHAR(255) NOT NULL
+);
+```
+
+**MySQL:**
+
+```sql
+CREATE TABLE `users` (
+  `id` INT NOT NULL AUTO_INCREMENT,
+  `name` VARCHAR(255) NOT NULL,
+  PRIMARY KEY (`id`)
+);
+```
+
+PostgreSQL uses double quotes and `SERIAL`; MySQL uses backticks and `AUTO_INCREMENT`. You write the entity once and it works on both — and on SQLite, where the key becomes `INTEGER PRIMARY KEY AUTOINCREMENT`.
+
+Three pieces are doing the work:
+
+- **`defineEntity("users", { … })`** declares the entity and its table name. (Pass a different name through the third options argument with `tableName` if the table should differ from the first argument — see [Advanced options](#advanced-entity-options).)
+- **`t.int().primary().generated()`** is the auto-increment primary key. `.primary()` marks it as the PK; `.generated()` makes the database fill in 1, 2, 3… on INSERT. At the SQL level this is `SERIAL PRIMARY KEY` (PostgreSQL) or `INT AUTO_INCREMENT PRIMARY KEY` (MySQL).
+- **`t.varchar(255)`** is a regular `VARCHAR(255)` column. The builder fixes the TypeScript type to `string`, so you never annotate it yourself.
+
+```sql
+-- You write:
+await em.save(User, { name: "Alice" });
+-- Generated SQL (the DB fills in id = 1 automatically):
+INSERT INTO "users" ("name") VALUES ('Alice');
+```
 
 ## The `t` builder
 
@@ -41,6 +99,7 @@ Every field is a call on the `t` namespace. Column builders carry their inferred
 | `t.int()` / `t.integer()` | `number` | `int` |
 | `t.bigint()` | `number` | `bigint` |
 | `t.float()` / `t.double()` | `number` | `float` / `double` |
+| `t.number()` | `number` | `number` |
 | `t.decimal(precision?, scale?)` | `number` | `number` |
 | `t.varchar(length?)` | `string` | `varchar` |
 | `t.char(length?)` | `string` | `char` |
@@ -53,19 +112,32 @@ Every field is a call on the `t` namespace. Column builders carry their inferred
 | `t.array<T>()` | `T[]` | `array` |
 | `t.enum(["a", "b"])` | `"a" \| "b"` | `enum` |
 
+A realistic mix of types and the type it infers:
+
 ```typescript
-const Event = defineEntity("events", {
-  id:       t.int().primary().generated(),
-  payload:  t.jsonb<{ kind: string; data: unknown }>(),
-  tags:     t.array<string>(),
-  level:    t.enum(["info", "warn", "error"]).default("info"),
+export const Product = defineEntity("products", {
+  id:          t.int().primary().generated(),
+  name:        t.varchar(255),       // VARCHAR(255), required
+  description: t.text(),             // TEXT (megabytes, not 255 chars)
+  price:       t.float(),           // FLOAT / REAL
+  isAvailable: t.boolean(),         // TINYINT(1) / BOOLEAN
+  releaseDate: t.datetime(),        // DATETIME / TIMESTAMP
+  payload:     t.jsonb<{ kind: string; data: unknown }>(),
+  tags:        t.array<string>(),
+  level:       t.enum(["info", "warn", "error"]).default("info"),
 });
-// InferEntity → payload: { kind: string; data: unknown }; tags: string[]; level: "info" | "warn" | "error"
+// InferEntity<typeof Product> →
+//   { id: number; name: string; description: string; price: number;
+//     isAvailable: boolean; releaseDate: Date;
+//     payload: { kind: string; data: unknown }; tags: string[];
+//     level: "info" | "warn" | "error" }
 ```
 
-### Modifiers
+`VARCHAR(255)` caps at 255 characters; `TEXT` stores megabytes. Pick the builder that matches the intent — even though both are `string` in TypeScript, they are very different columns. See the [ColumnType reference](#columntype-reference) for the full per-driver mapping.
 
-Chain modifiers in any order; each returns a new builder.
+## Column modifiers
+
+Chain modifiers in any order; each returns a new builder, and modifiers that change nullability also refine the inferred type.
 
 | Modifier | Effect |
 | --- | --- |
@@ -86,24 +158,543 @@ Chain modifiers in any order; each returns a new builder.
 | `.jsonIndex(opts)` | JSON/JSONB expression index. |
 | `.tenant()` | Tenant discriminator column. |
 
+### Length
+
+`t.varchar(100)` sets the length inline; `.length(100)` does the same after the fact. Both render `VARCHAR(100)`, and the database rejects an over-length insert.
+
 ```typescript
-export const Account = defineEntity("accounts", {
-  id:        t.uuid().primary().generated("uuid-v7"),
-  email:     t.varchar(255).unique().transformer({
-    to:   (v: string) => v.toLowerCase(),
-    from: (v: string) => v,
-  }),
-  balance:   t.decimal(12, 2).default(0),
-  createdAt: t.datetime().createTimestamp(),
-  updatedAt: t.datetime().updateTimestamp(),
-  deletedAt: t.datetime().deletedAt(),
-  version:   t.int().version(),
+sku: t.varchar(100),           // VARCHAR(100)
+sku2: t.varchar().length(100), // identical
+```
+
+### Nullable
+
+Every column is `NOT NULL` by default. `.nullable()` drops the constraint **and** widens the inferred type to `T | null`, so the type and the schema stay in lockstep:
+
+```typescript
+bio: t.varchar(255).nullable(), // VARCHAR(255), no NOT NULL → bio: string | null
+```
+
+### Column name alias
+
+Use `.name()` when the property name and the DB column should differ — the common case is camelCase in TypeScript, snake_case in the database:
+
+```typescript
+price: t.float().name("unit_price"),
+// entity property: product.price / DB column: unit_price
+```
+
+The DDL names the column `unit_price`; on SELECT, Stingerloom maps `unit_price` back to `price`. (Prefer a project-wide convention? Register a [`SnakeNamingStrategy`](./configuration.md) and drop the per-column `.name()` calls.)
+
+### Default value
+
+`.default(value)` sets the column default. Literal strings, numbers, and booleans are used as-is; to emit a raw SQL expression (a function call), wrap it in parentheses.
+
+```typescript
+status:     t.varchar(255).default("active"),
+retryCount: t.int().default(0),
+isVisible:  t.boolean().default(true),
+createdAt:  t.datetime().default("(CURRENT_TIMESTAMP)"),
+```
+
+**PostgreSQL:**
+
+```sql
+"status" VARCHAR(255) NOT NULL DEFAULT 'active',
+"retryCount" INTEGER NOT NULL DEFAULT 0,
+"isVisible" BOOLEAN NOT NULL DEFAULT TRUE,
+"createdAt" TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+```
+
+Without the parentheses, `"CURRENT_TIMESTAMP"` would be emitted as the literal string `'CURRENT_TIMESTAMP'`, not the SQL function.
+
+### JSON columns
+
+`t.json<T>()` and `t.jsonb<T>()` store structured data in one column, and the type parameter flows straight through to the inferred row type:
+
+```typescript
+settings: t.json<{ theme: string }>().nullable(),
+// settings: { theme: string } | null
+```
+
+In PostgreSQL, `jsonb` is stored in a decomposed binary format — slower to write, far faster to query, and the only form you can index for `WHERE settings->>'theme' = 'dark'`. Prefer `jsonb` whenever you query inside the document.
+
+Stingerloom installs a default round-trip on `json`/`jsonb` columns: on write, a non-string value is `JSON.stringify`d before it reaches the driver; on read, a string returned by the driver is `JSON.parse`d. So you assign plain JS values directly:
+
+```typescript
+await em.save(Issue, { customFields: { priority: "high", labels: ["bug"] } });
+const issue = await em.findOne(Issue, { where: { id } });
+issue!.customFields.priority; // "high" — already an object, dialect-agnostic
+```
+
+Supplying an explicit [`.transformer()`](#transformers) overrides the default for that direction.
+
+### PostgreSQL ENUM
+
+`t.enum([...])` both fixes the literal union type **and** carries the allowed values to the database. Name the generated PostgreSQL type with `.enumName()`:
+
+```typescript
+status: t.enum(["draft", "published", "archived"]).enumName("post_status"),
+// status: "draft" | "published" | "archived"
+```
+
+PostgreSQL DDL:
+
+```sql
+CREATE TYPE "post_status" AS ENUM ('draft', 'published', 'archived');
+-- ...
+"status" "post_status" NOT NULL
+```
+
+If `.enumName()` is omitted, the name defaults to `{tableName}_{columnName}_enum`. On MySQL the column becomes a native `ENUM(...)`; on SQLite it is stored as `TEXT`.
+
+## Primary keys
+
+### Generated keys
+
+`.primary().generated(strategy)` produces a database-generated key. The strategy controls how:
+
+```typescript
+id: t.int().primary().generated(),              // auto-increment (default "increment")
+id: t.uuid().primary().generated("uuid"),       // random UUIDv4
+id: t.uuid().primary().generated("uuid-v7"),    // time-sortable UUIDv7
+```
+
+`"increment"` maps to `SERIAL` (PostgreSQL) / `AUTO_INCREMENT` (MySQL). `"uuid"` and `"uuid-v7"` generate the value in application code before INSERT — `"uuid-v7"` is time-ordered, so it indexes far better than random UUIDs for primary keys.
+
+### Manual primary key
+
+Drop `.generated()` and you have a key you supply yourself — the builder equivalent of `@PrimaryColumn()`. Useful for natural keys like a config table:
+
+```typescript
+export const Config = defineEntity("config", {
+  key:   t.varchar(64).primary(),
+  value: t.text(),
+});
+
+await em.save(Config, { key: "site.title", value: "My Blog" });
+// INSERT INTO "config" ("key", "value") VALUES ('site.title', 'My Blog')
+```
+
+### Composite primary key
+
+Mark more than one column `.primary()` for a composite key:
+
+```typescript
+export const Enrollment = defineEntity("enrollments", {
+  studentId: t.int().primary().name("student_id"),
+  courseId:  t.int().primary().name("course_id"),
+  grade:     t.varchar(2).nullable(),
 });
 ```
 
+```sql
+CREATE TABLE "enrollments" (
+  "student_id" INTEGER NOT NULL,
+  "course_id" INTEGER NOT NULL,
+  "grade" VARCHAR(2),
+  PRIMARY KEY ("student_id", "course_id")
+);
+```
+
+## Transformers
+
+A transformer translates a value in **both** directions: `to` runs before every INSERT/UPDATE, `from` runs after every SELECT. The classic use is normalizing email to lowercase so `Alice@Example.com` and `alice@example.com` never both exist:
+
+```typescript
+export const Account = defineEntity("accounts", {
+  id:    t.int().primary().generated(),
+  email: t.varchar(255).unique().transformer({
+    to:   (value: string) => value.toLowerCase(), // entity → DB (write)
+    from: (value: string) => value,               // DB → entity (read)
+  }),
+});
+
+await em.save(Account, { email: "Alice@Example.COM" });
+// INSERT INTO "accounts" ("email") VALUES ('alice@example.com')
+```
+
+Encryption is the same shape — encrypt in `to`, decrypt in `from` — so the database only ever stores ciphertext while your code works with plaintext:
+
+```typescript
+ssn: t.text().transformer({
+  to:   (value: string) => encrypt(value),
+  from: (value: string) => decrypt(value),
+}),
+```
+
+## Indexes
+
+### Single-column index
+
+`.index()` adds a non-unique index, and `.unique()` a unique one. Both turn a full table scan into an O(log n) B-tree lookup for `WHERE`/`JOIN`/`ORDER BY` on that column:
+
+```typescript
+export const User = defineEntity("users", {
+  id:    t.int().primary().generated(),
+  email: t.varchar(255).index(),   // CREATE INDEX ... ON "users" ("email")
+  slug:  t.varchar(255).unique(),  // single-column UNIQUE index
+});
+```
+
+```sql
+CREATE INDEX "INDEX_users_email" ON "users" ("email");
+```
+
+A `.unique()` constraint is lifted into the entity's unique-index list, so it composes with any composite unique indexes you declare in the options object.
+
+### Composite and unique indexes
+
+Multi-column indexes live in the third options argument. `indexes` are non-unique, `uniqueIndexes` enforce uniqueness across the combination:
+
+```typescript
+export const Order = defineEntity(
+  "orders",
+  {
+    id:       t.int().primary().generated(),
+    tenantId: t.int().name("tenant_id"),
+    status:   t.varchar(50),
+    slug:     t.varchar(120),
+  },
+  {
+    indexes:       [{ columns: ["tenant_id", "status"] }],
+    uniqueIndexes: [{ columns: ["tenant_id", "slug"], name: "uq_order_slug" }],
+  },
+);
+```
+
+```sql
+CREATE INDEX "idx_orders_tenant_id_status" ON "orders" ("tenant_id", "status");
+CREATE UNIQUE INDEX "uq_order_slug" ON "orders" ("tenant_id", "slug");
+```
+
+A composite index works left-to-right, like a phone book sorted by last name then first name: it serves `WHERE tenant_id = 5` and `WHERE tenant_id = 5 AND status = 'pending'`, but not `WHERE status = 'pending'` alone.
+
+### Advanced index options
+
+Each `indexes` entry takes an `options` object carrying the same `AdvancedIndexOptions` the decorator's `@Index([cols], options)` accepts — partial, expression, `USING`, and covering (`INCLUDE`) indexes:
+
+```typescript
+export const User = defineEntity(
+  "users",
+  {
+    id:        t.int().primary().generated(),
+    email:     t.varchar(255),
+    name:      t.varchar(255),
+    metadata:  t.jsonb(),
+    deletedAt: t.datetime().deletedAt(),
+  },
+  {
+    indexes: [
+      // Partial covering index (PostgreSQL / SQLite for WHERE; PG for INCLUDE)
+      {
+        columns: ["email"],
+        options: {
+          name: "idx_active_user_email",
+          where: "deleted_at IS NULL", // partial — skips soft-deleted rows
+          include: ["name"],           // covering — index-only scans
+        },
+      },
+      // Expression index — column list empty, expression replaces it
+      { columns: [], options: { name: "idx_lower_email", expression: "LOWER(email)" } },
+      // GIN index for JSONB containment queries
+      { columns: ["metadata"], options: { using: "gin" } },
+    ],
+  },
+);
+```
+
+```sql
+CREATE INDEX "idx_active_user_email" ON "users" ("email") INCLUDE ("name") WHERE deleted_at IS NULL;
+CREATE INDEX "idx_lower_email" ON "users" ((LOWER(email)));
+CREATE INDEX "idx_users_metadata" ON "users" USING gin ("metadata");
+```
+
+| `using` value | Best for | PostgreSQL | MySQL |
+| --- | --- | --- | --- |
+| `btree` | Equality, range, sorting (default) | Yes | Yes |
+| `hash` | Equality only | Yes | Yes |
+| `gin` | JSONB, arrays, full-text | Yes | No |
+| `gist` | Geometric, range types | Yes | No |
+| `brin` | Large time-series tables | Yes | No |
+
+Partial (`where`), covering (`include`), and non-btree `using` are PostgreSQL features (partial indexes also work on SQLite); MySQL ignores or rejects them. See the decorator guide's [Advanced Index Options](./entities.md#advanced-index-options) for the full conceptual treatment — the option object is identical.
+
+### Full-text indexes
+
+Full-text indexes go in `fullTextIndexes`:
+
+```typescript
+export const Post = defineEntity(
+  "posts",
+  {
+    id:      t.int().primary().generated(),
+    title:   t.varchar(200),
+    content: t.text(),
+  },
+  {
+    fullTextIndexes: [
+      { columns: ["title", "content"], name: "ft_post", language: "english" },
+    ],
+  },
+);
+```
+
+PostgreSQL emits a GIN `to_tsvector` index, MySQL a `FULLTEXT` index; SQLite is a no-op.
+
+### JSON path indexes
+
+`.jsonIndex()` declares an expression index over a path inside a `jsonb` column — the builder form of `@JsonIndex`:
+
+```typescript
+profile: t.jsonb<{ tags: string[] }>().jsonIndex({
+  path: "tags",
+  using: "gin",
+  opclass: "jsonb_path_ops",
+}),
+```
+
+PostgreSQL DDL:
+
+```sql
+CREATE INDEX "idx_users_profile_tags_gin"
+  ON "users" USING gin ((profile -> 'tags') jsonb_path_ops);
+```
+
+`path` is dot-bracket (`"contact.email"`, `"tags[0]"`); omit it to index the whole column. `using: "btree"` suits a single scalar leaf for equality/range. MySQL and SQLite emit no DDL (a warning is logged). See [JSON Path Indexes](./entities.md#json-path-indexes-jsonindex) for the full option reference, and [Query Builder — JSON](./query-builder-json.md) for operators that line up with these indexes.
+
+## Optimistic locking
+
+`.version()` adds a version counter that detects the *lost update* problem — two writers reading the same row and clobbering each other. On INSERT the version is set to 1; on UPDATE, Stingerloom adds `WHERE version = N` and increments it. If the row was changed in between, the UPDATE matches 0 rows and an `OptimisticLockError` is thrown instead of silently losing data.
+
+```typescript
+export const Order = defineEntity("orders", {
+  id:      t.int().primary().generated(),
+  status:  t.varchar(255),
+  version: t.int().version(),
+});
+```
+
+```sql
+-- Writer A (read version 1) succeeds, version becomes 2:
+UPDATE "orders" SET "status" = 'shipped', "version" = "version" + 1
+WHERE "id" = 1 AND "version" = 1;          -- 1 row affected
+
+-- Writer B (also read version 1) now fails:
+UPDATE "orders" SET "status" = 'refunded', "version" = "version" + 1
+WHERE "id" = 1 AND "version" = 1;          -- 0 rows → OptimisticLockError
+```
+
+Use it where conflicts are rare but correctness matters (order status, inventory). For high-contention rows, prefer pessimistic locking (`SELECT … FOR UPDATE`).
+
+## Soft delete
+
+`.deletedAt()` turns deletes into a timestamp stamp rather than a row removal. It implies `.nullable()` (a `NULL` marker means "not deleted"), so the inferred type is `Date | null`:
+
+```typescript
+export const Post = defineEntity("posts", {
+  id:        t.int().primary().generated(),
+  title:     t.varchar(255),
+  deletedAt: t.datetime().deletedAt(), // deletedAt: Date | null
+});
+```
+
+The marker changes three behaviors:
+
+```typescript
+await em.softDelete(Post, { id: 1 });
+// UPDATE "posts" SET "deletedAt" = NOW() WHERE "id" = 1;   (not DELETE)
+
+await em.find(Post);
+// SELECT * FROM "posts" WHERE "deletedAt" IS NULL;          (auto-excludes)
+
+await em.find(Post, { withDeleted: true });
+// SELECT * FROM "posts";                                    (includes deleted)
+
+await em.restore(Post, { id: 1 });
+// UPDATE "posts" SET "deletedAt" = NULL WHERE "id" = 1;     (un-delete)
+```
+
+## Automatic timestamps
+
+`.createTimestamp()` and `.updateTimestamp()` fill in audit timestamps for you. On INSERT both are set; on UPDATE only the update timestamp is refreshed:
+
+```typescript
+export const Article = defineEntity("articles", {
+  id:        t.int().primary().generated(),
+  title:     t.varchar(255),
+  createdAt: t.datetime().createTimestamp(),
+  updatedAt: t.datetime().updateTimestamp(),
+});
+```
+
+```sql
+-- INSERT — both set to the same instant (generated as new Date() in app code):
+INSERT INTO "articles" ("title", "createdAt", "updatedAt")
+VALUES ('Hello', '2026-06-30 10:30:00', '2026-06-30 10:30:00');
+
+-- UPDATE — only updatedAt is in the SET clause:
+UPDATE "articles" SET "title" = 'Hello v2', "updatedAt" = '2026-06-30 11:45:00'
+WHERE "id" = 1;
+```
+
+If you pass an explicit value for a timestamp column in `save()`, that value is used instead of the auto-generated one — handy for data migration. For timezone-aware columns in PostgreSQL, use `t.timestamptz()`.
+
+## Computed columns
+
+`t.computed()` declares a database-level generated column — the builder form of `@ComputedColumn`. The value is computed by the database from other columns and is **excluded from every INSERT and UPDATE** (writing to it would error). It renders as `GENERATED ALWAYS AS (expression)`:
+
+```typescript
+export const OrderLine = defineEntity("order_lines", {
+  id:       t.int().primary().generated(),
+  price:    t.float(),
+  quantity: t.int(),
+  total:    t.computed<number>("price * quantity", { stored: true, type: "float" }),
+});
+```
+
+PostgreSQL DDL:
+
+```sql
+CREATE TABLE "order_lines" (
+  "id" SERIAL PRIMARY KEY,
+  "price" REAL NOT NULL,
+  "quantity" INTEGER NOT NULL,
+  "total" REAL GENERATED ALWAYS AS (price * quantity) STORED
+);
+```
+
+```typescript
+await em.save(OrderLine, { price: 29.99, quantity: 3 });
+// INSERT INTO "order_lines" ("price", "quantity") VALUES (29.99, 3)
+// "total" is omitted — the DB computes it as 89.97
+```
+
+The options mirror `@ComputedColumn`: `stored`, `type`, `length`, and `nullable`.
+
+| `stored` | Mode | Behavior | Disk | Indexable |
+| --- | --- | --- | --- | --- |
+| `true` | STORED | Computed on write, persisted | Uses space | Yes |
+| `false` (default) | VIRTUAL | Computed on every read | None | Limited |
+
+### Dialect-portable expressions
+
+A literal string expression is embedded into the DDL verbatim, so it must already be valid for the target database. That is fine for portable arithmetic like `price * quantity`, but date math diverges sharply between engines. Pass a **builder function** instead and Stingerloom compiles it to dialect-correct SQL once per connection:
+
+```typescript
+export const Issue = defineEntity("issues", {
+  id:          t.int().primary().generated(),
+  createdAt:   t.datetime().nullable().name("created_at"),
+  completedAt: t.datetime().nullable().name("completed_at"),
+  cycleTimeHours: t.computed<number>(
+    (e) => e.dateDiff(e.col("completed_at"), e.col("created_at"), "hour"),
+    { type: "int", nullable: true },
+  ),
+});
+```
+
+```sql
+-- MySQL
+`cycleTimeHours` INT GENERATED ALWAYS AS (TIMESTAMPDIFF(HOUR, `created_at`, `completed_at`)) VIRTUAL
+-- PostgreSQL
+"cycleTimeHours" INTEGER GENERATED ALWAYS AS (EXTRACT(EPOCH FROM ("completed_at" - "created_at")) / 3600) VIRTUAL
+```
+
+The context `e` exposes the full Expressions DSL (`e.iff`, `e.caseBuilder`, `e.coalesce`, `e.dateDiff`, `e.col(name)`). See the decorator guide's [dialect-portable expressions](./entities.md#dialect-portable-expressions-builder-form) for the full DSL.
+
+::: tip How computed columns reach the database
+`GENERATED ALWAYS AS` DDL is emitted by the schema **generator** — the same path the migration CLI uses (`stingerloom migrate:generate`). The runtime `synchronize` create-table path renders stored columns only. This matches the decorator `@ComputedColumn` exactly: generate a migration to add (or change) a computed column. Stingerloom always excludes the column from writes regardless of how the table was created.
+:::
+
+## Validation
+
+`.validate([...])` attaches application-level constraints checked **before** the SQL is built — the builder form of `@NotNull`, `@MinLength`, `@Min`, and friends. A failure throws `ValidationError` and no query is sent:
+
+```typescript
+export const Member = defineEntity("members", {
+  id:   t.int().primary().generated(),
+  name: t.varchar(50).validate([
+    { constraint: "notNull" },
+    { constraint: "minLength", value: 2 },
+    { constraint: "maxLength", value: 50 },
+  ]),
+  age:  t.int().validate([
+    { constraint: "min", value: 0 },
+    { constraint: "max", value: 150 },
+  ]),
+});
+
+await em.save(Member, { name: "A", age: -1 });
+// ValidationError: name must be at least 2 characters long  (no INSERT attempted)
+```
+
+Each entry is `{ constraint, value?, message? }`. Available constraints are `notNull`, `minLength`, `maxLength`, `min`, and `max` (pass a custom `message` to override the default). Unlike a database `NOT NULL` violation (which surfaces after a round trip with a cryptic message), validation is caught in your process with a clear message.
+
+## Lifecycle hooks
+
+Hooks run custom logic at a moment in an entity's lifecycle — generate a slug before insert, send a notification after, clean up before delete. Declare them in the third options argument; each event maps to a function (or the name of a method already on the class):
+
+```typescript
+export const Article = defineEntity(
+  "articles",
+  {
+    id:    t.int().primary().generated(),
+    title: t.varchar(200),
+    slug:  t.varchar(200).nullable(),
+  },
+  {
+    hooks: {
+      beforeInsert(article) {
+        article.slug ??= article.title.toLowerCase().replace(/\s+/g, "-");
+      },
+      afterInsert(article) {
+        console.log(`Article #${article.id} created`);
+      },
+    },
+  },
+);
+```
+
+The hook receives the entity both as `this` and as its first argument, so `beforeInsert(a) { a.slug = … }` and `beforeInsert() { this.slug = … }` are equivalent.
+
+::: warning Hooks fire on instances — use `new Entity(...)`
+A hook is a method on the entity prototype, so it only runs when the object you save **carries that prototype**. The minted class constructor accepts a partial initializer for exactly this reason: `new Article({ … })` gives you a typed, hook-capable instance.
+
+```typescript
+// ✓ Hook runs — the saved object is an Article instance.
+const saved = await em.save(Article, new Article({ title: "Hello World" }));
+saved.slug; // "hello-world"
+
+// ✗ Hook does NOT run — a plain object literal has no prototype method.
+await em.save(Article, { title: "Hello World" });
+```
+
+This is the same requirement decorator entities have (`@BeforeInsert` also needs an instance); `new Article({...})` is the decorator-free, type-checked equivalent of `Object.assign(new Article(), {...})`.
+:::
+
+There are six events, and they fire around the corresponding SQL:
+
+| Event | Timing | Typical use |
+| --- | --- | --- |
+| `beforeInsert` | Just before INSERT | Defaults, slug generation, normalization |
+| `afterInsert` | After INSERT (entity now has its ID) | Logging, notifications, cache invalidation |
+| `beforeUpdate` | Just before UPDATE | Recomputing fields, validation |
+| `afterUpdate` | After UPDATE | Change history, webhooks |
+| `beforeDelete` | Just before DELETE | Cleanup, permission checks |
+| `afterDelete` | After DELETE | Releasing related resources, logging |
+
+For a new entity, the order is: `beforeInsert` hooks → `INSERT` → `afterInsert` hooks. Mutations in `before*` hooks are reflected in the SQL; `after*` hooks run once the row is written, so use them for side effects.
+
 ## Relations
 
-Relation builders take a lazy `() => TargetEntity` (lazy to allow circular references). `manyToOne` / `oneToOne` infer the related row type; `oneToMany` / `manyToMany` infer an array. Relation fields are **optional** in the inferred type — they are populated only when you request them with `relations: [...]`.
+Relation builders take a lazy `() => TargetEntity` (lazy so two entities can reference each other). `manyToOne` / `oneToOne` infer the related row type; `oneToMany` / `manyToMany` infer an array. Relation fields are **optional** in the inferred type — they are populated only when you request them with `relations: [...]`.
+
+| Builder | Signature | Inferred field |
+| --- | --- | --- |
+| `t.manyToOne` | `(() => Target, options?)` | `Target?` |
+| `t.oneToMany` | `(() => Target, mappedBy, options?)` | `Target[]?` |
+| `t.oneToOne` | `(() => Target, options?)` | `Target?` |
+| `t.manyToMany` | `(() => Target, options?)` | `Target[]?` |
 
 ```typescript
 export const Author = defineEntity("authors", {
@@ -122,37 +713,78 @@ export const Post = defineEntity("posts", {
   }),
 });
 
+export const Tag = defineEntity("tags", {
+  id:   t.int().primary().generated(),
+  name: t.varchar(60).unique(),
+});
+
 export type Author = InferEntity<typeof Author>; // posts?: Post[]
 export type Post = InferEntity<typeof Post>;     // author?: Author; tags?: Tag[]
 ```
 
 ::: warning Declare the foreign-key column
-A `manyToOne` / owning `oneToOne` needs its foreign-key column declared as a real column (e.g. `authorId: t.int().name("author_id")`) so it is created during schema sync — exactly as the decorator API pairs `@ManyToOne` with a `@Column`/`@RelationColumn` for the FK. The relation's `joinColumn` then points at that column. (Alternatively pass `relationColumn: { … }` in the relation options.)
+A `manyToOne` / owning `oneToOne` needs its foreign-key column declared as a real column (`authorId: t.int().name("author_id")`) so it is created during schema sync — exactly as the decorator API pairs `@ManyToOne` with a `@Column`/`@RelationColumn` for the FK. The relation's `joinColumn` then points at that column. Alternatively, pass `relationColumn: { … }` in the relation options to declare the FK metadata inline.
 :::
 
-| Builder | Signature | Inferred field |
-| --- | --- | --- |
-| `t.manyToOne` | `(() => Target, options?)` | `Target?` |
-| `t.oneToMany` | `(() => Target, mappedBy, options?)` | `Target[]?` |
-| `t.oneToOne` | `(() => Target, options?)` | `Target?` |
-| `t.manyToMany` | `(() => Target, options?)` | `Target[]?` |
+### Relation options
 
-## Computed columns
-
-`t.computed` declares a database-generated column (excluded from `INSERT`/`UPDATE`):
+`manyToOne` and `oneToOne` accept the loading and referential-action options the decorators do:
 
 ```typescript
-export const Person = defineEntity("people", {
-  id:        t.int().primary().generated(),
-  firstName: t.varchar(80).name("first_name"),
-  lastName:  t.varchar(80).name("last_name"),
-  fullName:  t.computed("first_name || ' ' || last_name", { stored: false, type: "varchar" }),
+author: t.manyToOne(() => Author, {
+  joinColumn: "author_id",
+  eager: true,                 // always LEFT JOIN and hydrate
+  cascade: ["insert", "update"],
+  onDelete: "CASCADE",         // FK ON DELETE action
+  onUpdate: "RESTRICT",
+  relationColumn: {            // explicit FK column metadata (a la @RelationColumn)
+    name: "author_id",
+    type: "bigint",
+    nullable: false,
+    referencedColumn: "id",
+  },
+}),
+```
+
+`oneToMany` takes the inverse-side property name as its required second argument (`"author"` above — the `manyToOne` field on `Post`) plus an optional `{ cascade }`. `manyToMany` takes `{ joinTable, mappedBy, cascade }`; declare the join table on the owning side, and the join-table DDL is generated for you. See [Relations](./relations.md) for the conceptual guide to loading strategies and cascades.
+
+## Inheritance
+
+Inheritance models an *is-a* relationship (a `CreditCardPayment` **is a** `Payment`), so it needs a real TypeScript class hierarchy — `class Child extends Parent`. Because `defineEntity` mints one standalone class per call, hierarchies are the one place to reach for the lower-level [`EntitySchema`](./decorator-free.md#entityschema-entity-definition) form, which attaches schema to classes you write with `extends`:
+
+```typescript
+import { EntitySchema } from "@stingerloom/orm";
+
+class Payment {
+  id!: number;
+  amount!: number;
+}
+class CreditCardPayment extends Payment {
+  cardNumber!: string;
+}
+
+new EntitySchema<Payment>({
+  target: Payment,
+  inheritance: { strategy: "SINGLE_TABLE" },
+  discriminatorColumn: { name: "payment_type" },
+  columns: {
+    id:     { type: "int", primary: true, autoIncrement: true },
+    amount: { type: "int" },
+  },
+});
+
+new EntitySchema<CreditCardPayment>({
+  target: CreditCardPayment,
+  discriminatorValue: "credit_card",
+  columns: { cardNumber: { type: "varchar", nullable: true } },
 });
 ```
 
+All three strategies (single-table, table-per-type, table-per-concrete-class) are supported decorator-free this way. See [Inheritance Mapping](./inheritance-mapping.md) for the full strategy reference. Builder entities and these `EntitySchema` hierarchies coexist and can relate to one another.
+
 ## Registering and using the entity
 
-Pass the entity class to your `EntityManager` exactly like a decorated class:
+Pass the builder entity to your `EntityManager` exactly like a decorated class:
 
 ```typescript
 import "reflect-metadata";
@@ -174,16 +806,16 @@ const withAuthor = await em.findOne(Post, {
   where: { id: post.id },
   relations: ["author"],
 });
-// withAuthor.author?.name === "Ada"  — fully typed
+withAuthor!.author?.name; // "Ada" — fully typed
 ```
 
 ::: tip `reflect-metadata`
-The ORM core still uses `reflect-metadata` at runtime, so keep `import "reflect-metadata"` at your entry point. What you *don't* need for code-first entities are the `experimentalDecorators` and `emitDecoratorMetadata` compiler options.
+The ORM core uses `reflect-metadata` at runtime, so keep `import "reflect-metadata"` at your entry point. What you *don't* need for code-first entities are the `experimentalDecorators` and `emitDecoratorMetadata` compiler options.
 :::
 
-## Advanced options
+## Advanced entity options
 
-`defineEntity` takes an optional third argument for the less-common, entity-level settings:
+The optional third argument carries the less-common, entity-level settings. Everything in it is also reachable individually, but grouping rarely-used options keeps the column map clean:
 
 ```typescript
 export const Member = defineEntity(
@@ -195,18 +827,117 @@ export const Member = defineEntity(
   },
   {
     tableName: "org_members",          // override the table name
-    uniqueIndexes: [{ columns: ["org_id", "email"], name: "uq_member_email" }],
     indexes: [{ columns: ["org_id"] }],
+    uniqueIndexes: [{ columns: ["org_id", "email"], name: "uq_member_email" }],
+    fullTextIndexes: [{ columns: ["email"] }],
+    hooks: { beforeInsert(m) { m.email = m.email.toLowerCase(); } },
     nonTenant: true,                   // opt out of the tenant_column strategy
   },
 );
 ```
 
-For the full decorator → builder mapping (including full-text indexes, tenant columns, and lifecycle hooks), see the [Decorator-Free Reference](./decorator-free.md).
+| Option | Purpose | Decorator equivalent |
+| --- | --- | --- |
+| `tableName` | Table name (overrides the first argument) | `@Entity({ name })` |
+| `indexes` | Composite / advanced indexes | `@Index([cols], options)` |
+| `uniqueIndexes` | Composite unique indexes | `@UniqueIndex([cols])` |
+| `fullTextIndexes` | Full-text indexes | `@FullTextIndex([cols])` |
+| `hooks` | Lifecycle hooks | `@BeforeInsert` … `@AfterDelete` |
+| `nonTenant` | Exclude from the tenant_column strategy | `@NonTenantEntity()` |
+
+### Tenant column
+
+When the global `tenantStrategy` is `"tenant_column"`, mark the discriminator column with `.tenant()` so it is readable on instances and used to scope queries, and opt inherently global tables out with `nonTenant: true`:
+
+```typescript
+// Per-tenant entity — tenant column readable as log.tenantId
+export const AuditLog = defineEntity("audit_logs", {
+  id:       t.int().primary().generated(),
+  action:   t.varchar(255),
+  tenantId: t.varchar(64).name("tenant_id").tenant(),
+});
+
+// Inherently global entity — no tenant scoping
+export const Tenant = defineEntity(
+  "tenants",
+  { id: t.varchar(64).primary(), name: t.varchar(255) },
+  { nonTenant: true },
+);
+```
+
+See [Multi-Tenancy](./multi-tenancy.md) for the full strategy reference.
+
+## Complete real-world example
+
+A blog user entity combining most of the features above:
+
+```typescript
+import { defineEntity, t, InferEntity } from "@stingerloom/orm";
+
+export const User = defineEntity(
+  "users",
+  {
+    id:        t.int().primary().generated(),
+    name:      t.varchar(50).validate([
+      { constraint: "notNull" },
+      { constraint: "minLength", value: 2 },
+      { constraint: "maxLength", value: 50 },
+    ]),
+    email:     t.varchar(255).index(),
+    phone:     t.varchar(20).nullable(),
+    isActive:  t.boolean().default(true),
+    profile:   t.json<{ bio?: string }>().nullable(),
+    version:   t.int().version(),
+    deletedAt: t.datetime().deletedAt(),
+    createdAt: t.datetime().createTimestamp(),
+    updatedAt: t.datetime().updateTimestamp(),
+  },
+  {
+    hooks: {
+      afterInsert(user) {
+        console.log(`User #${user.id} created`);
+      },
+    },
+  },
+);
+
+export type User = InferEntity<typeof User>;
+```
+
+**PostgreSQL DDL:**
+
+```sql
+CREATE TABLE "users" (
+  "id" SERIAL PRIMARY KEY,
+  "name" VARCHAR(50) NOT NULL,
+  "email" VARCHAR(255) NOT NULL,
+  "phone" VARCHAR(20),
+  "isActive" BOOLEAN NOT NULL DEFAULT TRUE,
+  "profile" JSON,
+  "version" INTEGER NOT NULL,
+  "deletedAt" TIMESTAMP,
+  "createdAt" TIMESTAMP NOT NULL,
+  "updatedAt" TIMESTAMP NOT NULL
+);
+CREATE INDEX "INDEX_users_email" ON "users" ("email");
+```
+
+```typescript
+// INSERT — version auto-set to 1, timestamps auto-set, afterInsert logs:
+const u = await em.save(User, new User({ name: "Alice", email: "alice@example.com" }));
+
+// UPDATE — version increments, only updatedAt refreshes:
+await em.save(User, { id: u.id, name: "Alice Smith", version: u.version });
+
+// Soft delete + queries that auto-exclude deleted rows:
+await em.softDelete(User, { id: u.id });
+await em.find(User);                       // WHERE "deletedAt" IS NULL
+await em.find(User, { withDeleted: true }); // no filter
+```
 
 ## Mixing with decorators
 
-Code-first and decorator entities share the same metadata pipeline, so they coexist and can even relate to each other:
+Code-first and decorator entities share the same metadata pipeline, so they coexist and can relate to each other:
 
 ```typescript
 @Entity()
@@ -224,3 +955,61 @@ export const Comment = defineEntity("comments", {
 ```
 
 Adopt the builder API incrementally — new entities code-first, existing decorated entities untouched.
+
+## ColumnType reference
+
+### Builder → TypeScript type
+
+| Builder | Inferred TS type |
+| --- | --- |
+| `t.int()`, `t.integer()`, `t.bigint()`, `t.float()`, `t.double()`, `t.number()`, `t.decimal()` | `number` |
+| `t.varchar()`, `t.char()`, `t.text()`, `t.longtext()`, `t.uuid()` | `string` |
+| `t.boolean()` | `boolean` |
+| `t.datetime()`, `t.timestamp()`, `t.timestamptz()`, `t.date()` | `Date` |
+| `t.blob()` | `Buffer` |
+| `t.json<T>()`, `t.jsonb<T>()` | `T` (default `unknown`) |
+| `t.array<T>()` | `T[]` |
+| `t.enum([...])` | the literal union |
+| `.nullable()` on any column | widens to `T \| null` |
+
+### Abstract type → database type
+
+Each abstract `ColumnType` is translated to a concrete database type by the driver:
+
+| ColumnType | MySQL/MariaDB | PostgreSQL | SQLite |
+| --- | --- | --- | --- |
+| `varchar` | VARCHAR(n) | VARCHAR(n) | TEXT |
+| `int` / `number` | INT | INTEGER | INTEGER |
+| `float` | FLOAT | REAL | REAL |
+| `double` | DOUBLE | DOUBLE PRECISION | REAL |
+| `bigint` | BIGINT | BIGINT | INTEGER |
+| `boolean` | TINYINT(1) | BOOLEAN | INTEGER |
+| `datetime` | DATETIME | TIMESTAMP | TEXT |
+| `timestamp` | TIMESTAMP | TIMESTAMP | TEXT |
+| `timestamptz` | DATETIME | TIMESTAMPTZ | TEXT |
+| `date` | DATE | DATE | TEXT |
+| `text` | TEXT | TEXT | TEXT |
+| `longtext` | LONGTEXT | TEXT | TEXT |
+| `blob` | BLOB | BYTEA | BLOB |
+| `json` | JSON | JSON | TEXT |
+| `jsonb` | JSON | JSONB | TEXT |
+| `uuid` | CHAR(36) *(UUID on MariaDB 10.7+)* | UUID | VARCHAR(36) |
+| `enum` | ENUM | (custom ENUM) | TEXT |
+
+## Troubleshooting
+
+**My relation field is always `undefined`.** Relations are optional and lazy — request them with `relations: ["author"]` on the query. Without it, the field is not loaded.
+
+**The FK column is missing from the table.** A `manyToOne`/owning `oneToOne` does not create its own FK column; declare it as a real column (`authorId: t.int().name("author_id")`) and point `joinColumn` at it, or pass `relationColumn` in the relation options.
+
+**My lifecycle hook never runs.** Hooks fire on instances. Save `new MyEntity({ … })`, not a plain object literal — see [Lifecycle hooks](#lifecycle-hooks).
+
+**A computed column isn't in the created table.** `GENERATED ALWAYS AS` DDL comes from the schema generator (the migration CLI), not the runtime `synchronize` path — generate a migration. This matches the decorator `@ComputedColumn`.
+
+**Am I really decorator-free?** Define every entity with `defineEntity` (or `EntitySchema`) and run a dry sync — it logs the DDL it *would* run without touching the database, confirming every column, index, and relation resolved without any compiler-emitted metadata:
+
+```typescript
+await em.register({ entities: [User, Post, /* … */], synchronize: "dry-run" });
+```
+
+For the complete decorator → builder/`EntitySchema` mapping — including transactions and NestJS injection without decorators — see the [Decorator-Free Reference](./decorator-free.md).

--- a/docs/ko/define-entity.md
+++ b/docs/ko/define-entity.md
@@ -21,89 +21,680 @@ export type User = InferEntity<typeof User>;
 `User`는 실제 런타임 클래스예요 — ORM이 엔티티를 기대하는 모든 곳(`em.getRepository(User)`, `em.findOne(User, …)`, 관계 타깃)에서 그대로 쓰면 돼요. `InferEntity<typeof User>`는 행(row) 타입을 복원하므로, 같은 이름이 타입 역할도 겸해요.
 
 ::: tip 데코레이터가 더 좋다면?
-데코레이터 API(`@Entity`, `@Column`, …)도 완전히 지원되고 동일한 메타데이터를 생성해요 — [엔티티 & 컬럼 (데코레이터)](./entities.md)를 참고하세요. 두 스타일은 같은 프로젝트에서 자유롭게 함께 쓸 수 있어요. 이 페이지는 새 코드에 권장하는 기본 방식이에요.
+데코레이터 API(`@Entity`, `@Column`, …)도 완전히 지원되고 동일한 메타데이터를 생성해요 — [엔티티 & 컬럼 (데코레이터)](./entities.md)를 참고하세요. 두 스타일은 같은 프로젝트에서 자유롭게 함께 쓸 수 있어요. 이 페이지는 새 코드에 권장하는 기본 방식이고, 데코레이터 가이드와 **같은 범위**를 다뤄요: 데코레이터로 표현할 수 있는 모든 기능에 대응하는 빌더가 여기 있어요.
 :::
 
 ## 왜 코드 우선인가
 
+ORM 없이는 테이블을 서너 번 기술해야 해요: `CREATE TABLE`, `INSERT`, `SELECT`, 그리고 TypeScript 타입. 컬럼을 하나 추가하면 그 모두를 수정하죠. 데코레이터 ORM은 이걸 클래스 하나로 줄이지만, 프로퍼티 타입을 읽기 위해 `emitDecoratorMetadata` 컴파일러 플래그에 의존해요 — esbuild, SWC, Vite의 기본 트랜스포머, TypeScript 5의 *표준* 데코레이터가 내보내지 않는 플래그죠. 메타데이터가 없으면 `@Column()`은 조용히 타입을 잃어요.
+
+`defineEntity`는 그 의존성을 완전히 없애요:
+
 - **단일 진실 공급원(single source of truth).** 컬럼 빌더가 데이터베이스 타입*과* TypeScript 타입을 동시에 고정해요. `t.int()`는 `number`이고, 실수로 `string`으로 표기할 수 없어요. 손으로 쓴 클래스와 별도 스키마를 쓰면 이 둘이 조용히 어긋날 수 있죠.
 - **타입 추론, 코드 생성 없음.** `InferEntity`가 빌더를 직접 읽어요. 생성 단계도, 감시(watch) 프로세스도 없고, 스키마를 편집하는 즉시 타입이 갱신돼요.
-- **데코레이터 툴체인 불필요.** `experimentalDecorators` / `emitDecoratorMetadata` 없이도 strict 모드와 ESM에서 esbuild, swc, Vite, Bun과 함께 동작해요. 잘못 설정할 게 없어요.
+- **데코레이터 툴체인 불필요.** strict 모드와 ESM에서 esbuild, swc, Vite, Bun과 함께 `experimentalDecorators` / `emitDecoratorMetadata` 없이 동작해요. 잘못 설정할 게 없어요.
+
+내부적으로 `defineEntity`는 빌더를 데코레이터가 등록하는 것과 정확히 같은 메타데이터로 변환한 뒤, `EntitySchema` 브리지에 넘겨요. 그래서 나머지 ORM — EntityManager, SchemaGenerator, QueryBuilder, WriteBuffer — 은 빌더 엔티티와 데코레이터 엔티티, 손으로 쓴 `EntitySchema`를 구분하지 못해요.
+
+## 첫 번째 엔티티 만들기
+
+사용자를 저장한다고 가정해 볼게요. 가장 간단한 엔티티는 두 컬럼이에요:
+
+```typescript
+// user.entity.ts
+import { defineEntity, t, InferEntity } from "@stingerloom/orm";
+
+export const User = defineEntity("users", {
+  id:   t.int().primary().generated(),
+  name: t.varchar(255),
+});
+
+export type User = InferEntity<typeof User>; // { id: number; name: string }
+```
+
+첫 번째 인자(`"users"`)는 테이블 이름이에요. 이것만으로 Stingerloom은 자동 증가 기본 키와 `VARCHAR(255)` `name` 컬럼을 가진 `users` 테이블을 생성해요. 다음은 그 정확한 DDL이에요.
+
+**PostgreSQL:**
+
+```sql
+CREATE TABLE "users" (
+  "id" SERIAL PRIMARY KEY,
+  "name" VARCHAR(255) NOT NULL
+);
+```
+
+**MySQL:**
+
+```sql
+CREATE TABLE `users` (
+  `id` INT NOT NULL AUTO_INCREMENT,
+  `name` VARCHAR(255) NOT NULL,
+  PRIMARY KEY (`id`)
+);
+```
+
+PostgreSQL은 큰따옴표와 `SERIAL`을, MySQL은 백틱과 `AUTO_INCREMENT`를 써요. 엔티티를 한 번만 작성하면 둘 다에서 — 그리고 키가 `INTEGER PRIMARY KEY AUTOINCREMENT`가 되는 SQLite에서도 — 동작해요.
+
+세 부분이 일을 하고 있어요:
+
+- **`defineEntity("users", { … })`** 는 엔티티와 테이블 이름을 선언해요. (테이블 이름이 첫 번째 인자와 달라야 하면 세 번째 옵션 인자의 `tableName`으로 전달하세요 — [고급 엔티티 옵션](#고급-엔티티-옵션)을 참고하세요.)
+- **`t.int().primary().generated()`** 는 자동 증가 기본 키예요. `.primary()`는 PK로 표시하고, `.generated()`는 INSERT 시 데이터베이스가 1, 2, 3…을 채우게 해요. SQL 수준에서는 `SERIAL PRIMARY KEY`(PostgreSQL) 또는 `INT AUTO_INCREMENT PRIMARY KEY`(MySQL)예요.
+- **`t.varchar(255)`** 는 일반 `VARCHAR(255)` 컬럼이에요. 빌더가 TypeScript 타입을 `string`으로 고정하므로 직접 표기할 필요가 없어요.
+
+```sql
+-- 작성:
+await em.save(User, { name: "Alice" });
+-- 생성된 SQL (DB가 id = 1을 자동으로 채워요):
+INSERT INTO "users" ("name") VALUES ('Alice');
+```
 
 ## `t` 빌더
 
-모든 필드는 `t` 네임스페이스의 호출이에요. 컬럼 빌더는 추론된 타입을 들고 다니고, 체이닝된 수정자(modifier)가 그 타입을 다듬어요(`.nullable()`은 타입을 `T | null`로 넓혀요).
+모든 필드는 `t` 네임스페이스의 호출이에요. 컬럼 빌더는 추론된 타입을 지니고, 체이닝된 수정자가 이를 다듬어요(`.nullable()`은 타입을 `T | null`로 넓혀요).
 
 ### 컬럼 타입
 
-| Builder | TypeScript type | Abstract column type |
+| 빌더 | TypeScript 타입 | 추상 컬럼 타입 |
 | --- | --- | --- |
 | `t.int()` / `t.integer()` | `number` | `int` |
 | `t.bigint()` | `number` | `bigint` |
 | `t.float()` / `t.double()` | `number` | `float` / `double` |
+| `t.number()` | `number` | `number` |
 | `t.decimal(precision?, scale?)` | `number` | `number` |
 | `t.varchar(length?)` | `string` | `varchar` |
 | `t.char(length?)` | `string` | `char` |
 | `t.text()` / `t.longtext()` | `string` | `text` / `longtext` |
 | `t.uuid()` | `string` | `uuid` |
 | `t.boolean()` | `boolean` | `boolean` |
-| `t.datetime()` / `t.timestamp()` / `t.timestamptz()` / `t.date()` | `Date` | matching temporal type |
+| `t.datetime()` / `t.timestamp()` / `t.timestamptz()` / `t.date()` | `Date` | 해당 시간 타입 |
 | `t.blob()` | `Buffer` | `blob` |
-| `t.json<T>()` / `t.jsonb<T>()` | `T` (default `unknown`) | `json` / `jsonb` |
+| `t.json<T>()` / `t.jsonb<T>()` | `T` (기본 `unknown`) | `json` / `jsonb` |
 | `t.array<T>()` | `T[]` | `array` |
 | `t.enum(["a", "b"])` | `"a" \| "b"` | `enum` |
 
+여러 타입을 섞은 현실적인 예와 그것이 추론하는 타입:
+
 ```typescript
-const Event = defineEntity("events", {
-  id:       t.int().primary().generated(),
-  payload:  t.jsonb<{ kind: string; data: unknown }>(),
-  tags:     t.array<string>(),
-  level:    t.enum(["info", "warn", "error"]).default("info"),
+export const Product = defineEntity("products", {
+  id:          t.int().primary().generated(),
+  name:        t.varchar(255),       // VARCHAR(255), 필수
+  description: t.text(),             // TEXT (255자가 아니라 메가바이트)
+  price:       t.float(),           // FLOAT / REAL
+  isAvailable: t.boolean(),         // TINYINT(1) / BOOLEAN
+  releaseDate: t.datetime(),        // DATETIME / TIMESTAMP
+  payload:     t.jsonb<{ kind: string; data: unknown }>(),
+  tags:        t.array<string>(),
+  level:       t.enum(["info", "warn", "error"]).default("info"),
 });
-// InferEntity → payload: { kind: string; data: unknown }; tags: string[]; level: "info" | "warn" | "error"
+// InferEntity<typeof Product> →
+//   { id: number; name: string; description: string; price: number;
+//     isAvailable: boolean; releaseDate: Date;
+//     payload: { kind: string; data: unknown }; tags: string[];
+//     level: "info" | "warn" | "error" }
 ```
 
-### 수정자(Modifier)
+`VARCHAR(255)`는 255자에서 잘리고, `TEXT`는 메가바이트를 저장해요. 의도에 맞는 빌더를 고르세요 — TypeScript에서는 둘 다 `string`이지만 매우 다른 컬럼이에요. 전체 드라이버별 매핑은 [ColumnType 참조](#columntype-참조)를 확인하세요.
 
-수정자는 어떤 순서로든 체이닝할 수 있고, 각각 새 빌더를 반환해요.
+## 컬럼 수정자
 
-| Modifier | 효과 |
+수정자는 어떤 순서로든 체이닝할 수 있고, 각 호출은 새 빌더를 반환해요. nullable을 바꾸는 수정자는 추론된 타입도 함께 다듬어요.
+
+| 수정자 | 효과 |
 | --- | --- |
-| `.primary()` | (복합) 기본 키의 일부로 표시해요. |
-| `.generated(strategy?)` | DB 생성 키: `"increment"`(기본값), `"uuid"`, `"uuid-v7"`. `.primary()`와 함께 쓰세요. |
-| `.nullable()` | `NULL`을 허용하고, 추론된 타입을 `T \| null`로 넓혀요. |
+| `.primary()` | 기본 키(의 일부)로 표시해요. |
+| `.generated(strategy?)` | DB 생성 키: `"increment"`(기본), `"uuid"`, `"uuid-v7"`. `.primary()`와 함께 쓰세요. |
+| `.nullable()` | `NULL`을 허용하고, 추론 타입을 `T \| null`로 넓혀요. |
 | `.unique(name?)` | 단일 컬럼 고유 인덱스. |
 | `.index()` | 단일 컬럼 인덱스. |
 | `.default(value)` | 컬럼 기본값. |
-| `.name(dbName)` | 데이터베이스 컬럼 이름을 재정의해요(기본값: 프로퍼티 키). |
+| `.name(dbName)` | 데이터베이스 컬럼 이름 재정의(기본: 프로퍼티 키). |
 | `.length(n)` / `.precision(n)` / `.scale(n)` | 크기 / 숫자 정밀도. |
 | `.transformer({ to, from })` | 양방향 값 트랜스포머. |
 | `.createTimestamp()` / `.updateTimestamp()` | 자동 설정 타임스탬프. |
-| `.deletedAt()` | 소프트 삭제 마커(nullable을 함의). |
+| `.deletedAt()` | 소프트 삭제 마커(nullable 함의). |
 | `.version()` | 낙관적 잠금 버전 컬럼. |
 | `.validate([...])` | 인라인 검증 제약. |
-| `.enumName(name)` | PostgreSQL `ENUM` 타입의 이름을 지정해요. |
+| `.enumName(name)` | PostgreSQL `ENUM` 타입 이름 지정. |
 | `.jsonIndex(opts)` | JSON/JSONB 표현식 인덱스. |
-| `.tenant()` | 테넌트 구분 컬럼. |
+| `.tenant()` | 테넌트 식별자 컬럼. |
+
+### 길이
+
+`t.varchar(100)`은 길이를 인라인으로 설정하고, `.length(100)`은 사후에 같은 일을 해요. 둘 다 `VARCHAR(100)`을 렌더링하고, 데이터베이스는 길이를 초과한 INSERT를 거부해요.
 
 ```typescript
-export const Account = defineEntity("accounts", {
-  id:        t.uuid().primary().generated("uuid-v7"),
-  email:     t.varchar(255).unique().transformer({
-    to:   (v: string) => v.toLowerCase(),
-    from: (v: string) => v,
-  }),
-  balance:   t.decimal(12, 2).default(0),
-  createdAt: t.datetime().createTimestamp(),
-  updatedAt: t.datetime().updateTimestamp(),
-  deletedAt: t.datetime().deletedAt(),
-  version:   t.int().version(),
+sku: t.varchar(100),           // VARCHAR(100)
+sku2: t.varchar().length(100), // 동일
+```
+
+### NULL 허용
+
+모든 컬럼은 기본적으로 `NOT NULL`이에요. `.nullable()`은 그 제약을 없애고 **동시에** 추론 타입을 `T | null`로 넓혀서, 타입과 스키마가 함께 가도록 해요:
+
+```typescript
+bio: t.varchar(255).nullable(), // VARCHAR(255), NOT NULL 없음 → bio: string | null
+```
+
+### 컬럼 이름 별칭
+
+프로퍼티 이름과 DB 컬럼이 달라야 할 때 `.name()`을 쓰세요 — 흔한 경우는 TypeScript는 camelCase, 데이터베이스는 snake_case죠:
+
+```typescript
+price: t.float().name("unit_price"),
+// 엔티티 프로퍼티: product.price / DB 컬럼: unit_price
+```
+
+DDL에서는 컬럼 이름이 `unit_price`가 되고, SELECT 시 Stingerloom이 `unit_price`를 `price`로 다시 매핑해요. (프로젝트 전반의 규칙을 원하면 [`SnakeNamingStrategy`](./configuration.md)를 등록하고 컬럼별 `.name()` 호출을 빼면 돼요.)
+
+### 기본값
+
+`.default(value)`는 컬럼 기본값을 설정해요. 리터럴 문자열·숫자·불리언은 그대로 쓰이고, 원시 SQL 표현식(함수 호출)을 내보내려면 괄호로 감싸세요.
+
+```typescript
+status:     t.varchar(255).default("active"),
+retryCount: t.int().default(0),
+isVisible:  t.boolean().default(true),
+createdAt:  t.datetime().default("(CURRENT_TIMESTAMP)"),
+```
+
+**PostgreSQL:**
+
+```sql
+"status" VARCHAR(255) NOT NULL DEFAULT 'active',
+"retryCount" INTEGER NOT NULL DEFAULT 0,
+"isVisible" BOOLEAN NOT NULL DEFAULT TRUE,
+"createdAt" TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+```
+
+괄호가 없으면 `"CURRENT_TIMESTAMP"`는 SQL 함수가 아니라 리터럴 문자열 `'CURRENT_TIMESTAMP'`로 내보내져요.
+
+### JSON 컬럼
+
+`t.json<T>()`와 `t.jsonb<T>()`는 구조화된 데이터를 한 컬럼에 저장하고, 타입 인자가 추론된 행 타입으로 그대로 흘러가요:
+
+```typescript
+settings: t.json<{ theme: string }>().nullable(),
+// settings: { theme: string } | null
+```
+
+PostgreSQL에서 `jsonb`는 분해된 바이너리 형식으로 저장돼요 — 쓰기는 느리지만 쿼리는 훨씬 빠르고, `WHERE settings->>'theme' = 'dark'`처럼 인덱싱할 수 있는 유일한 형식이죠. 문서 내부를 쿼리한다면 언제나 `jsonb`를 택하세요.
+
+Stingerloom은 `json`/`jsonb` 컬럼에 기본 왕복 변환을 설치해요: 쓰기 시 문자열이 아닌 값은 드라이버에 닿기 전에 `JSON.stringify`되고, 읽기 시 드라이버가 반환한 문자열은 `JSON.parse`돼요. 그래서 평범한 JS 값을 직접 할당하면 돼요:
+
+```typescript
+await em.save(Issue, { customFields: { priority: "high", labels: ["bug"] } });
+const issue = await em.findOne(Issue, { where: { id } });
+issue!.customFields.priority; // "high" — 이미 객체, 방언 독립적
+```
+
+명시적인 [`.transformer()`](#트랜스포머)를 주면 해당 방향의 기본 변환을 덮어써요.
+
+### PostgreSQL ENUM
+
+`t.enum([...])`은 리터럴 유니온 타입을 고정**하고** 허용 값을 데이터베이스로 전달해요. 생성되는 PostgreSQL 타입의 이름은 `.enumName()`으로 지정해요:
+
+```typescript
+status: t.enum(["draft", "published", "archived"]).enumName("post_status"),
+// status: "draft" | "published" | "archived"
+```
+
+PostgreSQL DDL:
+
+```sql
+CREATE TYPE "post_status" AS ENUM ('draft', 'published', 'archived');
+-- ...
+"status" "post_status" NOT NULL
+```
+
+`.enumName()`을 생략하면 이름은 `{tableName}_{columnName}_enum`이 돼요. MySQL에서는 컬럼이 네이티브 `ENUM(...)`이 되고, SQLite에서는 `TEXT`로 저장돼요.
+
+## 기본 키
+
+### 생성 키
+
+`.primary().generated(strategy)`는 데이터베이스 생성 키를 만들어요. 전략이 방식을 정해요:
+
+```typescript
+id: t.int().primary().generated(),              // 자동 증가 (기본 "increment")
+id: t.uuid().primary().generated("uuid"),       // 랜덤 UUIDv4
+id: t.uuid().primary().generated("uuid-v7"),    // 시간 정렬 가능한 UUIDv7
+```
+
+`"increment"`는 `SERIAL`(PostgreSQL) / `AUTO_INCREMENT`(MySQL)에 대응해요. `"uuid"`와 `"uuid-v7"`은 INSERT 전 애플리케이션 코드에서 값을 생성하고 — `"uuid-v7"`은 시간순이라 랜덤 UUID보다 기본 키 인덱스에 훨씬 유리해요.
+
+### 수동 기본 키
+
+`.generated()`를 빼면 직접 값을 공급하는 키가 돼요 — `@PrimaryColumn()`의 빌더 대응이죠. config 테이블 같은 자연 키에 유용해요:
+
+```typescript
+export const Config = defineEntity("config", {
+  key:   t.varchar(64).primary(),
+  value: t.text(),
+});
+
+await em.save(Config, { key: "site.title", value: "My Blog" });
+// INSERT INTO "config" ("key", "value") VALUES ('site.title', 'My Blog')
+```
+
+### 복합 기본 키
+
+둘 이상의 컬럼을 `.primary()`로 표시하면 복합 키가 돼요:
+
+```typescript
+export const Enrollment = defineEntity("enrollments", {
+  studentId: t.int().primary().name("student_id"),
+  courseId:  t.int().primary().name("course_id"),
+  grade:     t.varchar(2).nullable(),
 });
 ```
 
+```sql
+CREATE TABLE "enrollments" (
+  "student_id" INTEGER NOT NULL,
+  "course_id" INTEGER NOT NULL,
+  "grade" VARCHAR(2),
+  PRIMARY KEY ("student_id", "course_id")
+);
+```
+
+## 트랜스포머
+
+트랜스포머는 값을 **양방향**으로 번역해요: `to`는 모든 INSERT/UPDATE 전에, `from`은 모든 SELECT 후에 실행돼요. 대표적인 용도는 이메일을 소문자로 정규화해서 `Alice@Example.com`과 `alice@example.com`이 둘 다 존재하지 않게 하는 거예요:
+
+```typescript
+export const Account = defineEntity("accounts", {
+  id:    t.int().primary().generated(),
+  email: t.varchar(255).unique().transformer({
+    to:   (value: string) => value.toLowerCase(), // 엔티티 → DB (쓰기)
+    from: (value: string) => value,               // DB → 엔티티 (읽기)
+  }),
+});
+
+await em.save(Account, { email: "Alice@Example.COM" });
+// INSERT INTO "accounts" ("email") VALUES ('alice@example.com')
+```
+
+암호화도 같은 모양이에요 — `to`에서 암호화, `from`에서 복호화 — 그래서 데이터베이스에는 항상 암호문만 저장되고 코드는 평문으로 작업해요:
+
+```typescript
+ssn: t.text().transformer({
+  to:   (value: string) => encrypt(value),
+  from: (value: string) => decrypt(value),
+}),
+```
+
+## 인덱스
+
+### 단일 컬럼 인덱스
+
+`.index()`는 비고유 인덱스를, `.unique()`는 고유 인덱스를 추가해요. 둘 다 해당 컬럼의 `WHERE`/`JOIN`/`ORDER BY`에서 전체 테이블 스캔을 O(log n) B-tree 조회로 바꿔요:
+
+```typescript
+export const User = defineEntity("users", {
+  id:    t.int().primary().generated(),
+  email: t.varchar(255).index(),   // CREATE INDEX ... ON "users" ("email")
+  slug:  t.varchar(255).unique(),  // 단일 컬럼 UNIQUE 인덱스
+});
+```
+
+```sql
+CREATE INDEX "INDEX_users_email" ON "users" ("email");
+```
+
+`.unique()` 제약은 엔티티의 고유 인덱스 목록으로 올려지므로, 옵션 객체에 선언하는 복합 고유 인덱스와 함께 구성돼요.
+
+### 복합 및 고유 인덱스
+
+다중 컬럼 인덱스는 세 번째 옵션 인자에 들어가요. `indexes`는 비고유, `uniqueIndexes`는 조합에 대한 고유성을 강제해요:
+
+```typescript
+export const Order = defineEntity(
+  "orders",
+  {
+    id:       t.int().primary().generated(),
+    tenantId: t.int().name("tenant_id"),
+    status:   t.varchar(50),
+    slug:     t.varchar(120),
+  },
+  {
+    indexes:       [{ columns: ["tenant_id", "status"] }],
+    uniqueIndexes: [{ columns: ["tenant_id", "slug"], name: "uq_order_slug" }],
+  },
+);
+```
+
+```sql
+CREATE INDEX "idx_orders_tenant_id_status" ON "orders" ("tenant_id", "status");
+CREATE UNIQUE INDEX "uq_order_slug" ON "orders" ("tenant_id", "slug");
+```
+
+복합 인덱스는 성(姓)으로 먼저 정렬한 뒤 이름으로 정렬한 전화번호부처럼 왼쪽부터 동작해요: `WHERE tenant_id = 5`와 `WHERE tenant_id = 5 AND status = 'pending'`에는 쓰이지만, `WHERE status = 'pending'` 단독에는 쓰이지 않아요.
+
+### 고급 인덱스 옵션
+
+각 `indexes` 항목은 `options` 객체를 받는데, 데코레이터의 `@Index([cols], options)`가 받는 것과 같은 `AdvancedIndexOptions`예요 — 부분(partial), 표현식, `USING`, 커버링(`INCLUDE`) 인덱스죠:
+
+```typescript
+export const User = defineEntity(
+  "users",
+  {
+    id:        t.int().primary().generated(),
+    email:     t.varchar(255),
+    name:      t.varchar(255),
+    metadata:  t.jsonb(),
+    deletedAt: t.datetime().deletedAt(),
+  },
+  {
+    indexes: [
+      // 부분 커버링 인덱스 (WHERE는 PostgreSQL / SQLite, INCLUDE는 PG)
+      {
+        columns: ["email"],
+        options: {
+          name: "idx_active_user_email",
+          where: "deleted_at IS NULL", // 부분 — 소프트 삭제 행 제외
+          include: ["name"],           // 커버링 — index-only 스캔
+        },
+      },
+      // 표현식 인덱스 — 컬럼 목록은 비우고 표현식이 대체
+      { columns: [], options: { name: "idx_lower_email", expression: "LOWER(email)" } },
+      // JSONB 포함(containment) 쿼리용 GIN 인덱스
+      { columns: ["metadata"], options: { using: "gin" } },
+    ],
+  },
+);
+```
+
+```sql
+CREATE INDEX "idx_active_user_email" ON "users" ("email") INCLUDE ("name") WHERE deleted_at IS NULL;
+CREATE INDEX "idx_lower_email" ON "users" ((LOWER(email)));
+CREATE INDEX "idx_users_metadata" ON "users" USING gin ("metadata");
+```
+
+| `using` 값 | 적합한 용도 | PostgreSQL | MySQL |
+| --- | --- | --- | --- |
+| `btree` | 동등·범위·정렬 (기본) | Yes | Yes |
+| `hash` | 동등만 | Yes | Yes |
+| `gin` | JSONB, 배열, 전문 검색 | Yes | No |
+| `gist` | 기하, 범위 타입 | Yes | No |
+| `brin` | 대용량 시계열 테이블 | Yes | No |
+
+부분(`where`), 커버링(`include`), 비-btree `using`은 PostgreSQL 기능이에요(부분 인덱스는 SQLite에서도 동작). MySQL은 이를 무시하거나 거부해요. 옵션 객체는 동일하니 개념 설명은 데코레이터 가이드의 [고급 인덱스 옵션](./entities.md#고급-인덱스-옵션)을 참고하세요.
+
+### 전문 인덱스
+
+전문(full-text) 인덱스는 `fullTextIndexes`에 들어가요:
+
+```typescript
+export const Post = defineEntity(
+  "posts",
+  {
+    id:      t.int().primary().generated(),
+    title:   t.varchar(200),
+    content: t.text(),
+  },
+  {
+    fullTextIndexes: [
+      { columns: ["title", "content"], name: "ft_post", language: "english" },
+    ],
+  },
+);
+```
+
+PostgreSQL은 GIN `to_tsvector` 인덱스를, MySQL은 `FULLTEXT` 인덱스를 내보내요. SQLite는 no-op이에요.
+
+### JSON 경로 인덱스
+
+`.jsonIndex()`는 `jsonb` 컬럼 내부 경로에 대한 표현식 인덱스를 선언해요 — `@JsonIndex`의 빌더 형식이죠:
+
+```typescript
+profile: t.jsonb<{ tags: string[] }>().jsonIndex({
+  path: "tags",
+  using: "gin",
+  opclass: "jsonb_path_ops",
+}),
+```
+
+PostgreSQL DDL:
+
+```sql
+CREATE INDEX "idx_users_profile_tags_gin"
+  ON "users" USING gin ((profile -> 'tags') jsonb_path_ops);
+```
+
+`path`는 점-대괄호 표기예요(`"contact.email"`, `"tags[0]"`). 생략하면 컬럼 전체를 인덱싱해요. `using: "btree"`는 동등/범위에 쓰는 단일 스칼라 리프에 적합해요. MySQL과 SQLite는 DDL을 내보내지 않아요(경고가 로깅됨). 전체 옵션은 [JSON 경로 인덱스](./entities.md#json-경로-인덱스-jsonindex)를, 이 인덱스와 맞물리는 연산자는 [쿼리 빌더 — JSON](./query-builder-json.md)을 참고하세요.
+
+## 낙관적 잠금
+
+`.version()`은 *손실된 업데이트(lost update)* 문제 — 두 작성자가 같은 행을 읽고 서로를 덮어쓰는 — 를 감지하는 버전 카운터를 추가해요. INSERT 시 버전이 1로 설정되고, UPDATE 시 Stingerloom이 `WHERE version = N`을 추가하고 값을 증가시켜요. 그 사이 행이 바뀌었으면 UPDATE는 0개 행에 매치되고, 데이터를 조용히 잃는 대신 `OptimisticLockError`가 던져져요.
+
+```typescript
+export const Order = defineEntity("orders", {
+  id:      t.int().primary().generated(),
+  status:  t.varchar(255),
+  version: t.int().version(),
+});
+```
+
+```sql
+-- 작성자 A (버전 1 읽음) 성공, 버전은 2가 됨:
+UPDATE "orders" SET "status" = 'shipped', "version" = "version" + 1
+WHERE "id" = 1 AND "version" = 1;          -- 1개 행 영향
+
+-- 작성자 B (역시 버전 1 읽음) 이제 실패:
+UPDATE "orders" SET "status" = 'refunded', "version" = "version" + 1
+WHERE "id" = 1 AND "version" = 1;          -- 0개 행 → OptimisticLockError
+```
+
+충돌이 드물지만 정확성이 중요한 곳(주문 상태, 재고)에 쓰세요. 경합이 심한 행에는 비관적 잠금(`SELECT … FOR UPDATE`)을 택하세요.
+
+## 소프트 삭제
+
+`.deletedAt()`은 삭제를 행 제거가 아니라 타임스탬프 표시로 바꿔요. `.nullable()`을 함의하므로(`NULL` 마커는 "삭제되지 않음"을 뜻함) 추론 타입은 `Date | null`이에요:
+
+```typescript
+export const Post = defineEntity("posts", {
+  id:        t.int().primary().generated(),
+  title:     t.varchar(255),
+  deletedAt: t.datetime().deletedAt(), // deletedAt: Date | null
+});
+```
+
+이 마커는 세 가지 동작을 바꿔요:
+
+```typescript
+await em.softDelete(Post, { id: 1 });
+// UPDATE "posts" SET "deletedAt" = NOW() WHERE "id" = 1;   (DELETE 아님)
+
+await em.find(Post);
+// SELECT * FROM "posts" WHERE "deletedAt" IS NULL;          (자동 제외)
+
+await em.find(Post, { withDeleted: true });
+// SELECT * FROM "posts";                                    (삭제된 행 포함)
+
+await em.restore(Post, { id: 1 });
+// UPDATE "posts" SET "deletedAt" = NULL WHERE "id" = 1;     (복원)
+```
+
+## 자동 타임스탬프
+
+`.createTimestamp()`와 `.updateTimestamp()`는 감사 타임스탬프를 대신 채워줘요. INSERT 시 둘 다 설정되고, UPDATE 시 갱신 타임스탬프만 새로 채워져요:
+
+```typescript
+export const Article = defineEntity("articles", {
+  id:        t.int().primary().generated(),
+  title:     t.varchar(255),
+  createdAt: t.datetime().createTimestamp(),
+  updatedAt: t.datetime().updateTimestamp(),
+});
+```
+
+```sql
+-- INSERT — 둘 다 같은 순간으로 설정 (앱 코드의 new Date()로 생성):
+INSERT INTO "articles" ("title", "createdAt", "updatedAt")
+VALUES ('Hello', '2026-06-30 10:30:00', '2026-06-30 10:30:00');
+
+-- UPDATE — SET 절에는 updatedAt만:
+UPDATE "articles" SET "title" = 'Hello v2', "updatedAt" = '2026-06-30 11:45:00'
+WHERE "id" = 1;
+```
+
+`save()`에서 타임스탬프 컬럼에 명시적인 값을 주면 자동 생성 값 대신 그 값이 쓰여요 — 데이터 마이그레이션에 유용하죠. PostgreSQL에서 시간대 인식 컬럼이 필요하면 `t.timestamptz()`를 쓰세요.
+
+## 계산 컬럼
+
+`t.computed()`는 데이터베이스 수준의 생성 컬럼을 선언해요 — `@ComputedColumn`의 빌더 형식이죠. 값은 다른 컬럼으로부터 데이터베이스가 계산하고, **모든 INSERT와 UPDATE에서 제외돼요**(쓰려고 하면 오류). `GENERATED ALWAYS AS (expression)`으로 렌더링돼요:
+
+```typescript
+export const OrderLine = defineEntity("order_lines", {
+  id:       t.int().primary().generated(),
+  price:    t.float(),
+  quantity: t.int(),
+  total:    t.computed<number>("price * quantity", { stored: true, type: "float" }),
+});
+```
+
+PostgreSQL DDL:
+
+```sql
+CREATE TABLE "order_lines" (
+  "id" SERIAL PRIMARY KEY,
+  "price" REAL NOT NULL,
+  "quantity" INTEGER NOT NULL,
+  "total" REAL GENERATED ALWAYS AS (price * quantity) STORED
+);
+```
+
+```typescript
+await em.save(OrderLine, { price: 29.99, quantity: 3 });
+// INSERT INTO "order_lines" ("price", "quantity") VALUES (29.99, 3)
+// "total"은 생략 — DB가 89.97로 계산
+```
+
+옵션은 `@ComputedColumn`을 그대로 따라요: `stored`, `type`, `length`, `nullable`.
+
+| `stored` | 모드 | 동작 | 디스크 | 인덱스 가능 |
+| --- | --- | --- | --- | --- |
+| `true` | STORED | 쓰기 시 계산, 영속화 | 공간 사용 | 가능 |
+| `false` (기본) | VIRTUAL | 읽기마다 계산 | 없음 | 제한적 |
+
+### 다이얼렉트 독립 표현식
+
+리터럴 문자열 표현식은 DDL에 그대로 박히므로, 대상 데이터베이스에 이미 유효한 SQL이어야 해요. `price * quantity` 같은 이식 가능한 산술에는 괜찮지만, 날짜 연산은 엔진마다 크게 갈려요. 대신 **빌더 함수**를 넘기면 Stingerloom이 연결당 한 번 방언에 맞는 SQL로 컴파일해요:
+
+```typescript
+export const Issue = defineEntity("issues", {
+  id:          t.int().primary().generated(),
+  createdAt:   t.datetime().nullable().name("created_at"),
+  completedAt: t.datetime().nullable().name("completed_at"),
+  cycleTimeHours: t.computed<number>(
+    (e) => e.dateDiff(e.col("completed_at"), e.col("created_at"), "hour"),
+    { type: "int", nullable: true },
+  ),
+});
+```
+
+```sql
+-- MySQL
+`cycleTimeHours` INT GENERATED ALWAYS AS (TIMESTAMPDIFF(HOUR, `created_at`, `completed_at`)) VIRTUAL
+-- PostgreSQL
+"cycleTimeHours" INTEGER GENERATED ALWAYS AS (EXTRACT(EPOCH FROM ("completed_at" - "created_at")) / 3600) VIRTUAL
+```
+
+컨텍스트 `e`는 전체 Expressions DSL(`e.iff`, `e.caseBuilder`, `e.coalesce`, `e.dateDiff`, `e.col(name)`)을 노출해요. 전체 DSL은 데코레이터 가이드의 [다이얼렉트 독립 표현식](./entities.md#다이얼렉트-독립-표현식-빌더-형식)을 참고하세요.
+
+::: tip 계산 컬럼이 데이터베이스에 닿는 방식
+`GENERATED ALWAYS AS` DDL은 스키마 **제너레이터** — 마이그레이션 CLI(`stingerloom migrate:generate`)가 쓰는 경로 — 가 내보내요. 런타임 `synchronize`의 테이블 생성 경로는 저장 컬럼만 렌더링해요. 이건 데코레이터 `@ComputedColumn`과 정확히 같아요: 계산 컬럼을 추가(또는 변경)하려면 마이그레이션을 생성하세요. 테이블이 어떻게 생성됐든 Stingerloom은 항상 그 컬럼을 쓰기에서 제외해요.
+:::
+
+## 검증
+
+`.validate([...])`는 SQL이 빌드되기 **전에** 검사되는 애플리케이션 수준 제약을 붙여요 — `@NotNull`, `@MinLength`, `@Min` 등의 빌더 형식이죠. 실패하면 `ValidationError`가 던져지고 쿼리는 전송되지 않아요:
+
+```typescript
+export const Member = defineEntity("members", {
+  id:   t.int().primary().generated(),
+  name: t.varchar(50).validate([
+    { constraint: "notNull" },
+    { constraint: "minLength", value: 2 },
+    { constraint: "maxLength", value: 50 },
+  ]),
+  age:  t.int().validate([
+    { constraint: "min", value: 0 },
+    { constraint: "max", value: 150 },
+  ]),
+});
+
+await em.save(Member, { name: "A", age: -1 });
+// ValidationError: name must be at least 2 characters long  (INSERT 시도 없음)
+```
+
+각 항목은 `{ constraint, value?, message? }`예요. 사용 가능한 제약은 `notNull`, `minLength`, `maxLength`, `min`, `max`이고, 커스텀 `message`로 기본 메시지를 덮어쓸 수 있어요. 데이터베이스 `NOT NULL` 위반(왕복 후 난해한 메시지로 드러남)과 달리, 검증은 명확한 메시지와 함께 프로세스 안에서 잡혀요.
+
+## 생명주기 훅
+
+훅은 엔티티 생명주기의 특정 순간에 커스텀 로직을 실행해요 — 삽입 전 슬러그 생성, 삽입 후 알림 전송, 삭제 전 정리 등이죠. 세 번째 옵션 인자에 선언하고, 각 이벤트는 함수(또는 클래스에 이미 있는 메서드의 이름)에 매핑돼요:
+
+```typescript
+export const Article = defineEntity(
+  "articles",
+  {
+    id:    t.int().primary().generated(),
+    title: t.varchar(200),
+    slug:  t.varchar(200).nullable(),
+  },
+  {
+    hooks: {
+      beforeInsert(article) {
+        article.slug ??= article.title.toLowerCase().replace(/\s+/g, "-");
+      },
+      afterInsert(article) {
+        console.log(`Article #${article.id} created`);
+      },
+    },
+  },
+);
+```
+
+훅은 엔티티를 `this`로도, 첫 번째 인자로도 받아요. 그래서 `beforeInsert(a) { a.slug = … }`와 `beforeInsert() { this.slug = … }`는 동등해요.
+
+::: warning 훅은 인스턴스에서 실행돼요 — `new Entity(...)`를 쓰세요
+훅은 엔티티 프로토타입의 메서드라서, 저장하는 객체가 **그 프로토타입을 지닐 때만** 실행돼요. minted 클래스 생성자는 바로 이를 위해 부분 초기화 객체를 받아요: `new Article({ … })`는 타입이 잡힌, 훅을 가진 인스턴스를 줘요.
+
+```typescript
+// 훅 실행됨 — 저장 객체가 Article 인스턴스.
+const saved = await em.save(Article, new Article({ title: "Hello World" }));
+saved.slug; // "hello-world"
+
+// 훅 실행 안 됨 — 평범한 객체 리터럴에는 프로토타입 메서드가 없음.
+await em.save(Article, { title: "Hello World" });
+```
+
+이건 데코레이터 엔티티와 같은 요구사항이에요(`@BeforeInsert`도 인스턴스가 필요). `new Article({...})`는 `Object.assign(new Article(), {...})`의 데코레이터 없는, 타입이 검사되는 대응이죠.
+:::
+
+이벤트는 여섯 개이고, 해당 SQL 주변에서 실행돼요:
+
+| 이벤트 | 시점 | 대표 용도 |
+| --- | --- | --- |
+| `beforeInsert` | INSERT 직전 | 기본값, 슬러그 생성, 정규화 |
+| `afterInsert` | INSERT 후 (엔티티에 ID가 생김) | 로깅, 알림, 캐시 무효화 |
+| `beforeUpdate` | UPDATE 직전 | 필드 재계산, 검증 |
+| `afterUpdate` | UPDATE 후 | 변경 이력, 웹훅 |
+| `beforeDelete` | DELETE 직전 | 정리, 권한 확인 |
+| `afterDelete` | DELETE 후 | 관련 리소스 해제, 로깅 |
+
+새 엔티티의 순서는: `beforeInsert` 훅 → `INSERT` → `afterInsert` 훅이에요. `before*` 훅에서의 변경은 SQL에 반영되고, `after*` 훅은 행이 쓰인 뒤 실행되므로 부수 효과에 쓰세요.
+
 ## 관계
 
-관계 빌더는 지연(lazy) `() => TargetEntity`를 받아요(순환 참조를 허용하기 위해 지연이에요). `manyToOne` / `oneToOne`은 관련 행 타입을 추론하고, `oneToMany` / `manyToMany`는 배열을 추론해요. 관계 필드는 추론된 타입에서 **선택적(optional)** 이에요 — `relations: [...]`로 요청할 때만 채워지거든요.
+관계 빌더는 지연 `() => TargetEntity`를 받아요(두 엔티티가 서로 참조할 수 있도록 지연). `manyToOne` / `oneToOne`은 관련 행 타입을, `oneToMany` / `manyToMany`는 배열을 추론해요. 관계 필드는 추론 타입에서 **선택적(optional)** 이에요 — `relations: [...]`로 요청할 때만 채워져요.
+
+| 빌더 | 시그니처 | 추론 필드 |
+| --- | --- | --- |
+| `t.manyToOne` | `(() => Target, options?)` | `Target?` |
+| `t.oneToMany` | `(() => Target, mappedBy, options?)` | `Target[]?` |
+| `t.oneToOne` | `(() => Target, options?)` | `Target?` |
+| `t.manyToMany` | `(() => Target, options?)` | `Target[]?` |
 
 ```typescript
 export const Author = defineEntity("authors", {
@@ -115,11 +706,16 @@ export const Author = defineEntity("authors", {
 export const Post = defineEntity("posts", {
   id:       t.int().primary().generated(),
   title:    t.varchar(200),
-  authorId: t.int().nullable().name("author_id"), // the physical FK column
+  authorId: t.int().nullable().name("author_id"), // 물리적 FK 컬럼
   author:   t.manyToOne(() => Author, { joinColumn: "author_id" }),
   tags:     t.manyToMany(() => Tag, {
     joinTable: { name: "post_tags", joinColumn: "post_id", inverseJoinColumn: "tag_id" },
   }),
+});
+
+export const Tag = defineEntity("tags", {
+  id:   t.int().primary().generated(),
+  name: t.varchar(60).unique(),
 });
 
 export type Author = InferEntity<typeof Author>; // posts?: Post[]
@@ -127,32 +723,68 @@ export type Post = InferEntity<typeof Post>;     // author?: Author; tags?: Tag[
 ```
 
 ::: warning 외래 키 컬럼을 선언하세요
-`manyToOne` / 소유 측 `oneToOne`은 외래 키 컬럼을 실제 컬럼으로 선언해야(예: `authorId: t.int().name("author_id")`) 스키마 동기화 때 생성돼요 — 데코레이터 API가 FK를 위해 `@ManyToOne`을 `@Column`/`@RelationColumn`과 짝지우는 것과 똑같아요. 그러면 관계의 `joinColumn`이 그 컬럼을 가리켜요. (또는 관계 옵션에 `relationColumn: { … }`를 전달해도 돼요.)
+`manyToOne` / 소유측 `oneToOne`은 외래 키 컬럼을 실제 컬럼(`authorId: t.int().name("author_id")`)으로 선언해야 스키마 동기화 시 생성돼요 — 데코레이터 API가 `@ManyToOne`에 FK용 `@Column`/`@RelationColumn`을 짝지우는 것과 똑같죠. 그러면 관계의 `joinColumn`이 그 컬럼을 가리켜요. 또는 관계 옵션에 `relationColumn: { … }`을 넘겨 FK 메타데이터를 인라인으로 선언할 수도 있어요.
 :::
 
-| Builder | 시그니처 | 추론된 필드 |
-| --- | --- | --- |
-| `t.manyToOne` | `(() => Target, options?)` | `Target?` |
-| `t.oneToMany` | `(() => Target, mappedBy, options?)` | `Target[]?` |
-| `t.oneToOne` | `(() => Target, options?)` | `Target?` |
-| `t.manyToMany` | `(() => Target, options?)` | `Target[]?` |
+### 관계 옵션
 
-## 계산 컬럼
-
-`t.computed`는 데이터베이스가 생성하는 컬럼을 선언해요(`INSERT`/`UPDATE`에서 제외돼요):
+`manyToOne`과 `oneToOne`은 데코레이터와 같은 로딩 및 참조 동작 옵션을 받아요:
 
 ```typescript
-export const Person = defineEntity("people", {
-  id:        t.int().primary().generated(),
-  firstName: t.varchar(80).name("first_name"),
-  lastName:  t.varchar(80).name("last_name"),
-  fullName:  t.computed("first_name || ' ' || last_name", { stored: false, type: "varchar" }),
+author: t.manyToOne(() => Author, {
+  joinColumn: "author_id",
+  eager: true,                 // 항상 LEFT JOIN 하고 채움
+  cascade: ["insert", "update"],
+  onDelete: "CASCADE",         // FK ON DELETE 동작
+  onUpdate: "RESTRICT",
+  relationColumn: {            // 명시적 FK 컬럼 메타데이터 (@RelationColumn 식)
+    name: "author_id",
+    type: "bigint",
+    nullable: false,
+    referencedColumn: "id",
+  },
+}),
+```
+
+`oneToMany`는 역방향 프로퍼티 이름을 필수 두 번째 인자(위의 `"author"` — `Post`의 `manyToOne` 필드)로 받고, 선택적 `{ cascade }`도 받아요. `manyToMany`는 `{ joinTable, mappedBy, cascade }`를 받고요. 조인 테이블은 소유측에 선언하면 조인 테이블 DDL이 자동 생성돼요. 로딩 전략과 캐스케이드의 개념 설명은 [관계](./relations.md)를 참고하세요.
+
+## 상속
+
+상속은 *is-a* 관계(`CreditCardPayment`는 **a** `Payment`)를 모델링하므로, 실제 TypeScript 클래스 계층 — `class Child extends Parent` — 이 필요해요. `defineEntity`는 호출마다 독립된 클래스 하나를 minting하므로, 계층은 더 낮은 수준의 [`EntitySchema`](./decorator-free.md#entityschema-엔티티-정의) 형식을 쓰는 유일한 지점이에요. 이 형식은 `extends`로 직접 작성한 클래스에 스키마를 붙여요:
+
+```typescript
+import { EntitySchema } from "@stingerloom/orm";
+
+class Payment {
+  id!: number;
+  amount!: number;
+}
+class CreditCardPayment extends Payment {
+  cardNumber!: string;
+}
+
+new EntitySchema<Payment>({
+  target: Payment,
+  inheritance: { strategy: "SINGLE_TABLE" },
+  discriminatorColumn: { name: "payment_type" },
+  columns: {
+    id:     { type: "int", primary: true, autoIncrement: true },
+    amount: { type: "int" },
+  },
+});
+
+new EntitySchema<CreditCardPayment>({
+  target: CreditCardPayment,
+  discriminatorValue: "credit_card",
+  columns: { cardNumber: { type: "varchar", nullable: true } },
 });
 ```
 
-## 엔티티 등록 및 사용
+세 가지 전략(단일 테이블, 타입별 테이블, 구체 클래스별 테이블)을 모두 이렇게 데코레이터 없이 지원해요. 전체 전략은 [상속 매핑](./inheritance-mapping.md)을 참고하세요. 빌더 엔티티와 이 `EntitySchema` 계층은 공존하고 서로 관계를 맺을 수 있어요.
 
-데코레이터 클래스와 똑같이 엔티티 클래스를 `EntityManager`에 전달하세요:
+## 엔티티 등록과 사용
+
+빌더 엔티티를 데코레이터 클래스와 똑같이 `EntityManager`에 넘기세요:
 
 ```typescript
 import "reflect-metadata";
@@ -174,16 +806,16 @@ const withAuthor = await em.findOne(Post, {
   where: { id: post.id },
   relations: ["author"],
 });
-// withAuthor.author?.name === "Ada"  — fully typed
+withAuthor!.author?.name; // "Ada" — 완전히 타입이 잡힘
 ```
 
 ::: tip `reflect-metadata`
-ORM 코어는 런타임에 여전히 `reflect-metadata`를 사용하므로, 진입점에 `import "reflect-metadata"`를 유지하세요. 코드 우선 엔티티에서 *필요 없는* 것은 `experimentalDecorators`와 `emitDecoratorMetadata` 컴파일러 옵션이에요.
+ORM 코어는 런타임에 `reflect-metadata`를 쓰므로, 진입점에 `import "reflect-metadata"`를 유지하세요. 코드 우선 엔티티에 *필요 없는* 것은 `experimentalDecorators`와 `emitDecoratorMetadata` 컴파일러 옵션이에요.
 :::
 
-## 고급 옵션
+## 고급 엔티티 옵션
 
-`defineEntity`는 덜 흔한 엔티티 수준 설정을 위해 선택적 세 번째 인수를 받아요:
+선택적 세 번째 인자는 덜 흔한 엔티티 수준 설정을 담아요. 안에 있는 모든 것은 개별적으로도 접근 가능하지만, 드물게 쓰는 옵션을 묶으면 컬럼 맵이 깔끔해져요:
 
 ```typescript
 export const Member = defineEntity(
@@ -194,19 +826,118 @@ export const Member = defineEntity(
     email: t.varchar(255),
   },
   {
-    tableName: "org_members",          // override the table name
-    uniqueIndexes: [{ columns: ["org_id", "email"], name: "uq_member_email" }],
+    tableName: "org_members",          // 테이블 이름 재정의
     indexes: [{ columns: ["org_id"] }],
-    nonTenant: true,                   // opt out of the tenant_column strategy
+    uniqueIndexes: [{ columns: ["org_id", "email"], name: "uq_member_email" }],
+    fullTextIndexes: [{ columns: ["email"] }],
+    hooks: { beforeInsert(m) { m.email = m.email.toLowerCase(); } },
+    nonTenant: true,                   // tenant_column 전략에서 제외
   },
 );
 ```
 
-전체 데코레이터 → 빌더 매핑(전문 검색 인덱스, 테넌트 컬럼, 라이프사이클 훅 포함)은 [데코레이터 없이 사용하기](./decorator-free.md)를 참고하세요.
+| 옵션 | 용도 | 데코레이터 대응 |
+| --- | --- | --- |
+| `tableName` | 테이블 이름 (첫 인자 재정의) | `@Entity({ name })` |
+| `indexes` | 복합 / 고급 인덱스 | `@Index([cols], options)` |
+| `uniqueIndexes` | 복합 고유 인덱스 | `@UniqueIndex([cols])` |
+| `fullTextIndexes` | 전문 인덱스 | `@FullTextIndex([cols])` |
+| `hooks` | 생명주기 훅 | `@BeforeInsert` … `@AfterDelete` |
+| `nonTenant` | tenant_column 전략에서 제외 | `@NonTenantEntity()` |
+
+### 테넌트 컬럼
+
+전역 `tenantStrategy`가 `"tenant_column"`일 때, 식별자 컬럼을 `.tenant()`로 표시하면 인스턴스에서 읽을 수 있고 쿼리 스코프에 쓰여요. 본질적으로 전역인 테이블은 `nonTenant: true`로 제외하세요:
+
+```typescript
+// 테넌트별 엔티티 — 테넌트 컬럼을 log.tenantId로 읽을 수 있음
+export const AuditLog = defineEntity("audit_logs", {
+  id:       t.int().primary().generated(),
+  action:   t.varchar(255),
+  tenantId: t.varchar(64).name("tenant_id").tenant(),
+});
+
+// 본질적으로 전역인 엔티티 — 테넌트 스코프 없음
+export const Tenant = defineEntity(
+  "tenants",
+  { id: t.varchar(64).primary(), name: t.varchar(255) },
+  { nonTenant: true },
+);
+```
+
+전체 전략은 [멀티테넌시](./multi-tenancy.md)를 참고하세요.
+
+## 실전 종합 예제
+
+위 기능 대부분을 결합한 블로그 사용자 엔티티:
+
+```typescript
+import { defineEntity, t, InferEntity } from "@stingerloom/orm";
+
+export const User = defineEntity(
+  "users",
+  {
+    id:        t.int().primary().generated(),
+    name:      t.varchar(50).validate([
+      { constraint: "notNull" },
+      { constraint: "minLength", value: 2 },
+      { constraint: "maxLength", value: 50 },
+    ]),
+    email:     t.varchar(255).index(),
+    phone:     t.varchar(20).nullable(),
+    isActive:  t.boolean().default(true),
+    profile:   t.json<{ bio?: string }>().nullable(),
+    version:   t.int().version(),
+    deletedAt: t.datetime().deletedAt(),
+    createdAt: t.datetime().createTimestamp(),
+    updatedAt: t.datetime().updateTimestamp(),
+  },
+  {
+    hooks: {
+      afterInsert(user) {
+        console.log(`User #${user.id} created`);
+      },
+    },
+  },
+);
+
+export type User = InferEntity<typeof User>;
+```
+
+**PostgreSQL DDL:**
+
+```sql
+CREATE TABLE "users" (
+  "id" SERIAL PRIMARY KEY,
+  "name" VARCHAR(50) NOT NULL,
+  "email" VARCHAR(255) NOT NULL,
+  "phone" VARCHAR(20),
+  "isActive" BOOLEAN NOT NULL DEFAULT TRUE,
+  "profile" JSON,
+  "version" INTEGER NOT NULL,
+  "deletedAt" TIMESTAMP,
+  "createdAt" TIMESTAMP NOT NULL,
+  "updatedAt" TIMESTAMP NOT NULL
+);
+CREATE INDEX "INDEX_users_email" ON "users" ("email");
+```
+
+```typescript
+// INSERT — version 자동 1, 타임스탬프 자동 설정, afterInsert 로깅:
+const u = await em.save(User, new User({ name: "Alice", email: "alice@example.com" }));
+
+// UPDATE — version 증가, updatedAt만 갱신:
+await em.save(User, { id: u.id, name: "Alice Smith", version: u.version });
+
+// 소프트 삭제 + 삭제 행을 자동 제외하는 쿼리:
+await em.softDelete(User, { id: u.id });
+await em.find(User);                       // WHERE "deletedAt" IS NULL
+await em.find(User, { withDeleted: true }); // 필터 없음
+```
 
 ## 데코레이터와 섞어 쓰기
 
-코드 우선 엔티티와 데코레이터 엔티티는 같은 메타데이터 파이프라인을 공유하므로, 공존할 수 있고 서로 관계를 맺을 수도 있어요:
+코드 우선과 데코레이터 엔티티는 같은 메타데이터 파이프라인을 공유하므로, 공존하고 서로 관계를 맺을 수 있어요:
 
 ```typescript
 @Entity()
@@ -223,4 +954,62 @@ export const Comment = defineEntity("comments", {
 });
 ```
 
-빌더 API는 점진적으로 도입하세요 — 새 엔티티는 코드 우선으로, 기존 데코레이터 엔티티는 손대지 않고요.
+빌더 API를 점진적으로 도입하세요 — 새 엔티티는 코드 우선으로, 기존 데코레이터 엔티티는 그대로 두면 돼요.
+
+## ColumnType 참조
+
+### 빌더 → TypeScript 타입
+
+| 빌더 | 추론 TS 타입 |
+| --- | --- |
+| `t.int()`, `t.integer()`, `t.bigint()`, `t.float()`, `t.double()`, `t.number()`, `t.decimal()` | `number` |
+| `t.varchar()`, `t.char()`, `t.text()`, `t.longtext()`, `t.uuid()` | `string` |
+| `t.boolean()` | `boolean` |
+| `t.datetime()`, `t.timestamp()`, `t.timestamptz()`, `t.date()` | `Date` |
+| `t.blob()` | `Buffer` |
+| `t.json<T>()`, `t.jsonb<T>()` | `T` (기본 `unknown`) |
+| `t.array<T>()` | `T[]` |
+| `t.enum([...])` | 리터럴 유니온 |
+| 모든 컬럼의 `.nullable()` | `T \| null`로 넓힘 |
+
+### 추상 타입 → 데이터베이스 타입
+
+각 추상 `ColumnType`은 드라이버가 구체적인 데이터베이스 타입으로 변환해요:
+
+| ColumnType | MySQL/MariaDB | PostgreSQL | SQLite |
+| --- | --- | --- | --- |
+| `varchar` | VARCHAR(n) | VARCHAR(n) | TEXT |
+| `int` / `number` | INT | INTEGER | INTEGER |
+| `float` | FLOAT | REAL | REAL |
+| `double` | DOUBLE | DOUBLE PRECISION | REAL |
+| `bigint` | BIGINT | BIGINT | INTEGER |
+| `boolean` | TINYINT(1) | BOOLEAN | INTEGER |
+| `datetime` | DATETIME | TIMESTAMP | TEXT |
+| `timestamp` | TIMESTAMP | TIMESTAMP | TEXT |
+| `timestamptz` | DATETIME | TIMESTAMPTZ | TEXT |
+| `date` | DATE | DATE | TEXT |
+| `text` | TEXT | TEXT | TEXT |
+| `longtext` | LONGTEXT | TEXT | TEXT |
+| `blob` | BLOB | BYTEA | BLOB |
+| `json` | JSON | JSON | TEXT |
+| `jsonb` | JSON | JSONB | TEXT |
+| `uuid` | CHAR(36) *(MariaDB 10.7+는 UUID)* | UUID | VARCHAR(36) |
+| `enum` | ENUM | (커스텀 ENUM) | TEXT |
+
+## 트러블슈팅
+
+**관계 필드가 항상 `undefined`예요.** 관계는 선택적이고 지연 로딩이에요 — 쿼리에서 `relations: ["author"]`로 요청하세요. 없으면 필드는 로드되지 않아요.
+
+**FK 컬럼이 테이블에 없어요.** `manyToOne`/소유측 `oneToOne`은 자체 FK 컬럼을 만들지 않아요. 실제 컬럼(`authorId: t.int().name("author_id")`)으로 선언하고 `joinColumn`을 가리키게 하거나, 관계 옵션에 `relationColumn`을 넘기세요.
+
+**생명주기 훅이 실행되지 않아요.** 훅은 인스턴스에서 실행돼요. 평범한 객체 리터럴이 아니라 `new MyEntity({ … })`를 저장하세요 — [생명주기 훅](#생명주기-훅)을 참고하세요.
+
+**계산 컬럼이 생성된 테이블에 없어요.** `GENERATED ALWAYS AS` DDL은 런타임 `synchronize`가 아니라 스키마 제너레이터(마이그레이션 CLI)에서 나와요 — 마이그레이션을 생성하세요. 데코레이터 `@ComputedColumn`과 동일해요.
+
+**정말 데코레이터 없이 동작하나요?** 모든 엔티티를 `defineEntity`(또는 `EntitySchema`)로 정의하고 dry 동기화를 실행하세요 — 데이터베이스를 건드리지 않고 실행*하려는* DDL을 로깅하므로, 컴파일러가 내보낸 메타데이터 없이 모든 컬럼·인덱스·관계가 해석됐는지 확인할 수 있어요:
+
+```typescript
+await em.register({ entities: [User, Post, /* … */], synchronize: "dry-run" });
+```
+
+데코레이터 → 빌더/`EntitySchema` 전체 매핑 — 트랜잭션과 데코레이터 없는 NestJS 주입 포함 — 은 [데코레이터 없이 사용하기](./decorator-free.md)를 참고하세요.

--- a/src/core/CascadeHandler.ts
+++ b/src/core/CascadeHandler.ts
@@ -36,7 +36,11 @@ export class CascadeHandler {
       if (hook.event !== event) continue;
       const method = (item as any)[hook.methodName];
       if (typeof method === "function") {
-        await method.call(item);
+        // Pass `item` both as `this` and as the first argument. Decorator hook
+        // methods read `this` and ignore the extra arg; decorator-free hook
+        // functions (defineEntity `hooks: { beforeInsert: (e) => … }`) can take
+        // the entity as a parameter instead of relying on `this`.
+        await method.call(item, item);
       }
     }
   }

--- a/src/schema/builders.ts
+++ b/src/schema/builders.ts
@@ -329,7 +329,12 @@ export const t = {
   // ── computed ─────────────────────────────────────────────────────────────
   computed: <T = unknown>(
     expression: ComputedColumnOption["expression"],
-    options?: { stored?: boolean; type?: ColumnType },
+    options?: {
+      stored?: boolean;
+      type?: ColumnType;
+      length?: number;
+      nullable?: boolean;
+    },
   ) => new ComputedBuilder<T>({ expression, ...options }),
 };
 

--- a/src/schema/defineEntity.ts
+++ b/src/schema/defineEntity.ts
@@ -50,7 +50,7 @@ export type InferShape<Cols extends EntityColumns> = Prettify<
  * (usable everywhere the ORM expects an entity target) whose instance type is
  * the inferred row shape, so `InferEntity<typeof X>` recovers it.
  */
-export type EntityClass<Shape> = (new (...args: any[]) => Shape) & {
+export type EntityClass<Shape> = (new (init?: Partial<Shape>) => Shape) & {
   /** Phantom brand carrying the inferred shape. Absent at runtime. */
   readonly __stinger_shape?: Shape;
 };
@@ -71,8 +71,19 @@ export type InferEntity<C> = C extends new (...args: any[]) => infer S
   ? S
   : never;
 
+/**
+ * A decorator-free lifecycle hook. Receives the entity instance both as `this`
+ * and as the first argument, so you can write either `function () { this.x }`
+ * or `(e) => { e.x }`. The instance must be created with the entity class (e.g.
+ * `new User({ … })`) for the hook to fire — see {@link defineEntity}.
+ */
+export type EntityHookFn<Shape> = (
+  this: Shape,
+  entity: Shape,
+) => void | Promise<void>;
+
 /** Advanced, low-frequency options for {@link defineEntity}. */
-export interface DefineEntityOptions {
+export interface DefineEntityOptions<Shape = any> {
   /** Database table name. Defaults to the first `defineEntity` argument. */
   tableName?: string;
   /** Composite / advanced indexes. */
@@ -81,8 +92,32 @@ export interface DefineEntityOptions {
   uniqueIndexes?: { columns: string[]; name?: string }[];
   /** Full-text search indexes. */
   fullTextIndexes?: { columns: string[]; name?: string; language?: string }[];
-  /** Lifecycle hooks → method names on a base class (rarely used decorator-free). */
-  hooks?: Partial<Record<HookEvent, string>>;
+  /**
+   * Lifecycle hooks (decorator-free `@BeforeInsert` … `@AfterDelete`). Each
+   * event maps to either an inline function or the name of a method on the
+   * entity's prototype. Hooks fire on entity **instances** — create one with
+   * `new MyEntity({ … })` (the minted constructor accepts a partial) so the
+   * hook method is present on the saved object.
+   *
+   * @example
+   * ```ts
+   * const Article = defineEntity("articles", {
+   *   id:    t.int().primary().generated(),
+   *   title: t.varchar(200),
+   *   slug:  t.varchar(200).nullable(),
+   * }, {
+   *   hooks: {
+   *     beforeInsert(e) {
+   *       e.slug ??= e.title.toLowerCase().replace(/\s+/g, "-");
+   *     },
+   *   },
+   * });
+   *
+   * await em.save(Article, new Article({ title: "Hello World" }));
+   * // slug === "hello-world"
+   * ```
+   */
+  hooks?: Partial<Record<HookEvent, string | EntityHookFn<Shape>>>;
   /** Excludes this entity from the `"tenant_column"` strategy. */
   nonTenant?: boolean;
 }
@@ -92,11 +127,50 @@ export interface DefineEntityOptions {
  * derives the entity/table name from `target.name`) treats it like a normal
  * decorated class. The computed-property trick is the standard way to give a
  * dynamically created class a real name.
+ *
+ * The constructor accepts an optional partial initializer and copies it onto
+ * the instance, so `new User({ name: "Ada" })` yields a typed, hook-capable
+ * instance — the decorator-free counterpart to `Object.assign(new User(), …)`.
  */
 function mintEntityClass(name: string): ClazzType {
   const ident = /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(name) ? name : "StingerEntity";
-  const holder: Record<string, ClazzType> = { [ident]: class {} };
+  const holder: Record<string, ClazzType> = {
+    [ident]: class {
+      constructor(init?: Record<string, unknown>) {
+        if (init) Object.assign(this, init);
+      }
+    },
+  };
   return holder[ident];
+}
+
+/**
+ * Resolves the `hooks` option into the `{ event: methodName }` map the
+ * EntitySchema bridge expects. Inline functions are attached to the prototype
+ * under a stable, non-enumerable method name; string handlers are passed
+ * through as-is (they name a method already on the class).
+ */
+function resolveHooks<Shape>(
+  target: ClazzType,
+  hooks: NonNullable<DefineEntityOptions<Shape>["hooks"]>,
+): Record<string, string> {
+  const map: Record<string, string> = {};
+  for (const [event, handler] of Object.entries(hooks)) {
+    if (!handler) continue;
+    if (typeof handler === "function") {
+      const methodName = `__stinger_hook_${event}`;
+      Object.defineProperty(target.prototype, methodName, {
+        value: handler,
+        writable: true,
+        configurable: true,
+        enumerable: false,
+      });
+      map[event] = methodName;
+    } else {
+      map[event] = handler;
+    }
+  }
+  return map;
 }
 
 /**
@@ -127,7 +201,7 @@ function mintEntityClass(name: string): ClazzType {
 export function defineEntity<Cols extends EntityColumns>(
   name: string,
   columns: Cols,
-  options: DefineEntityOptions = {},
+  options: DefineEntityOptions<InferShape<Cols>> = {},
 ): EntityClass<InferShape<Cols>> {
   const target = mintEntityClass(name);
 
@@ -157,6 +231,8 @@ export function defineEntity<Cols extends EntityColumns>(
     }
   }
 
+  const hooks = options.hooks ? resolveHooks(target, options.hooks) : undefined;
+
   const schemaOptions: EntitySchemaOptions<any> = {
     target,
     tableName: options.tableName ?? name,
@@ -172,7 +248,7 @@ export function defineEntity<Cols extends EntityColumns>(
     ...(options.fullTextIndexes
       ? { fullTextIndexes: options.fullTextIndexes }
       : {}),
-    ...(options.hooks ? { hooks: options.hooks as any } : {}),
+    ...(hooks && Object.keys(hooks).length ? { hooks: hooks as any } : {}),
     ...(options.nonTenant ? { nonTenant: true } : {}),
   };
 


### PR DESCRIPTION
## Motivation

The decorator-free entity docs (`define-entity.md`, 226 lines) were thin next to the decorator guide (`entities.md`, 1,828 lines). Worse, one feature documented for decorators — **lifecycle hooks** — was genuinely unreachable through `defineEntity`: the `hooks` option only accepted a method name, but the class `defineEntity` mints is empty, so a registered hook had nothing to call. So this PR closes the real parity gaps in code, then brings the docs up to the same depth.

## Code changes (real parity, not just docs)

- **Lifecycle hooks via `defineEntity`** — `hooks` now accepts inline functions (and still method-name strings), attached to the minted prototype as non-enumerable methods.
- **Constructor initializer** — the minted class accepts a partial (`new User({ ... })`), giving a typed, ergonomic way to build a hook-capable instance. Hooks fire only on instances that carry the prototype methods (same requirement decorators have).
- **`CascadeHandler.runHooks`** passes the entity as the first argument too (`method.call(item, item)`), so a hook function can take `(entity)` instead of relying on `this`. Backward-compatible — decorator hook methods ignore the extra arg.
- **`t.computed()`** gains `nullable` / `length`, matching `@ComputedColumn`.
- Export the `EntityHookFn` type.

## Docs

- Rewrote `docs/define-entity.md` and `docs/ko/define-entity.md` to the depth of the decorator guide: the *why* + generated PostgreSQL/MySQL DDL + SQL behavior for every feature — column types/modifiers, primary keys (generated/manual/composite), transformers, indexes (single/composite/advanced/full-text/JSON-path), optimistic locking, soft delete, timestamps, computed columns, validation, lifecycle hooks, relations, inheritance (via `EntitySchema`), tenant columns, a full real-world example, decorator interop, a ColumnType reference, and troubleshooting.
- EN/KO are structurally identical (41 headings, 55 code blocks each); all internal anchors verified against the built HTML.
- Accurately documents that computed columns render via the migration generator, not the runtime `synchronize` path — identical to `@ComputedColumn` (a shared, pre-existing limitation, so no behavior change).

## Tests

- `__tests__/unit/define-entity.test.ts` — hooks (registration, firing, string handler), constructor initializer, computed options pass-through, and `GENERATED ALWAYS AS` DDL via `SchemaGenerator`.
- `__tests__/integration/sqlite/define-entity-e2e.test.ts` — hook fires on a saved `new Entity()` instance; `t.computed()` column excluded from the INSERT.
- Full unit suite: **5,303 passed / 0 failures**. CJS+ESM build and VitePress docs build both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)