### PR TITLE
fix(core/buffer): repair WriteBuffer bulk DML, read cache, and flush-rollback data loss

### DIFF
--- a/__tests__/integration/sqlite/buffer-bulk-dml.test.ts
+++ b/__tests__/integration/sqlite/buffer-bulk-dml.test.ts
@@ -1,0 +1,172 @@
+/**
+ * SQLite In-Memory: WriteBuffer bulk DML (updateMany / deleteMany) against a
+ * real database.
+ *
+ * Regression for the audited FlushExecutor bug: executeBulkUpdate /
+ * executeBulkDelete hand-rolled `col = ?` SQL by iterating
+ * `Object.entries(where)`. That path:
+ *   1. bound an operator object (`{ gte: 18 }`) directly as a `?` parameter,
+ *      producing broken SQL that matched nothing (or threw),
+ *   2. used the entity PROPERTY name as the column name, ignoring the active
+ *      NamingStrategy — so `displayName` emitted `"displayName" = ?` instead of
+ *      `"display_name" = ?`, failing on a snake_cased schema.
+ *
+ * The fix delegates both to EntityManager.update / EntityManager.delete, the
+ * single canonical write path that already understands operator WHERE clauses,
+ * NamingStrategy column mapping, and tenant scoping.
+ *
+ * All assertions read back through `em.find` (which always hits the DB and
+ * never the buffer's identity map) so we verify the real row state, not the
+ * in-memory objects.
+ */
+
+import "reflect-metadata";
+import {
+  createTestConnection,
+  type TestConnectionResult,
+} from "../helpers/test-connection";
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+} from "../../../src";
+import { SnakeNamingStrategy } from "../../../src/core/generators/SnakeNamingStrategy";
+import { bufferPlugin } from "../../../src/core/plugin/buffer/bufferPlugin";
+import type { WriteBuffer } from "../../../src/core/plugin/buffer/WriteBuffer";
+import { getScannerInstance } from "../../../src/scanner/ScannerContainer";
+import { ColumnScanner } from "../../../src/scanner";
+
+function shortName(prefix: string): string {
+  return `${prefix}_${String(Date.now()).slice(-7)}`;
+}
+
+describe("[Integration] SQLite: WriteBuffer bulk DML (updateMany / deleteMany)", () => {
+  let conn: TestConnectionResult;
+  let User: new () => any;
+
+  beforeAll(async () => {
+    const usersClassName = shortName("BulkUser");
+
+    conn = await createTestConnection(
+      {
+        type: "sqlite",
+        database: ":memory:",
+        synchronize: true,
+        logging: false,
+        namingStrategy: new SnakeNamingStrategy(),
+        plugins: [bufferPlugin()],
+      },
+      () => {
+        getScannerInstance(ColumnScanner).clear();
+
+        const UC = class {} as any;
+        Object.defineProperty(UC, "name", { value: usersClassName });
+        Reflect.defineMetadata("design:type", Number, UC.prototype, "id");
+        PrimaryGeneratedColumn()(UC.prototype, "id");
+        Reflect.defineMetadata("design:type", Number, UC.prototype, "age");
+        Column()(UC.prototype, "age");
+        Reflect.defineMetadata("design:type", String, UC.prototype, "role");
+        Column({ nullable: true })(UC.prototype, "role");
+        // camelCase property → snake_case column (`display_name`) under
+        // SnakeNamingStrategy. Exercises NamingStrategy mapping in bulk DML.
+        Reflect.defineMetadata("design:type", String, UC.prototype, "displayName");
+        Column({ nullable: true })(UC.prototype, "displayName");
+        Entity()(UC);
+
+        User = UC;
+        return { entities: [UC] };
+      },
+    );
+  }, 30000);
+
+  afterAll(async () => {
+    if (conn) await conn.cleanup();
+  });
+
+  beforeEach(async () => {
+    // Reset table between tests via the buffer-free EntityManager.
+    await conn.em.clear(User);
+    await conn.em.save(User, { age: 10, role: "minor", displayName: "Ten" } as any);
+    await conn.em.save(User, { age: 18, role: "minor", displayName: "Eighteen" } as any);
+    await conn.em.save(User, { age: 40, role: "minor", displayName: "Forty" } as any);
+  });
+
+  async function allByAge(): Promise<any[]> {
+    const rows = await conn.em.find(User, { orderBy: { age: "ASC" } as any });
+    return rows;
+  }
+
+  it("updateMany with an operator WHERE ({ gte }) updates only matching rows", async () => {
+    const buf: WriteBuffer = (conn.em as any).buffer();
+
+    buf.updateMany(User, { where: { age: { gte: 18 } }, set: { role: "adult" } });
+    await buf.flush();
+
+    const rows = await allByAge();
+    const byAge = Object.fromEntries(rows.map((r) => [r.age, r.role]));
+    expect(byAge[10]).toBe("minor"); // below 18 — untouched
+    expect(byAge[18]).toBe("adult");
+    expect(byAge[40]).toBe("adult");
+  });
+
+  it("deleteMany with an operator WHERE ({ lt }) deletes only matching rows", async () => {
+    const buf: WriteBuffer = (conn.em as any).buffer();
+
+    buf.deleteMany(User, { age: { lt: 18 } });
+    await buf.flush();
+
+    const rows = await allByAge();
+    expect(rows.map((r) => r.age)).toEqual([18, 40]);
+  });
+
+  it("updateMany maps camelCase properties to snake_case columns (SET + WHERE)", async () => {
+    const buf: WriteBuffer = (conn.em as any).buffer();
+
+    // Both the SET target (displayName → display_name) and the WHERE key
+    // (displayName) must be NamingStrategy-mapped, or SQLite raises
+    // "no such column: displayName".
+    buf.updateMany(User, {
+      where: { displayName: "Forty" },
+      set: { displayName: "Renamed" },
+    });
+    await buf.flush();
+
+    const rows = await allByAge();
+    const names = rows.map((r) => r.displayName).sort();
+    expect(names).toEqual(["Eighteen", "Renamed", "Ten"]);
+  });
+
+  it("updateMany with an equality WHERE syncs the tracked in-memory instance", async () => {
+    const buf: WriteBuffer = (conn.em as any).buffer();
+
+    const rows = await buf.find(User, { orderBy: { age: "ASC" } as any });
+    const forty = rows.find((r: any) => r.age === 40);
+
+    buf.updateMany(User, { where: { age: 40 }, set: { role: "senior" } });
+    await buf.flush();
+
+    // Equality WHERE → precise in-memory sync.
+    expect(forty.role).toBe("senior");
+  });
+
+  it("operator-WHERE updateMany does not leave a stale tracked instance behind", async () => {
+    const buf: WriteBuffer = (conn.em as any).buffer();
+
+    // Resolve the age=40 row's PK dynamically (autoincrement drifts across tests).
+    const [forty] = await conn.em.find(User, { where: { age: 40 } as any });
+    const id40 = forty.id;
+
+    // Track it in the buffer's identity map via a PK lookup (cacheable).
+    const tracked = await buf.findOne(User, { where: { id: id40 } as any });
+    expect(tracked).not.toBeNull();
+    expect((tracked as any).role).toBe("minor");
+
+    buf.updateMany(User, { where: { age: { gte: 40 } }, set: { role: "adult" } });
+    await buf.flush();
+
+    // The DB row is now role="adult". A subsequent PK-cache probe must not
+    // serve a stale identity-map hit still carrying role="minor".
+    const reread = await buf.findOne(User, { where: { id: id40 } as any });
+    expect(reread!.role).toBe("adult");
+  });
+});

