### PR TITLE
fix(postgres): emit ENUM value literals as E'' escape strings

### DIFF
--- a/__tests__/unit/schema-diff-enum-sync.test.ts
+++ b/__tests__/unit/schema-diff-enum-sync.test.ts
@@ -252,7 +252,7 @@ describe("SchemaDiffMigrationGenerator — ENUM DDL generation", () => {
     };
 
     const { up } = generator.dryRun(diff, "postgres");
-    expect(up[0]).toBe(`CREATE TYPE "user_role" AS ENUM ('admin', 'user', 'guest')`);
+    expect(up[0]).toBe(`CREATE TYPE "user_role" AS ENUM (E'admin', E'user', E'guest')`);
   });
 
   it("should generate ALTER TYPE ADD VALUE IF NOT EXISTS for updated enums", () => {
@@ -273,8 +273,36 @@ describe("SchemaDiffMigrationGenerator — ENUM DDL generation", () => {
     };
 
     const { up } = generator.dryRun(diff, "postgres");
-    expect(up).toContain(`ALTER TYPE "user_role" ADD VALUE IF NOT EXISTS 'moderator'`);
-    expect(up).toContain(`ALTER TYPE "user_role" ADD VALUE IF NOT EXISTS 'editor'`);
+    expect(up).toContain(`ALTER TYPE "user_role" ADD VALUE IF NOT EXISTS E'moderator'`);
+    expect(up).toContain(`ALTER TYPE "user_role" ADD VALUE IF NOT EXISTS E'editor'`);
+  });
+
+  it("should emit E'' escape-string literals so backslashes are not corrupted", () => {
+    // Under the default `standard_conforming_strings = on`, a plain '...'
+    // literal treats a backslash as a literal character, so the doubled
+    // backslash produced by escapeEnumValue would be stored verbatim. The E''
+    // prefix forces escape-string semantics, so E'a\\b' denotes the value
+    // `a\b` regardless of the server setting.
+    const diff = {
+      addTables: [],
+      dropTables: [],
+      addColumns: [],
+      dropColumns: [],
+      alterColumns: [],
+      enumChanges: [
+        {
+          enumName: "path_kind",
+          addValues: ["a\\b", "quote's"],
+          removeValues: [],
+          isNew: true,
+        },
+      ],
+    };
+
+    const { up } = generator.dryRun(diff, "postgres");
+    expect(up[0]).toBe(
+      `CREATE TYPE "path_kind" AS ENUM (E'a\\\\b', E'quote''s')`,
+    );
   });
 
   it("should generate a warning comment for removed enum values", () => {

--- a/src/core/generators/SchemaDiffMigrationGenerator.ts
+++ b/src/core/generators/SchemaDiffMigrationGenerator.ts
@@ -27,6 +27,21 @@ function escapeEnumValue(val: string): string {
 }
 
 /**
+ * Renders a value as a PostgreSQL escape-string literal (`E'...'`).
+ *
+ * escapeEnumValue doubles backslashes to keep the literal closed, which is
+ * only correct under escape-string semantics. In a plain `'...'` literal with
+ * the default `standard_conforming_strings = on`, a backslash is literal, so
+ * the doubled backslash would be stored verbatim and corrupt any enum value
+ * containing a `\`. The `E'...'` prefix forces escape-string semantics
+ * regardless of the server setting. Postgres-only (MySQL inline `ENUM(...)`
+ * keeps the plain `'...'` form).
+ */
+function pgEnumLiteral(val: string): string {
+  return `E'${escapeEnumValue(val)}'`;
+}
+
+/**
  * Generates a Migration TypeScript file from a SchemaDiffResult.
  */
 export class SchemaDiffMigrationGenerator {
@@ -350,15 +365,14 @@ export class SchemaDiffMigrationGenerator {
 
     if (ec.isNew) {
       const valuesList = ec.addValues
-        .map((v) => `'${escapeEnumValue(v)}'`)
+        .map((v) => pgEnumLiteral(v))
         .join(", ");
       sqls.push(`CREATE TYPE ${escapedName} AS ENUM (${valuesList})`);
     } else {
       // Add new values with IF NOT EXISTS
       for (const val of ec.addValues) {
-        const escapedVal = escapeEnumValue(val);
         sqls.push(
-          `ALTER TYPE ${escapedName} ADD VALUE IF NOT EXISTS '${escapedVal}'`,
+          `ALTER TYPE ${escapedName} ADD VALUE IF NOT EXISTS ${pgEnumLiteral(val)}`,
         );
       }
       // Removed values: PostgreSQL cannot remove enum values — emit a warning comment

--- a/src/dialects/postgres/PostgresDriver.ts
+++ b/src/dialects/postgres/PostgresDriver.ts
@@ -25,6 +25,23 @@ import { escapeSqlLiteral } from "../../utils/escapeSqlLiteral";
 const escapeEnumValue = escapeSqlLiteral;
 
 /**
+ * Renders a value as a PostgreSQL escape-string literal (`E'...'`).
+ *
+ * `escapeSqlLiteral` doubles backslashes (`\` → `\\`) to stop a trailing
+ * backslash from swallowing the closing quote. That escaping is only correct
+ * when the literal is interpreted with escape-string semantics. In a plain
+ * `'...'` literal under the default `standard_conforming_strings = on`, a
+ * backslash is a literal character, so the doubled backslash would be stored
+ * verbatim — corrupting any ENUM value that contains a `\`. Wrapping the
+ * escaped value in `E'...'` forces escape-string semantics regardless of the
+ * server's `standard_conforming_strings` setting, keeping the value correct
+ * (GUC on) and injection-safe (GUC off).
+ */
+function pgStringLiteral(value: string): string {
+  return `E'${escapeEnumValue(value)}'`;
+}
+
+/**
  * SQL driver implementation for PostgreSQL.
  * Generates queries compatible with PostgreSQL's DDL/DML syntax.
  *
@@ -459,9 +476,8 @@ export class PostgresDriver implements ISqlDriver {
 
       for (const val of values) {
         if (!existingValues.has(val)) {
-          const escaped = escapeEnumValue(val);
           await this.connector.query(
-            `ALTER TYPE ${this.wrapQualified(enumName)} ADD VALUE IF NOT EXISTS '${escaped}'`,
+            `ALTER TYPE ${this.wrapQualified(enumName)} ADD VALUE IF NOT EXISTS ${pgStringLiteral(val)}`,
           );
         }
       }
@@ -479,7 +495,7 @@ export class PostgresDriver implements ISqlDriver {
     }
 
     const escapedValues = values
-      .map((v) => `'${escapeEnumValue(v)}'`)
+      .map((v) => pgStringLiteral(v))
       .join(", ");
 
     return this.connector.query(
@@ -523,13 +539,13 @@ export class PostgresDriver implements ISqlDriver {
     value: string,
     placement?: { before?: string; after?: string },
   ): Promise<any> {
-    const escaped = `'${escapeEnumValue(value)}'`;
+    const escaped = pgStringLiteral(value);
     let suffix = "";
 
     if (placement?.before) {
-      suffix = ` BEFORE '${escapeEnumValue(placement.before)}'`;
+      suffix = ` BEFORE ${pgStringLiteral(placement.before)}`;
     } else if (placement?.after) {
-      suffix = ` AFTER '${escapeEnumValue(placement.after)}'`;
+      suffix = ` AFTER ${pgStringLiteral(placement.after)}`;
     }
 
     return this.connector.query(
@@ -558,7 +574,7 @@ export class PostgresDriver implements ISqlDriver {
       );
     }
     return this.connector.query(
-      `ALTER TYPE ${this.wrapQualified(enumName)} RENAME VALUE '${escapeEnumValue(oldValue)}' TO '${escapeEnumValue(newValue)}'`,
+      `ALTER TYPE ${this.wrapQualified(enumName)} RENAME VALUE ${pgStringLiteral(oldValue)} TO ${pgStringLiteral(newValue)}`,
     );
   }
 


### PR DESCRIPTION
## Summary

PostgreSQL ENUM DDL interpolated values into plain `'...'` literals while `escapeSqlLiteral` / `escapeEnumValue` doubles backslashes (`\` → `\\`). That doubling is only correct under escape-string semantics.

Under the default `standard_conforming_strings = on`, a backslash is a literal character inside `'...'`, so the doubled backslash was **stored verbatim** — any ENUM value containing a backslash (e.g. a Windows-path enum member `C:\logs`) was silently corrupted to `C:\\logs`, and later inserts of the original value would fail to match the type. Under `standard_conforming_strings = off` the doubling is instead **required** to keep the literal closed.

## Fix

Wrap the escaped value in an `E'...'` escape-string literal, which forces escape-string semantics regardless of the server's `standard_conforming_strings` setting:

- `E'a\\b'` reliably denotes `a\b` (GUC on → no longer corrupted)
- trailing-backslash injection still prevented (GUC off → literal stays closed)

Normal values are unaffected: `E'admin'` ≡ `'admin'`.

## Scope

- **Runtime driver path** (`PostgresDriver`): `createEnumType`, `addEnumValue` (incl. `BEFORE`/`AFTER` placement), `renameEnumValue` — via a new `pgStringLiteral()` helper.
- **Migration-generator path** (`SchemaDiffMigrationGenerator.buildEnumUpSql`): `CREATE TYPE ... AS ENUM`, `ALTER TYPE ... ADD VALUE` — via a new `pgEnumLiteral()` helper.
- **Left unchanged (correct as-is):**
  - MySQL inline `ENUM(...)` column types (`SchemaRegistrar`, `renderColumnType`) — MySQL's default `NO_BACKSLASH_ESCAPES = OFF` already gives `'...'` escape-string semantics.
  - `to_tsvector('lang', ...)` language literal — validated against `[A-Za-z0-9_]`, so it can never contain a backslash.

## Tests

- Updated `schema-diff-enum-sync` expectations to the `E'...'` form (normal values, semantically identical).
- Added a regression test asserting backslash and single-quote enum values render as `E'a\\b'` / `E'quote''s'`.
- Full typecheck clean; `-t enum` filter across all 280 suites → 70 passed, 0 failed.