### PR TITLE
fix(core/buffer): INSERT new assigned-PK entities on persist()

### DIFF
--- a/__tests__/integration/sqlite/buffer-assigned-pk.test.ts
+++ b/__tests__/integration/sqlite/buffer-assigned-pk.test.ts
@@ -1,0 +1,143 @@
+/**
+ * SQLite In-Memory: WriteBuffer persist() with an application-assigned PK.
+ *
+ * Regression for the audited data-loss bug: buffer.persist() classified any
+ * instance that already carries a PK value as MANAGED (delegating to track()),
+ * on the assumption that a present PK means the row was loaded from the DB.
+ *
+ * That assumption only holds for DB-generated PKs (auto-increment / uuid), which
+ * are undefined on a freshly-constructed entity. For an APPLICATION-ASSIGNED PK
+ * (@PrimaryColumn — natural key, or a pre-set uuid) the value is always present
+ * on a brand-new entity, so persist() tracked it as already-managed and NEVER
+ * emitted an INSERT. flush() reported success while the row silently vanished.
+ *
+ * The fix: an assigned-PK instance that is not yet known to the buffer (not
+ * tracked, no prior MANAGED state) is a NEW entity → queue the INSERT. A DB-
+ * generated PK keeps the original track()-on-present-PK behavior.
+ */
+
+import "reflect-metadata";
+import {
+  createTestConnection,
+  type TestConnectionResult,
+} from "../helpers/test-connection";
+import { Entity, Column, PrimaryColumn } from "../../../src";
+import { bufferPlugin } from "../../../src/core/plugin/buffer/bufferPlugin";
+import type { WriteBuffer } from "../../../src/core/plugin/buffer/WriteBuffer";
+import { getScannerInstance } from "../../../src/scanner/ScannerContainer";
+import { ColumnScanner } from "../../../src/scanner";
+
+function shortName(prefix: string): string {
+  return `${prefix}_${String(Date.now()).slice(-7)}`;
+}
+
+describe("[Integration] SQLite: WriteBuffer persist() with assigned PK", () => {
+  let conn: TestConnectionResult;
+  // Natural-key entity: PK "code" is supplied by the application.
+  let Country: new () => any;
+
+  beforeAll(async () => {
+    const className = shortName("Country");
+
+    conn = await createTestConnection(
+      {
+        type: "sqlite",
+        database: ":memory:",
+        synchronize: true,
+        logging: false,
+        plugins: [bufferPlugin()],
+      },
+      () => {
+        getScannerInstance(ColumnScanner).clear();
+
+        const CC = class {} as any;
+        Object.defineProperty(CC, "name", { value: className });
+        Reflect.defineMetadata("design:type", String, CC.prototype, "code");
+        PrimaryColumn({ type: "varchar", length: 8 })(CC.prototype, "code");
+        Reflect.defineMetadata("design:type", String, CC.prototype, "name");
+        Column()(CC.prototype, "name");
+        Entity()(CC);
+
+        Country = CC;
+        return { entities: [CC] };
+      },
+    );
+  }, 30000);
+
+  afterAll(async () => {
+    if (conn) await conn.cleanup();
+  });
+
+  beforeEach(async () => {
+    await conn.em.clear(Country);
+  });
+
+  it("persist() of a brand-new assigned-PK entity INSERTs the row on flush", async () => {
+    const buf: WriteBuffer = (conn.em as any).buffer();
+
+    const kr = Object.assign(new Country(), { code: "KR", name: "Korea" });
+    buf.persist(kr);
+
+    // It must be scheduled as an INSERT, not silently treated as managed.
+    expect(buf.size().persists).toBe(1);
+    expect(buf.tracked()).toHaveLength(0);
+
+    await buf.flush();
+
+    // The row must actually exist in the database.
+    const row = await conn.em.findOne(Country, { where: { code: "KR" } as any });
+    expect(row).not.toBeNull();
+    expect((row as any).name).toBe("Korea");
+  });
+
+  it("persist() of several assigned-PK entities INSERTs all of them", async () => {
+    const buf: WriteBuffer = (conn.em as any).buffer();
+
+    buf.persist(Object.assign(new Country(), { code: "US", name: "United States" }));
+    buf.persist(Object.assign(new Country(), { code: "JP", name: "Japan" }));
+
+    expect(buf.size().persists).toBe(2);
+
+    await buf.flush();
+
+    const rows = await conn.em.find(Country);
+    const codes = rows.map((r: any) => r.code).sort();
+    expect(codes).toEqual(["JP", "US"]);
+  });
+
+  it("re-persist after flush is idempotent (no duplicate INSERT)", async () => {
+    const buf: WriteBuffer = (conn.em as any).buffer();
+
+    const fr = Object.assign(new Country(), { code: "FR", name: "France" });
+    buf.persist(fr);
+    await buf.flush();
+
+    // Same instance, now flushed → should be MANAGED, re-persist is a no-op.
+    buf.persist(fr);
+    expect(buf.size().persists).toBe(0);
+
+    // Second flush must not attempt another INSERT of the same PK.
+    await expect(buf.flush()).resolves.toBeDefined();
+
+    const rows = await conn.em.find(Country);
+    expect(rows).toHaveLength(1);
+  });
+
+  it("persist() of an already-tracked assigned-PK entity does not re-INSERT", async () => {
+    // Seed a row and load it through the buffer (auto-tracked / MANAGED).
+    await conn.em.save(Country, { code: "DE", name: "Germany" } as any);
+    const buf: WriteBuffer = (conn.em as any).buffer();
+
+    const loaded = await buf.findOne(Country, { where: { code: "DE" } as any });
+    expect(loaded).not.toBeNull();
+
+    // persist() on the loaded (managed) instance must NOT queue an INSERT.
+    buf.persist(loaded);
+    expect(buf.size().persists).toBe(0);
+
+    await buf.flush();
+
+    const rows = await conn.em.find(Country);
+    expect(rows).toHaveLength(1);
+  });
+});