--- a/__tests__/integration/sqlite/buffer-flush-rollback.test.ts
+++ b/__tests__/integration/sqlite/buffer-flush-rollback.test.ts
@@ -1,0 +1,169 @@
+/**
+ * SQLite In-Memory: WriteBuffer flush-failure state restoration.
+ *
+ * Regression for the audited rollback bug: flush() mutates instances in place
+ * (writes back the generated PK, increments @Version, sets timestamps) as each
+ * INSERT/UPDATE runs. When a LATER statement in the same flush fails, the whole
+ * transaction rolls back in the DB — but those in-memory mutations were not
+ * undone. The result:
+ *   - a persisted instance kept a PK for a row that no longer exists (ghost),
+ *   - a versioned instance kept an incremented @Version, so retrying the flush
+ *     raised a spurious OptimisticLockError (WHERE version = <already-bumped>).
+ *
+ * The fix snapshots each mutated instance's column values before the flush
+ * transaction and restores them if the transaction throws, leaving exactly the
+ * pre-flush (user-edited) state so a retry behaves as if the first flush never
+ * ran.
+ *
+ * The mid-flush failure is forced by a flush-event listener that throws — a
+ * schema-independent way to abort the transaction AFTER the earlier
+ * INSERT/UPDATE has already mutated its instance in memory. (An earlier draft
+ * relied on a NOT NULL violation, but the constraint's enforcement proved
+ * fragile across the shared-singleton integration environment.)
+ */
+
+import "reflect-metadata";
+import {
+  createTestConnection,
+  type TestConnectionResult,
+} from "../helpers/test-connection";
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  Version,
+} from "../../../src";
+import { bufferPlugin } from "../../../src/core/plugin/buffer/bufferPlugin";
+import type { WriteBuffer } from "../../../src/core/plugin/buffer/WriteBuffer";
+import { getScannerInstance } from "../../../src/scanner/ScannerContainer";
+import { ColumnScanner } from "../../../src/scanner";
+
+function shortName(prefix: string): string {
+  return `${prefix}_${String(Date.now()).slice(-7)}`;
+}
+
+describe("[Integration] SQLite: WriteBuffer flush-failure state restoration", () => {
+  let conn: TestConnectionResult;
+  let Item: new () => any;
+  let Doc: new () => any;
+
+  beforeAll(async () => {
+    const itemName = shortName("RbItem");
+    const docName = shortName("RbDoc");
+
+    conn = await createTestConnection(
+      {
+        type: "sqlite",
+        database: ":memory:",
+        synchronize: true,
+        logging: false,
+        plugins: [bufferPlugin()],
+      },
+      () => {
+        getScannerInstance(ColumnScanner).clear();
+
+        const IC = class {} as any;
+        Object.defineProperty(IC, "name", { value: itemName });
+        Reflect.defineMetadata("design:type", Number, IC.prototype, "id");
+        PrimaryGeneratedColumn()(IC.prototype, "id");
+        Reflect.defineMetadata("design:type", String, IC.prototype, "name");
+        Column()(IC.prototype, "name");
+        Entity()(IC);
+        Item = IC;
+
+        const DC = class {} as any;
+        Object.defineProperty(DC, "name", { value: docName });
+        Reflect.defineMetadata("design:type", Number, DC.prototype, "id");
+        PrimaryGeneratedColumn()(DC.prototype, "id");
+        Reflect.defineMetadata("design:type", String, DC.prototype, "title");
+        Column()(DC.prototype, "title");
+        Reflect.defineMetadata("design:type", Number, DC.prototype, "version");
+        Version()(DC.prototype, "version");
+        Entity()(DC);
+        Doc = DC;
+
+        return { entities: [IC, DC] };
+      },
+    );
+  }, 30000);
+
+  afterAll(async () => {
+    if (conn) await conn.cleanup();
+  });
+
+  beforeEach(async () => {
+    await conn.em.clear(Item);
+    await conn.em.clear(Doc);
+  });
+
+  it("does not leave a ghost PK on a persisted instance when flush fails", async () => {
+    const buf: WriteBuffer = (conn.em as any).buffer();
+
+    const good = new Item();
+    good.name = "good";
+    const bad = new Item();
+    bad.name = "bad";
+
+    buf.persist(good);
+    buf.persist(bad);
+
+    // Abort the transaction at `bad`'s INSERT — AFTER `good` was inserted and
+    // its PK written back in memory. Schema-independent.
+    let failNext = true;
+    buf.onFlushEvent("preInsert", (e: any) => {
+      if (failNext && e.instance === bad) throw new Error("boom");
+    });
+
+    await expect(buf.flush()).rejects.toThrow("boom");
+
+    // The whole transaction rolled back — `good` must NOT keep a PK for a row
+    // that no longer exists.
+    expect(good.id).toBeUndefined();
+
+    // Nothing was actually committed.
+    const rows = await conn.em.find(Item);
+    expect(rows).toHaveLength(0);
+
+    // Retry (disarmed) succeeds and inserts exactly two rows.
+    failNext = false;
+    const result = await buf.flush();
+    expect(result.inserts).toBe(2);
+    const after = await conn.em.find(Item);
+    expect(after).toHaveLength(2);
+    expect(good.id).toBeDefined();
+  });
+
+  it("does not leave an incremented @Version when flush fails, so retry does not raise a false lock error", async () => {
+    // Seed a versioned row (version = 1).
+    const seeded = await conn.em.save(Doc, { title: "v1" } as any);
+    expect(seeded.version).toBe(1);
+
+    const buf: WriteBuffer = (conn.em as any).buffer();
+
+    // Track + dirty the seeded doc (its UPDATE will bump version 1 → 2).
+    const doc = await buf.findOne(Doc, { where: { id: seeded.id } as any });
+    (doc as any).title = "v2";
+
+    // Abort the transaction right after the doc's UPDATE — postUpdate fires
+    // once @Version has already been bumped in memory, so we can prove the
+    // rollback restores it.
+    let failNext = true;
+    buf.onFlushEvent("postUpdate", () => {
+      if (failNext) throw new Error("boom");
+    });
+
+    await expect(buf.flush()).rejects.toThrow("boom");
+
+    // In-memory version must be restored to 1 (rollback undid the DB bump).
+    expect((doc as any).version).toBe(1);
+
+    // Retry (disarmed) must succeed — a lingering version=2 would make the
+    // UPDATE's WHERE version=? miss and raise a spurious OptimisticLockError.
+    failNext = false;
+    await expect(buf.flush()).resolves.toBeDefined();
+
+    const reloaded = await conn.em.findOne(Doc, { where: { id: seeded.id } as any });
+    expect(reloaded!.title).toBe("v2");
+    expect(reloaded!.version).toBe(2);
+  });
+});

