### PR TITLE
fix(core): reject empty-string database for server dialects in config validation

### DIFF
--- a/__tests__/unit/database-client-options-validation.test.ts
+++ b/__tests__/unit/database-client-options-validation.test.ts
@@ -1,0 +1,76 @@
+import "reflect-metadata";
+import {
+  DatabaseClientOptions,
+  ServerDatabaseClientOptions,
+  validateDatabaseClientOptions,
+} from "../../src/core/DatabaseClientOptions";
+
+describe("validateDatabaseClientOptions - database field", () => {
+  const serverBase: ServerDatabaseClientOptions = {
+    type: "postgres",
+    host: "localhost",
+    port: 5432,
+    username: "user",
+    password: "pass",
+    database: "testdb",
+    entities: [],
+  };
+
+  it("should accept a non-empty database name", () => {
+    expect(() => validateDatabaseClientOptions(serverBase)).not.toThrow();
+  });
+
+  it("should reject a missing database (undefined) as required", () => {
+    const options = { ...serverBase } as Partial<ServerDatabaseClientOptions>;
+    delete options.database;
+    expect(() =>
+      validateDatabaseClientOptions(options as DatabaseClientOptions),
+    ).toThrow(/'database' is required/);
+  });
+
+  it.each(["postgres", "mysql", "mariadb"] as const)(
+    "should reject an empty-string database for %s",
+    (type) => {
+      const port = type === "postgres" ? 5432 : 3306;
+      expect(() =>
+        validateDatabaseClientOptions({
+          ...serverBase,
+          type,
+          port,
+          database: "",
+        }),
+      ).toThrow(/'database' must not be empty/);
+    },
+  );
+
+  it("should not raise a duplicate error when database is undefined (required only)", () => {
+    const options = { ...serverBase } as Partial<ServerDatabaseClientOptions>;
+    delete options.database;
+    try {
+      validateDatabaseClientOptions(options as DatabaseClientOptions);
+      fail("expected validation to throw");
+    } catch (e) {
+      const message = (e as Error).message;
+      expect(message).toContain("'database' is required");
+      expect(message).not.toContain("must not be empty");
+    }
+  });
+
+  it("should still allow an empty-string database for sqlite (anonymous temp db)", () => {
+    const options: DatabaseClientOptions = {
+      type: "sqlite",
+      database: "",
+      entities: [],
+    };
+    expect(() => validateDatabaseClientOptions(options)).not.toThrow();
+  });
+
+  it("should allow :memory: database for sqlite", () => {
+    const options: DatabaseClientOptions = {
+      type: "sqlite",
+      database: ":memory:",
+      entities: [],
+    };
+    expect(() => validateDatabaseClientOptions(options)).not.toThrow();
+  });
+});

--- a/src/core/DatabaseClientOptions.ts
+++ b/src/core/DatabaseClientOptions.ts
@@ -426,6 +426,13 @@ export function validateDatabaseClientOptions(
     options.type === "mariadb" ||
     options.type === "postgres"
   ) {
+    // An empty database name is never valid for a server database. The generic
+    // `database` check above intentionally accepts "" (SQLite treats it as an
+    // anonymous temporary database), so reject it explicitly here.
+    if (options.database === "") {
+      errors.push(`'database' must not be empty for ${options.type}.`);
+    }
+
     if (!options.host) {
       errors.push(`'host' is required for ${options.type}.`);
     } else if (typeof options.host !== "string") {


### PR DESCRIPTION
## Summary

`validateDatabaseClientOptions()` silently accepted `database: ""` for `mysql` / `mariadb` / `postgres`. An empty database name is never valid for a server dialect, so the misconfiguration slips past runtime validation and only surfaces later as a confusing connection-time error.

## Root cause

The generic required-check special-cases the empty string:

```ts
if (!options.database && options.database !== "") {
  errors.push("'database' is required.");
}
```

`!options.database` is true for `""`, but `&& options.database !== ""` is false, so `""` skips the required-check, and the following `typeof "" === "string"` type-check passes too. The empty string is therefore accepted as a valid database.

This exemption is intentional for SQLite, where better-sqlite3 treats `""` as an anonymous temporary on-disk database. It should not apply to server dialects.

## Fix

Add a server-specific check that rejects `""` while leaving the generic required-check and SQLite's empty-string behavior untouched:

```ts
if (options.database === "") {
  errors.push(`'database' must not be empty for ${options.type}.`);
}
```

- `undefined` still reports only the `'database' is required` error (no duplicate).
- SQLite `""` (anonymous temp db) and `:memory:` remain valid.

## Tests

New `__tests__/unit/database-client-options-validation.test.ts` (7 cases): server-dialect empty-string rejection for postgres/mysql/mariadb, no duplicate error on undefined, SQLite empty-string and `:memory:` still allowed. Existing `ssl-options` suite regresses clean. 24 passed.