--- a/src/core/plugin/buffer/IdentityMapManager.ts
+++ b/src/core/plugin/buffer/IdentityMapManager.ts
@@ -178,6 +178,30 @@ export class IdentityMapManager {
   }
 
   /**
+   * Whether the entity's primary key is entirely DB-generated
+   * (auto-increment or a `generationStrategy` such as uuid / uuid-v7).
+   *
+   * When true, a present PK value reliably means the row already exists in the
+   * database (it was loaded, not constructed), so persist() can treat it as
+   * managed. When false, at least one PK column is application-assigned
+   * (@PrimaryColumn / natural key), and a present PK does NOT imply the row
+   * exists — a brand-new entity always carries its assigned PK.
+   *
+   * Returns false for keyless entities (no PK columns).
+   */
+  hasGeneratedPk(entityClass: ClazzType<any>): boolean {
+    const columns: ColumnMetadata[] =
+      Reflect.getMetadata(COLUMN_TOKEN, entityClass.prototype) ?? [];
+    const pkColumns = columns.filter((c) => c.options?.primary);
+    if (pkColumns.length === 0) return false;
+    return pkColumns.every(
+      (c) =>
+        c.options?.autoIncrement === true ||
+        c.options?.generationStrategy != null,
+    );
+  }
+
+  /**
    * Build a unique identity key for an entity instance based on class name + PK values.
    * Throws if any PK column is null/undefined.
    *

--- a/src/core/plugin/buffer/WriteBuffer.ts
+++ b/src/core/plugin/buffer/WriteBuffer.ts
@@ -459,8 +459,20 @@ export class WriteBuffer {
     });
 
     if (hasPk) {
-      this.cancelQueuedDelete(entityClass, instance, pkColumns);
-      return this.track(instance);
+      // A DB-generated PK (auto-increment / uuid) is only present once the row
+      // exists, so a present value means the entity was loaded → track it as
+      // managed. An APPLICATION-ASSIGNED PK (@PrimaryColumn / natural key) is
+      // always set on a brand-new entity, so its presence tells us nothing about
+      // whether the row exists: only treat it as managed if the buffer already
+      // knows the instance (tracked, or MANAGED from a prior flush). Otherwise
+      // it is a new entity that must be INSERTed — falling through to the queue.
+      const alreadyKnown =
+        this.trackedEntries.has(instance) ||
+        this.idMap.stateMap.get(instance) === EntityState.MANAGED;
+      if (this.idMap.hasGeneratedPk(entityClass) || alreadyKnown) {
+        this.cancelQueuedDelete(entityClass, instance, pkColumns);
+        return this.track(instance);
+      }
     }
 
     // Idempotent — same reference


### PR DESCRIPTION
## Problem

`WriteBuffer.persist()` classified any instance carrying a PK value as `MANAGED` (delegating to `track()`), assuming a present PK means the row was loaded from the DB. That only holds for DB-generated PKs. For an application-assigned PK (`@PrimaryColumn` / natural key), the value is always set on a brand-new entity, so `persist()` treated new entities as already-managed and never emitted an INSERT — `flush()` reported success while the row was silently dropped.

## Fix

- Add `IdentityMapManager.hasGeneratedPk()` — true only when every PK column is DB-generated (auto-increment or a `generationStrategy`).
- `persist()` now routes a present PK to `track()` only when the PK is DB-generated, or the buffer already knows the instance (tracked, or `MANAGED` from a prior flush). An assigned-PK entity the buffer has not seen is queued for INSERT.

`@PrimaryGeneratedColumn("uuid")` stays classified as generated: a uuid entity that has an id before flush was loaded from the DB, so `track()`/UPDATE is the common-case behavior.

## Verification

- New repro `__tests__/integration/sqlite/buffer-assigned-pk.test.ts` (4 cases): 3 failed before the fix (data loss reproduced), all pass after.
- Unit 5,326 passed (0 failures), SQLite buffer 14, real PostgreSQL + MySQL `buffer-plugin` 66 all pass, tsc clean.
- Existing contract `persist existing (has PK) delegates to track` (auto-increment) preserved on real DBs.