--- a/__tests__/integration/sqlite/buffer-read-consistency.test.ts
+++ b/__tests__/integration/sqlite/buffer-read-consistency.test.ts
@@ -1,0 +1,148 @@
+/**
+ * SQLite In-Memory: WriteBuffer identity-map read consistency.
+ *
+ * Regression for the audited cache-pollution bug: buf.findOne() / buf.find()
+ * unconditionally tracked whatever em returned, so a NON-CANONICAL read would
+ * poison the identity map for later canonical reads:
+ *
+ *   - Partial `select` — a row loaded with only some columns became the cached
+ *     instance; a later full PK findOne() returned that partial (missing
+ *     columns read back as undefined).
+ *   - `withDeleted` — a soft-deleted row got tracked; a later normal PK
+ *     findOne() (which must exclude trashed rows) returned the soft-deleted
+ *     instance from cache instead of null.
+ *
+ * The fix: non-canonical reads (select / withDeleted / onlyDeleted /
+ * withoutTenantScope) never create a NEW identity-map entry. They return the
+ * requested row as-is (or the already-tracked canonical instance if one
+ * exists), leaving the cache uncorrupted.
+ */
+
+import "reflect-metadata";
+import {
+  createTestConnection,
+  type TestConnectionResult,
+} from "../helpers/test-connection";
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  DeletedAt,
+} from "../../../src";
+import { bufferPlugin } from "../../../src/core/plugin/buffer/bufferPlugin";
+import type { WriteBuffer } from "../../../src/core/plugin/buffer/WriteBuffer";
+import { getScannerInstance } from "../../../src/scanner/ScannerContainer";
+import { ColumnScanner } from "../../../src/scanner";
+
+function shortName(prefix: string): string {
+  return `${prefix}_${String(Date.now()).slice(-7)}`;
+}
+
+describe("[Integration] SQLite: WriteBuffer read consistency (identity-map pollution)", () => {
+  let conn: TestConnectionResult;
+  let User: new () => any;
+
+  beforeAll(async () => {
+    const className = shortName("RcUser");
+
+    conn = await createTestConnection(
+      {
+        type: "sqlite",
+        database: ":memory:",
+        synchronize: true,
+        logging: false,
+        plugins: [bufferPlugin()],
+      },
+      () => {
+        getScannerInstance(ColumnScanner).clear();
+
+        const UC = class {} as any;
+        Object.defineProperty(UC, "name", { value: className });
+        Reflect.defineMetadata("design:type", Number, UC.prototype, "id");
+        PrimaryGeneratedColumn()(UC.prototype, "id");
+        Reflect.defineMetadata("design:type", String, UC.prototype, "name");
+        Column()(UC.prototype, "name");
+        Reflect.defineMetadata("design:type", String, UC.prototype, "email");
+        Column({ nullable: true })(UC.prototype, "email");
+        Reflect.defineMetadata("design:type", Date, UC.prototype, "deletedAt");
+        DeletedAt()(UC.prototype, "deletedAt");
+        Entity()(UC);
+
+        User = UC;
+        return { entities: [UC] };
+      },
+    );
+  }, 30000);
+
+  afterAll(async () => {
+    if (conn) await conn.cleanup();
+  });
+
+  beforeEach(async () => {
+    await conn.em.clear(User);
+  });
+
+  it("a partial-select read does not poison a later full PK read", async () => {
+    const saved = await conn.em.save(User, {
+      name: "Alice",
+      email: "alice@example.com",
+    } as any);
+    const buf: WriteBuffer = (conn.em as any).buffer();
+
+    // Non-canonical read: only id + name.
+    const partial = await buf.findOne(User, {
+      where: { id: saved.id } as any,
+      select: ["id", "name"] as any,
+    });
+    expect(partial).not.toBeNull();
+    expect((partial as any).email).toBeUndefined();
+
+    // Canonical full PK read must return every column, not the cached partial.
+    const full = await buf.findOne(User, { where: { id: saved.id } as any });
+    expect(full).not.toBeNull();
+    expect((full as any).email).toBe("alice@example.com");
+  });
+
+  it("a withDeleted read does not poison a later normal PK read", async () => {
+    const saved = await conn.em.save(User, {
+      name: "Bob",
+      email: "bob@example.com",
+    } as any);
+    await conn.em.softDelete(User, { id: saved.id } as any);
+
+    const buf: WriteBuffer = (conn.em as any).buffer();
+
+    // Non-canonical read: includes the soft-deleted row.
+    const trashed = await buf.findOne(User, {
+      where: { id: saved.id } as any,
+      withDeleted: true,
+    });
+    expect(trashed).not.toBeNull();
+
+    // A normal PK read must exclude trashed rows → null, not the cached
+    // soft-deleted instance.
+    const normal = await buf.findOne(User, { where: { id: saved.id } as any });
+    expect(normal).toBeNull();
+  });
+
+  it("an already-tracked full instance is returned by a later partial read (identity preserved)", async () => {
+    const saved = await conn.em.save(User, {
+      name: "Carol",
+      email: "carol@example.com",
+    } as any);
+    const buf: WriteBuffer = (conn.em as any).buffer();
+
+    // Canonical read first → tracked, full.
+    const full = await buf.findOne(User, { where: { id: saved.id } as any });
+    expect((full as any).email).toBe("carol@example.com");
+
+    // A later partial read returns the SAME tracked instance (still full),
+    // never a downgraded partial.
+    const partial = await buf.findOne(User, {
+      where: { id: saved.id } as any,
+      select: ["id", "name"] as any,
+    });
+    expect(partial).toBe(full);
+    expect((partial as any).email).toBe("carol@example.com");
+  });
+});

--- a/__tests__/unit/buffer-plugin.test.ts
+++ b/__tests__/unit/buffer-plugin.test.ts
@@ -3952,10 +3952,13 @@ describe("Buffer Plugin", () => {
   // ── Bulk DML ────────────────────────────────────────────────────
 
   describe("bulk DML", () => {
-    it("updateMany should queue and execute during flush", async () => {
+    it("updateMany should queue and delegate to em.update during flush", async () => {
       const em = createExtendedEm(User);
       jest.spyOn(em, "transaction").mockImplementation(async (cb) => cb(em as any));
-      const querySpy = jest.spyOn(em, "query").mockResolvedValue([]);
+      // Bulk UPDATE now delegates to the canonical EntityManager.update path
+      // (operator WHERE, NamingStrategy, tenant scoping) instead of hand-rolled
+      // `col = ?` SQL executed via em.query.
+      const updateSpy = jest.spyOn(em, "update").mockResolvedValue({ affected: 1 });
 
       const buf = em.buffer();
       buf.updateMany(User, { where: { email: "a@b.c" }, set: { name: "Updated" } });
@@ -3964,16 +3967,17 @@ describe("Buffer Plugin", () => {
 
       const result = await buf.flush();
       expect(result.updates).toBe(1);
-      expect(querySpy).toHaveBeenCalledWith(
-        expect.stringContaining("UPDATE"),
-        expect.arrayContaining(["Updated", "a@b.c"]),
+      expect(updateSpy).toHaveBeenCalledWith(
+        User,
+        { email: "a@b.c" },
+        { name: "Updated" },
       );
     });
 
-    it("deleteMany should queue and execute during flush", async () => {
+    it("deleteMany should queue and delegate to em.delete during flush", async () => {
       const em = createExtendedEm(User);
       jest.spyOn(em, "transaction").mockImplementation(async (cb) => cb(em as any));
-      const querySpy = jest.spyOn(em, "query").mockResolvedValue([]);
+      const deleteSpy = jest.spyOn(em, "delete").mockResolvedValue(undefined as any);
 
       const buf = em.buffer();
       buf.deleteMany(User, { email: "a@b.c" });
@@ -3982,10 +3986,7 @@ describe("Buffer Plugin", () => {
 
       const result = await buf.flush();
       expect(result.deletes).toBe(1);
-      expect(querySpy).toHaveBeenCalledWith(
-        expect.stringContaining("DELETE"),
-        expect.arrayContaining(["a@b.c"]),
-      );
+      expect(deleteSpy).toHaveBeenCalledWith(User, { email: "a@b.c" });
     });
 
     it("bulk queues should be included in preview", () => {
@@ -4232,7 +4233,7 @@ describe("Buffer Plugin", () => {
         Object.assign(new User(), { id: 1, name: "Alice", email: "a@b.c" }),
       );
       jest.spyOn(em, "transaction").mockImplementation(async (cb) => cb(em as any));
-      jest.spyOn(em, "query").mockResolvedValue([]);
+      jest.spyOn(em, "update").mockResolvedValue({ affected: 1 });
 
       const buf = em.buffer();
       const user = await buf.findOne(User, { where: { id: 1 } as any });
@@ -4255,7 +4256,7 @@ describe("Buffer Plugin", () => {
         Object.assign(new User(), { id: 1, name: "Alice", email: "a@b.c" }),
       );
       jest.spyOn(em, "transaction").mockImplementation(async (cb) => cb(em as any));
-      jest.spyOn(em, "query").mockResolvedValue([]);
+      jest.spyOn(em, "delete").mockResolvedValue(undefined as any);
 
       const buf = em.buffer();
       await buf.findOne(User, { where: { id: 1 } as any });
@@ -4278,7 +4279,7 @@ describe("Buffer Plugin", () => {
         Object.assign(new User(), { id: 2, name: "Bob", email: "b@b.c" }),
       );
       jest.spyOn(em, "transaction").mockImplementation(async (cb) => cb(em as any));
-      jest.spyOn(em, "query").mockResolvedValue([]);
+      jest.spyOn(em, "update").mockResolvedValue({ affected: 1 });
 
       const buf = em.buffer();
       const user1 = await buf.findOne(User, { where: { id: 1 } as any });

--- a/src/core/plugin/buffer/FlushExecutor.ts
+++ b/src/core/plugin/buffer/FlushExecutor.ts
@@ -325,64 +325,55 @@ export class FlushExecutor {
 
   /**
    * Execute a bulk UPDATE statement.
+   *
+   * Delegates to `EntityManager.update`, the single canonical write path, so
+   * operator WHERE clauses (`{ age: { gte: 18 } }`), NamingStrategy column
+   * mapping (camelCase property → snake_case column), tenant scoping, and
+   * `@UpdateTimestamp` injection are all handled uniformly. The previous
+   * hand-rolled `col = ?` builder bound operator objects directly as `?`
+   * parameters (broken SQL) and used the property name as the column name
+   * (ignoring the NamingStrategy).
    */
   async executeBulkUpdate(
     txEm: EntityManager,
     entry: BulkUpdateEntry,
   ): Promise<void> {
-    const entityMeta = Reflect.getMetadata(ENTITY_TOKEN, entry.entity);
-    const tableName = entityMeta?.name || entry.entity.name;
-    const wrappedTable = this.ctx.wrapTable(tableName);
-
-    const setClauses: string[] = [];
-    const params: any[] = [];
-
-    for (const [col, val] of Object.entries(entry.set)) {
-      setClauses.push(`${this.ctx.wrap(col)} = ?`);
-      params.push(val);
-    }
-
-    const whereClauses: string[] = [];
-    for (const [col, val] of Object.entries(entry.where)) {
-      whereClauses.push(`${this.ctx.wrap(col)} = ?`);
-      params.push(val);
-    }
-
-    const sql = `UPDATE ${wrappedTable} SET ${setClauses.join(", ")} WHERE ${whereClauses.join(" AND ")}`;
-    await txEm.query(sql, params);
+    await txEm.update(entry.entity, entry.where as any, entry.set as any);
   }
 
   /**
    * Execute a bulk DELETE statement.
+   *
+   * Delegates to `EntityManager.delete` for the same reasons as
+   * {@link executeBulkUpdate}: operator WHERE support, NamingStrategy column
+   * mapping, and tenant scoping via the canonical write path.
    */
   async executeBulkDelete(
     txEm: EntityManager,
     entry: BulkDeleteEntry,
   ): Promise<void> {
-    const entityMeta = Reflect.getMetadata(ENTITY_TOKEN, entry.entity);
-    const tableName = entityMeta?.name || entry.entity.name;
-    const wrappedTable = this.ctx.wrapTable(tableName);
-
-    const whereClauses: string[] = [];
-    const params: any[] = [];
-
-    for (const [col, val] of Object.entries(entry.where)) {
-      whereClauses.push(`${this.ctx.wrap(col)} = ?`);
-      params.push(val);
-    }
-
-    const sql = `DELETE FROM ${wrappedTable} WHERE ${whereClauses.join(" AND ")}`;
-    await txEm.query(sql, params);
+    await txEm.delete(entry.entity, entry.where as any);
   }
 
   /**
-   * After a bulk UPDATE, sync tracked in-memory instances that match
-   * the WHERE clause: apply SET values and re-snapshot.
+   * After a bulk UPDATE, reconcile the in-memory identity map with the DB.
+   *
+   * For a plain equality WHERE + plain scalar SET, matchesWhere() reproduces
+   * the DB's row selection exactly, so matching instances are synced in place
+   * (apply SET values + re-snapshot). For an operator/combinator WHERE (or a
+   * raw-`Sql` SET value) the row selection is resolved by the database and
+   * cannot be reproduced faithfully in memory — so every tracked instance of
+   * this entity is conservatively detached, forcing the next read to reload
+   * fresh instead of serving a stale identity-map hit.
    */
   syncTrackedAfterBulkUpdate(
     entry: BulkUpdateEntry,
     trackedEntries: Map<EntityInstance, TrackedEntry>,
   ): void {
+    if (!this.idMap.isPureEqualityWhere(entry.where) || !this.idMap.isPlainSetData(entry.set)) {
+      this.detachAllTrackedOfEntity(entry.entity, trackedEntries);
+      return;
+    }
     for (const tracked of trackedEntries.values()) {
       if (tracked.entity !== entry.entity) continue;
       if (!this.idMap.matchesWhere(tracked.instance, entry.where)) continue;
@@ -394,15 +385,21 @@ export class FlushExecutor {
   }
 
   /**
-   * After a bulk DELETE, evict tracked instances that match the WHERE clause
-   * from identityMap, trackedEntries, and stateMap.
+   * After a bulk DELETE, evict tracked instances whose rows were removed.
    *
-   * Fixed: builds identity key BEFORE deleting from trackedEntries (was O(n) bug).
+   * A plain equality WHERE evicts exactly the matching tracked instances; an
+   * operator/combinator WHERE conservatively detaches every tracked instance of
+   * this entity (the DB decided which rows were deleted, and keeping any stale
+   * identity-map entry risks a later phantom cache hit).
    */
   evictTrackedAfterBulkDelete(
     entry: BulkDeleteEntry,
     trackedEntries: Map<EntityInstance, TrackedEntry>,
   ): void {
+    if (!this.idMap.isPureEqualityWhere(entry.where)) {
+      this.detachAllTrackedOfEntity(entry.entity, trackedEntries);
+      return;
+    }
     const toEvict: EntityInstance[] = [];
     for (const tracked of trackedEntries.values()) {
       if (tracked.entity !== entry.entity) continue;
@@ -410,14 +407,25 @@ export class FlushExecutor {
       toEvict.push(tracked.instance);
     }
     for (const instance of toEvict) {
-      // Build identity key BEFORE deleting from trackedEntries (fix: was O(n) scan)
-      const tracked = trackedEntries.get(instance);
-      if (tracked) {
-        const key = this.idMap.buildIdentityKey(tracked.entity, instance, tracked.pkColumns);
-        this.idMap.identityMap.delete(key);
-      }
-      trackedEntries.delete(instance);
-      this.idMap.stateMap.delete(instance);
+      this.idMap.detachTracked(instance, trackedEntries);
+    }
+  }
+
+  /**
+   * Detach every tracked instance of a given entity class — used to
+   * conservatively invalidate the identity map after a bulk op whose WHERE
+   * clause cannot be matched precisely in memory.
+   */
+  private detachAllTrackedOfEntity(
+    entity: ClazzType<any>,
+    trackedEntries: Map<EntityInstance, TrackedEntry>,
+  ): void {
+    const toDetach: EntityInstance[] = [];
+    for (const tracked of trackedEntries.values()) {
+      if (tracked.entity === entity) toDetach.push(tracked.instance);
+    }
+    for (const instance of toDetach) {
+      this.idMap.detachTracked(instance, trackedEntries);
     }
   }
 

--- a/src/core/plugin/buffer/IdentityMapManager.ts
+++ b/src/core/plugin/buffer/IdentityMapManager.ts
@@ -318,12 +318,74 @@ export class IdentityMapManager {
 
   /**
    * Check if an entity instance matches a simple WHERE clause (equality check).
+   *
+   * Only meaningful for a plain equality map — guard with
+   * {@link isPureEqualityWhere} before calling for a WHERE that may contain
+   * operator objects or AND/OR/NOT combinators.
    */
   matchesWhere(instance: EntityInstance, where: ColumnValueMap): boolean {
     for (const [col, val] of Object.entries(where)) {
       if (instance[col] !== val) return false;
     }
     return true;
+  }
+
+  /**
+   * True iff `where` is a plain `{ col: scalar }` equality map that
+   * {@link matchesWhere} can evaluate exactly against an in-memory instance —
+   * no operator objects (`{ gte: 18 }`), arrays, or AND/OR/NOT combinators.
+   *
+   * Used to decide, after a bulk UPDATE/DELETE, whether the in-memory identity
+   * map can be synced precisely or must be conservatively invalidated (an
+   * operator WHERE is resolved by the database, and reproducing its exact row
+   * selection in memory risks diverging from the real result).
+   */
+  isPureEqualityWhere(where: ColumnValueMap): boolean {
+    for (const [key, val] of Object.entries(where)) {
+      if (key === "OR" || key === "AND" || key === "NOT") return false;
+      if (!this.isComparableScalar(val)) return false;
+    }
+    return true;
+  }
+
+  /**
+   * True iff every SET value is a plain scalar safe to assign onto an in-memory
+   * instance — excludes raw `Sql` expressions and other objects whose resulting
+   * value is only known after the database evaluates them.
+   */
+  isPlainSetData(set: ColumnValueMap): boolean {
+    for (const val of Object.values(set)) {
+      if (val === null || val === undefined) continue;
+      const t = typeof val;
+      if (t === "string" || t === "number" || t === "boolean" || t === "bigint") continue;
+      if (val instanceof Date) continue;
+      return false;
+    }
+    return true;
+  }
+
+  private isComparableScalar(val: unknown): boolean {
+    if (val === null) return true;
+    const t = typeof val;
+    return t === "string" || t === "number" || t === "boolean" || t === "bigint";
+  }
+
+  /**
+   * Remove a tracked instance from the identity map, tracked entries, and state
+   * map. The identity key is computed from the entry's own pkColumns before the
+   * entry is deleted, so this stays O(1) (no scan of the identity map).
+   */
+  detachTracked(
+    instance: EntityInstance,
+    trackedEntries: Map<EntityInstance, TrackedEntry>,
+  ): void {
+    const entry = trackedEntries.get(instance);
+    if (entry) {
+      const key = this.buildIdentityKey(entry.entity, instance, entry.pkColumns);
+      this.identityMap.delete(key);
+      trackedEntries.delete(instance);
+    }
+    this.stateMap.delete(instance);
   }
 
   /**

--- a/src/core/plugin/buffer/WriteBuffer.ts
+++ b/src/core/plugin/buffer/WriteBuffer.ts
@@ -217,6 +217,13 @@ export class WriteBuffer {
       if (this.options.logging) this.log("findOne → null", { entity: entity.name });
       return null;
     }
+    // Non-canonical reads (partial select / soft-deleted / unscoped) must not
+    // create a NEW identity-map entry — a partial or trashed row would poison
+    // later canonical PK lookups. Return the already-tracked canonical instance
+    // if one exists, otherwise the raw row untracked.
+    if (!this.isCanonicalReadOption(option)) {
+      return this.mapThroughExisting(entity, result) as T;
+    }
     const tracked = this.resolveIdentity(entity, result) as T;
     if (this.options.logging) {
       const { pkColumns } = this.idMap.getColumnInfo(entity);
@@ -241,10 +248,14 @@ export class WriteBuffer {
   ): Promise<T[]> {
     await this.autoFlushIfNeeded();
     const results = await this.ctx.em.find(entity, option);
-    return results.map((item) => {
-      const tracked = this.resolveIdentity(entity, item) as T;
-      return tracked;
-    });
+    // Non-canonical reads (partial select / soft-deleted / unscoped) map
+    // through the identity map without creating new entries — see findOne().
+    const canonical = this.isCanonicalReadOption(option);
+    return results.map((item) =>
+      canonical
+        ? (this.resolveIdentity(entity, item) as T)
+        : (this.mapThroughExisting(entity, item) as T),
+    );
   }
 
   /**
@@ -977,6 +988,13 @@ export class WriteBuffer {
     const bulkUpdatesCopy = [...this.bulkUpdateQueue];
     const bulkDeletesCopy = [...this.bulkDeleteQueue];
 
+    // Snapshot the pre-flush column values of every instance flush may mutate,
+    // so a mid-flush failure (the whole transaction rolls back) can restore
+    // them. Otherwise a persisted instance keeps a PK / an incremented @Version
+    // / a timestamp for a row that no longer exists — ghost state that also
+    // triggers a spurious OptimisticLockError on retry.
+    const preFlushState = this.capturePreFlushColumnState(persistsCopy);
+
     try {
       const flushFn = async (txEm: EntityManager) => {
         const visited = new Set<any>();
@@ -1167,6 +1185,11 @@ export class WriteBuffer {
       return result;
     } catch (error) {
       if (this.options.logging) this.log("flush → FAILED (queues restored)", { error: (error as Error).message });
+      // Undo the in-place mutations flush applied to instances before it failed
+      // (PK write-back, @Version bump, timestamps). The DB rolled the whole
+      // transaction back, so restoring the pre-flush column values leaves each
+      // instance exactly as the user left it — ready for a clean retry.
+      this.restorePreFlushColumnState(preFlushState);
       // On failure, restore queues so the user can retry
       this.insertQueue.length = 0;
       this.insertQueue.push(...insertsCopy);
@@ -1183,6 +1206,50 @@ export class WriteBuffer {
   }
 
   // ── Private helpers ──────────────────────────────────────────
+
+  /**
+   * Snapshot the current column values of every instance a flush may mutate:
+   * all persist-queue instances (PK write-back) and all tracked instances
+   * (write-back / @Version bump / timestamps on UPDATE). Returns a map from
+   * instance → its pre-flush column values, used by
+   * {@link restorePreFlushColumnState} to undo those mutations if the flush
+   * transaction rolls back.
+   *
+   * Note: cascade-inserted CHILD instances loaded/created outside these two
+   * sets are not captured here — restoring their PKs after a failed cascade
+   * flush is a deeper concern tracked separately.
+   */
+  private capturePreFlushColumnState(
+    persists: PersistEntry[],
+  ): Map<any, Record<string, any>> {
+    const state = new Map<any, Record<string, any>>();
+    const record = (instance: any, columnNames: string[]): void => {
+      if (state.has(instance)) return;
+      const snap: Record<string, any> = {};
+      for (const col of columnNames) snap[col] = instance[col];
+      state.set(instance, snap);
+    };
+    for (const entry of persists) record(entry.instance, entry.columnNames);
+    for (const entry of this.trackedEntries.values()) {
+      record(entry.instance, entry.columnNames);
+    }
+    return state;
+  }
+
+  /**
+   * Restore instances to the column values captured by
+   * {@link capturePreFlushColumnState}, undoing flush's in-place mutations
+   * after a rolled-back transaction.
+   */
+  private restorePreFlushColumnState(
+    state: Map<any, Record<string, any>>,
+  ): void {
+    for (const [instance, snap] of state) {
+      for (const col of Object.keys(snap)) {
+        instance[col] = snap[col];
+      }
+    }
+  }
 
   /**
    * Validate all dirty tracked entities and persist queue entries
@@ -1253,6 +1320,43 @@ export class WriteBuffer {
     if (instance[versionCol] === oldVersion) {
       instance[versionCol] = (oldVersion as number) + 1;
     }
+  }
+
+  /**
+   * A read is "canonical" when its result faithfully represents the full,
+   * live row: all columns loaded, soft-deleted rows excluded, and the active
+   * tenant scope applied. Only canonical reads may populate the identity map;
+   * partial (`select`), soft-delete-inclusive (`withDeleted` / `onlyDeleted`),
+   * and unscoped (`withoutTenantScope`) reads must not, or they would poison
+   * later PK lookups with a downgraded instance.
+   */
+  private isCanonicalReadOption(option: FindOption<any>): boolean {
+    return !(
+      option.select ||
+      option.withDeleted ||
+      option.onlyDeleted ||
+      option.withoutTenantScope
+    );
+  }
+
+  /**
+   * Return the already-tracked canonical instance for a freshly loaded row if
+   * one exists (preserving object identity), otherwise the row as-is — without
+   * ever inserting a new identity-map entry. Used for non-canonical reads.
+   */
+  private mapThroughExisting(entityClass: ClazzType<any>, instance: any): any {
+    try {
+      const { pkColumns } = this.idMap.getColumnInfo(entityClass);
+      const key = this.idMap.buildIdentityKey(entityClass, instance, pkColumns);
+      const existing = this.idMap.identityMap.get(key);
+      if (existing && !this.referenceStubs.has(existing)) {
+        this.idMap.touch(key);
+        return existing;
+      }
+    } catch {
+      // PK column missing (e.g. a `select` that omits the PK) → nothing to map.
+    }
+    return instance;
   }
 
   private resolveIdentity(entityClass: ClazzType<any>, instance: any): any {


### PR DESCRIPTION
Fixes three data-loss defects in the WriteBuffer (UoW) plugin, surfaced by the 2026-07-03 adversarial audit. Each is verified with a new SQLite in-memory real-SQL repro (no unit mocks).

## Bulk DML: broken operator WHERE + ignored NamingStrategy
`executeBulkUpdate`/`executeBulkDelete` hand-rolled `col = ?` SQL by iterating `Object.entries(where)`, which bound an operator object (`{ gte: 18 }`) directly as a parameter and used the property name as the column name. Result: `updateMany`/`deleteMany` with any operator WHERE threw or matched nothing, and snake_cased schemas raised `no such column`. Both now delegate to `EntityManager.update`/`delete`, the canonical write path (operator WHERE, NamingStrategy, tenant scoping, `@UpdateTimestamp`). The in-memory identity map is synced precisely for a plain equality WHERE and conservatively invalidated for operator/complex WHERE clauses.

## Read cache pollution
`buf.findOne`/`find` tracked every result unconditionally, so a partial `select` or a `withDeleted` read became the cached instance — a later full PK read returned the partial (columns read back as `undefined`), and a normal read returned a soft-deleted row instead of `null`. Non-canonical reads (`select` / `withDeleted` / `onlyDeleted` / `withoutTenantScope`) now never create a new identity-map entry.

## Flush-rollback ghost state
flush() mutated instances in place (PK write-back, `@Version` bump, timestamps). When a later statement failed, the transaction rolled back but those in-memory mutations were not undone, leaving a ghost PK and a spurious `OptimisticLockError` on retry. flush() now snapshots pre-flush column state and restores it if the transaction throws. (Cascade-child restoration is a known follow-up.)

## Verification
- Full unit suite: 5,277 passed / 20 skipped / 0 failures (5 delegation-based bulk-DML mock tests updated)
- SQLite integration: 531 passed, deterministic under both parallel and `--runInBand`
- `tsc` clean for CJS and ESM
- PostgreSQL / MySQL not exercised this pass (SQLite + unit only)