### PR TITLE
fix(core/buffer): repair cascade-persist, orphan reparent, and stale-cache data loss

### DIFF
--- a/__tests__/integration/sqlite/buffer-cascade-persist-data-loss.test.ts
+++ b/__tests__/integration/sqlite/buffer-cascade-persist-data-loss.test.ts
@@ -1,0 +1,263 @@
+/**
+ * SQLite In-Memory: WriteBuffer cascade-persist data loss regressions.
+ *
+ * Three audited data-loss defects, each reproduced against real SQL:
+ *
+ *  1. M2M cascade persist of a NEW parent drops the pivot rows.
+ *     A newly persist()ed parent lands in the persist queue, not the tracked
+ *     set, so the collection-diff step (which writes pivot rows) never runs for
+ *     it. The child rows exist, but the join table stays empty — the M2M link
+ *     is silently lost.
+ *
+ *  2. O2O owning-side cascade persist leaves the parent FK NULL.
+ *     The parent row is INSERTed before the cascaded related entity is saved,
+ *     so the FK is written only in memory (instance[joinColumn]) and never
+ *     reaches the already-inserted parent row.
+ *
+ *  3. merge() of a detached instance never UPDATEs.
+ *     merge() of an instance the buffer has never seen falls through to
+ *     track(), which snapshots the instance's CURRENT values — so the diff is
+ *     empty and the detached edits are dropped on flush.
+ *
+ * SQLite does not support ALTER TABLE ADD FOREIGN KEY / ADD CONSTRAINT and does
+ * not auto-create M2M pivot tables, so we use synchronize:false and create
+ * every table (incl. the pivot) by hand.
+ */
+
+import "reflect-metadata";
+import {
+  createTestConnection,
+  type TestConnectionResult,
+} from "../helpers/test-connection";
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  ManyToMany,
+  OneToOne,
+} from "../../../src";
+import { bufferPlugin } from "../../../src/core/plugin/buffer/bufferPlugin";
+import type { WriteBuffer } from "../../../src/core/plugin/buffer/WriteBuffer";
+import { getScannerInstance } from "../../../src/scanner/ScannerContainer";
+import {
+  ColumnScanner,
+  ManyToOneScanner,
+  OneToManyScanner,
+  ManyToManyScanner,
+  OneToOneScanner,
+} from "../../../src/scanner";
+import { DatabaseClient } from "../../../src/DatabaseClient";
+
+function shortName(prefix: string): string {
+  return `${prefix}_${String(Date.now()).slice(-7)}`;
+}
+
+describe("[Integration] SQLite: WriteBuffer cascade-persist data loss", () => {
+  let conn: TestConnectionResult;
+  let Post: new () => any;
+  let Tag: new () => any;
+  let Usr: new () => any;
+  let Profile: new () => any;
+  let Widget: new () => any;
+
+  // All-lowercase single tokens: the default SnakeNamingStrategy would rewrite
+  // a camelCase class name (cpPost → cp_post), so the entity's resolved table
+  // name would not match the table we CREATE by hand below.
+  const postName = shortName("cppost");
+  const tagName = shortName("cptag");
+  const pivotName = shortName("cppivot");
+  const usrName = shortName("cpusr");
+  const profileName = shortName("cpprofile");
+  const widgetName = shortName("cpwidget");
+
+  beforeAll(async () => {
+    conn = await createTestConnection(
+      {
+        type: "sqlite",
+        database: ":memory:",
+        synchronize: false,
+        logging: false,
+        plugins: [bufferPlugin()],
+      },
+      () => {
+        getScannerInstance(ColumnScanner).clear();
+        getScannerInstance(ManyToOneScanner).clear();
+        getScannerInstance(OneToManyScanner).clear();
+        getScannerInstance(ManyToManyScanner).clear();
+        getScannerInstance(OneToOneScanner).clear();
+
+        // ── Tag ──
+        const TagC = class {} as any;
+        Object.defineProperty(TagC, "name", { value: tagName });
+        Reflect.defineMetadata("design:type", Number, TagC.prototype, "id");
+        PrimaryGeneratedColumn()(TagC.prototype, "id");
+        Reflect.defineMetadata("design:type", String, TagC.prototype, "label");
+        Column()(TagC.prototype, "label");
+        Entity()(TagC);
+        Tag = TagC;
+
+        // ── Post (owning M2M → Tag) ──
+        const PostC = class {} as any;
+        Object.defineProperty(PostC, "name", { value: postName });
+        Reflect.defineMetadata("design:type", Number, PostC.prototype, "id");
+        PrimaryGeneratedColumn()(PostC.prototype, "id");
+        Reflect.defineMetadata("design:type", String, PostC.prototype, "title");
+        Column()(PostC.prototype, "title");
+        Reflect.defineMetadata("design:type", Array, PostC.prototype, "tags");
+        ManyToMany(() => TagC, {
+          joinTable: {
+            name: pivotName,
+            joinColumn: "post_id",
+            inverseJoinColumn: "tag_id",
+          },
+        })(PostC.prototype, "tags");
+        Entity()(PostC);
+        Post = PostC;
+
+        // ── Profile ──
+        const ProfileC = class {} as any;
+        Object.defineProperty(ProfileC, "name", { value: profileName });
+        Reflect.defineMetadata("design:type", Number, ProfileC.prototype, "id");
+        PrimaryGeneratedColumn()(ProfileC.prototype, "id");
+        Reflect.defineMetadata("design:type", String, ProfileC.prototype, "bio");
+        Column()(ProfileC.prototype, "bio");
+        Entity()(ProfileC);
+        Profile = ProfileC;
+
+        // ── Usr (owning O2O → Profile via profile_id, cascade insert) ──
+        const UsrC = class {} as any;
+        Object.defineProperty(UsrC, "name", { value: usrName });
+        Reflect.defineMetadata("design:type", Number, UsrC.prototype, "id");
+        PrimaryGeneratedColumn()(UsrC.prototype, "id");
+        Reflect.defineMetadata("design:type", String, UsrC.prototype, "name");
+        Column()(UsrC.prototype, "name");
+        Reflect.defineMetadata("design:type", Number, UsrC.prototype, "profile_id");
+        Column({ type: "int", nullable: true })(UsrC.prototype, "profile_id");
+        Reflect.defineMetadata("design:type", ProfileC, UsrC.prototype, "profile");
+        OneToOne(() => ProfileC, {
+          joinColumn: "profile_id",
+          cascade: true,
+        })(UsrC.prototype, "profile");
+        Entity()(UsrC);
+        Usr = UsrC;
+
+        // ── Widget (plain, for merge) ──
+        const WidgetC = class {} as any;
+        Object.defineProperty(WidgetC, "name", { value: widgetName });
+        Reflect.defineMetadata("design:type", Number, WidgetC.prototype, "id");
+        PrimaryGeneratedColumn()(WidgetC.prototype, "id");
+        Reflect.defineMetadata("design:type", String, WidgetC.prototype, "name");
+        Column()(WidgetC.prototype, "name");
+        Reflect.defineMetadata("design:type", String, WidgetC.prototype, "color");
+        Column()(WidgetC.prototype, "color");
+        Entity()(WidgetC);
+        Widget = WidgetC;
+
+        return { entities: [TagC, PostC, ProfileC, UsrC, WidgetC] };
+      },
+    );
+
+    const connector = DatabaseClient.getInstance().getConnection();
+    await connector.query(
+      `CREATE TABLE IF NOT EXISTS "${tagName}" ("id" INTEGER PRIMARY KEY AUTOINCREMENT, "label" TEXT)`,
+    );
+    await connector.query(
+      `CREATE TABLE IF NOT EXISTS "${postName}" ("id" INTEGER PRIMARY KEY AUTOINCREMENT, "title" TEXT)`,
+    );
+    await connector.query(
+      `CREATE TABLE IF NOT EXISTS "${pivotName}" ("post_id" INTEGER NOT NULL, "tag_id" INTEGER NOT NULL, PRIMARY KEY ("post_id", "tag_id"))`,
+    );
+    await connector.query(
+      `CREATE TABLE IF NOT EXISTS "${profileName}" ("id" INTEGER PRIMARY KEY AUTOINCREMENT, "bio" TEXT)`,
+    );
+    await connector.query(
+      `CREATE TABLE IF NOT EXISTS "${usrName}" ("id" INTEGER PRIMARY KEY AUTOINCREMENT, "name" TEXT, "profile_id" INTEGER)`,
+    );
+    await connector.query(
+      `CREATE TABLE IF NOT EXISTS "${widgetName}" ("id" INTEGER PRIMARY KEY AUTOINCREMENT, "name" TEXT, "color" TEXT)`,
+    );
+  }, 30000);
+
+  afterAll(async () => {
+    if (conn) await conn.cleanup();
+  });
+
+  beforeEach(async () => {
+    const connector = DatabaseClient.getInstance().getConnection();
+    await connector.query(`DELETE FROM "${pivotName}"`);
+    await connector.query(`DELETE FROM "${postName}"`);
+    await connector.query(`DELETE FROM "${tagName}"`);
+    await connector.query(`DELETE FROM "${usrName}"`);
+    await connector.query(`DELETE FROM "${profileName}"`);
+    await connector.query(`DELETE FROM "${widgetName}"`);
+  });
+
+  it("writes M2M pivot rows when a NEW parent is persisted with existing children", async () => {
+    const t1 = await conn.em.save(Tag, { label: "red" } as any);
+    const t2 = await conn.em.save(Tag, { label: "blue" } as any);
+
+    const buf: WriteBuffer = (conn.em as any).buffer();
+    const post = new Post();
+    (post as any).title = "hello";
+    (post as any).tags = [t1, t2];
+    buf.persist(post);
+    await buf.flush();
+
+    expect((post as any).id).toBeDefined();
+    const rows: any[] = await conn.em.query(
+      `SELECT * FROM "${pivotName}" WHERE post_id = ?`,
+      [(post as any).id],
+    );
+    expect(rows).toHaveLength(2);
+    const tagIds = rows.map((r) => r.tag_id).sort();
+    expect(tagIds).toEqual([(t1 as any).id, (t2 as any).id].sort());
+  });
+
+  it("persists the owning-side FK to the DB on O2O cascade insert", async () => {
+    const buf: WriteBuffer = (conn.em as any).buffer();
+    const user = new Usr();
+    (user as any).name = "alice";
+    const profile = new Profile();
+    (profile as any).bio = "hi";
+    (user as any).profile = profile;
+
+    buf.persist(user);
+    await buf.flush();
+
+    expect((profile as any).id).toBeDefined();
+    expect((user as any).profile_id).toBe((profile as any).id);
+
+    const rows: any[] = await conn.em.query(
+      `SELECT profile_id FROM "${usrName}" WHERE id = ?`,
+      [(user as any).id],
+    );
+    expect(rows).toHaveLength(1);
+    // The regression: profile_id stayed NULL in the DB even though it was set
+    // on the in-memory instance.
+    expect(rows[0].profile_id).toBe((profile as any).id);
+  });
+
+  it("UPDATEs a detached instance's changed columns on merge()", async () => {
+    const seeded = await conn.em.save(Widget, {
+      name: "a",
+      color: "red",
+    } as any);
+
+    const buf: WriteBuffer = (conn.em as any).buffer();
+    const detached = new Widget();
+    (detached as any).id = (seeded as any).id;
+    (detached as any).name = "b";
+    (detached as any).color = "red";
+
+    buf.merge(detached);
+    const result = await buf.flush();
+    expect(result.updates).toBe(1);
+
+    const reloaded: any = await conn.em.findOne(Widget, {
+      where: { id: (seeded as any).id } as any,
+    });
+    expect(reloaded).not.toBeNull();
+    expect(reloaded.name).toBe("b");
+    expect(reloaded.color).toBe("red");
+  });
+});

--- a/__tests__/integration/sqlite/buffer-delete-criteria-cache.test.ts
+++ b/__tests__/integration/sqlite/buffer-delete-criteria-cache.test.ts
@@ -1,0 +1,106 @@
+/**
+ * SQLite In-Memory: buf.delete(entity, criteria) must invalidate the Identity Map.
+ *
+ * Audited data-loss / stale-read defect: a criteria delete queues a DELETE but
+ * never evicts the matching tracked instance from the Identity Map. After flush
+ * the row is gone from the DB, yet a subsequent PK findOne() returns the stale
+ * cached instance (first-level cache hit) instead of null — a phantom read of a
+ * deleted row. remove(instance) untracks correctly; delete(criteria) did not.
+ */
+
+import "reflect-metadata";
+import {
+  createTestConnection,
+  type TestConnectionResult,
+} from "../helpers/test-connection";
+import { Entity, Column, PrimaryGeneratedColumn } from "../../../src";
+import { bufferPlugin } from "../../../src/core/plugin/buffer/bufferPlugin";
+import type { WriteBuffer } from "../../../src/core/plugin/buffer/WriteBuffer";
+import { getScannerInstance } from "../../../src/scanner/ScannerContainer";
+import {
+  ColumnScanner,
+  ManyToOneScanner,
+  OneToManyScanner,
+  ManyToManyScanner,
+  OneToOneScanner,
+} from "../../../src/scanner";
+import { DatabaseClient } from "../../../src/DatabaseClient";
+
+function shortName(prefix: string): string {
+  return `${prefix}_${String(Date.now()).slice(-7)}`;
+}
+
+describe("[Integration] SQLite: buf.delete(criteria) Identity Map invalidation", () => {
+  let conn: TestConnectionResult;
+  let Item: new () => any;
+  const itemName = shortName("dcitem");
+
+  beforeAll(async () => {
+    conn = await createTestConnection(
+      {
+        type: "sqlite",
+        database: ":memory:",
+        synchronize: false,
+        logging: false,
+        plugins: [bufferPlugin()],
+      },
+      () => {
+        getScannerInstance(ColumnScanner).clear();
+        getScannerInstance(ManyToOneScanner).clear();
+        getScannerInstance(OneToManyScanner).clear();
+        getScannerInstance(ManyToManyScanner).clear();
+        getScannerInstance(OneToOneScanner).clear();
+
+        const ItemC = class {} as any;
+        Object.defineProperty(ItemC, "name", { value: itemName });
+        Reflect.defineMetadata("design:type", Number, ItemC.prototype, "id");
+        PrimaryGeneratedColumn()(ItemC.prototype, "id");
+        Reflect.defineMetadata("design:type", String, ItemC.prototype, "name");
+        Column()(ItemC.prototype, "name");
+        Entity()(ItemC);
+        Item = ItemC;
+
+        return { entities: [ItemC] };
+      },
+    );
+
+    const connector = DatabaseClient.getInstance().getConnection();
+    await connector.query(
+      `CREATE TABLE IF NOT EXISTS "${itemName}" ("id" INTEGER PRIMARY KEY AUTOINCREMENT, "name" TEXT)`,
+    );
+  }, 30000);
+
+  afterAll(async () => {
+    if (conn) await conn.cleanup();
+  });
+
+  beforeEach(async () => {
+    const connector = DatabaseClient.getInstance().getConnection();
+    await connector.query(`DELETE FROM "${itemName}"`);
+  });
+
+  it("evicts a cached instance after delete(criteria) so findOne returns null", async () => {
+    const seeded: any = await conn.em.save(Item, { name: "a" } as any);
+
+    const buf: WriteBuffer = (conn.em as any).buffer();
+    // Load into the Identity Map (first-level cache) so a later PK findOne is a
+    // cache-hit candidate.
+    const loaded = await buf.findOne(Item, { where: { id: seeded.id } as any });
+    expect(loaded).not.toBeNull();
+
+    // Delete by criteria (not by instance), then flush.
+    buf.delete(Item, { id: seeded.id });
+    await buf.flush();
+
+    // DB row is gone.
+    const rows: any[] = await conn.em.query(
+      `SELECT COUNT(*) AS c FROM "${itemName}" WHERE id = ?`,
+      [seeded.id],
+    );
+    expect(Number(rows[0].c)).toBe(0);
+
+    // The regression: this returned the stale cached instance instead of null.
+    const after = await buf.findOne(Item, { where: { id: seeded.id } as any });
+    expect(after).toBeNull();
+  });
+});

--- a/__tests__/integration/sqlite/buffer-lazy-collection-loss.test.ts
+++ b/__tests__/integration/sqlite/buffer-lazy-collection-loss.test.ts
@@ -1,0 +1,149 @@
+/**
+ * SQLite In-Memory: WriteBuffer lazy-collection change loss regression.
+ *
+ * When a tracked entity is loaded through the buffer, its @OneToMany /
+ * @ManyToMany collections are injected as lazy proxies — they are NOT arrays
+ * until first accessed. track() snapshots collections eagerly, so an unloaded
+ * (proxy) collection gets no snapshot baseline. If the caller then awaits the
+ * collection and mutates it, the flush collection-diff step finds no snapshot
+ * for that property and silently skips it — the added/removed children are
+ * dropped.
+ *
+ * The fix captures the collection's baseline the moment its lazy proxy
+ * materializes (with the freshly loaded items), so a later mutation diffs
+ * correctly.
+ *
+ * synchronize:false + hand-created tables (SQLite has no ALTER ADD FK).
+ */
+
+import "reflect-metadata";
+import {
+  createTestConnection,
+  type TestConnectionResult,
+} from "../helpers/test-connection";
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  ManyToOne,
+  OneToMany,
+} from "../../../src";
+import { bufferPlugin } from "../../../src/core/plugin/buffer/bufferPlugin";
+import type { WriteBuffer } from "../../../src/core/plugin/buffer/WriteBuffer";
+import { getScannerInstance } from "../../../src/scanner/ScannerContainer";
+import {
+  ColumnScanner,
+  ManyToOneScanner,
+  OneToManyScanner,
+} from "../../../src/scanner";
+import { DatabaseClient } from "../../../src/DatabaseClient";
+
+function shortName(prefix: string): string {
+  return `${prefix}_${String(Date.now()).slice(-7)}`;
+}
+
+describe("[Integration] SQLite: WriteBuffer lazy-collection change loss", () => {
+  let conn: TestConnectionResult;
+  let Parent: new () => any;
+  let Child: new () => any;
+
+  const parentName = shortName("lcparent");
+  const childName = shortName("lcchild");
+
+  beforeAll(async () => {
+    conn = await createTestConnection(
+      {
+        type: "sqlite",
+        database: ":memory:",
+        synchronize: false,
+        logging: false,
+        plugins: [bufferPlugin()],
+      },
+      () => {
+        getScannerInstance(ColumnScanner).clear();
+        getScannerInstance(ManyToOneScanner).clear();
+        getScannerInstance(OneToManyScanner).clear();
+
+        const PC = class {} as any;
+        Object.defineProperty(PC, "name", { value: parentName });
+        Reflect.defineMetadata("design:type", Number, PC.prototype, "id");
+        PrimaryGeneratedColumn()(PC.prototype, "id");
+        Reflect.defineMetadata("design:type", String, PC.prototype, "name");
+        Column()(PC.prototype, "name");
+        Reflect.defineMetadata("design:type", Array, PC.prototype, "children");
+        OneToMany(() => CC, { mappedBy: "parent", cascade: ["insert"] })(
+          PC.prototype,
+          "children",
+        );
+        Entity()(PC);
+
+        const CC = class {} as any;
+        Object.defineProperty(CC, "name", { value: childName });
+        Reflect.defineMetadata("design:type", Number, CC.prototype, "id");
+        PrimaryGeneratedColumn()(CC.prototype, "id");
+        Reflect.defineMetadata("design:type", String, CC.prototype, "title");
+        Column()(CC.prototype, "title");
+        Reflect.defineMetadata("design:type", Number, CC.prototype, "parentfk");
+        Column({ type: "int", nullable: true })(CC.prototype, "parentfk");
+        Reflect.defineMetadata("design:type", PC, CC.prototype, "parent");
+        ManyToOne(() => PC, (e: any) => e.parent, {
+          joinColumn: "parentfk",
+        })(CC.prototype, "parent");
+        Entity()(CC);
+
+        Parent = PC;
+        Child = CC;
+        return { entities: [PC, CC] };
+      },
+    );
+
+    const connector = DatabaseClient.getInstance().getConnection();
+    await connector.query(
+      `CREATE TABLE IF NOT EXISTS "${parentName}" ("id" INTEGER PRIMARY KEY AUTOINCREMENT, "name" TEXT)`,
+    );
+    await connector.query(
+      `CREATE TABLE IF NOT EXISTS "${childName}" ("id" INTEGER PRIMARY KEY AUTOINCREMENT, "title" TEXT, "parentfk" INTEGER)`,
+    );
+  }, 30000);
+
+  afterAll(async () => {
+    if (conn) await conn.cleanup();
+  });
+
+  beforeEach(async () => {
+    const connector = DatabaseClient.getInstance().getConnection();
+    await connector.query(`DELETE FROM "${childName}"`);
+    await connector.query(`DELETE FROM "${parentName}"`);
+  });
+
+  it("cascade-inserts a child pushed onto a lazily-loaded O2M collection", async () => {
+    const parent = await conn.em.save(Parent, { name: "p1" } as any);
+    await conn.em.save(Child, { title: "c1", parentfk: (parent as any).id } as any);
+    await conn.em.save(Child, { title: "c2", parentfk: (parent as any).id } as any);
+
+    const buf: WriteBuffer = (conn.em as any).buffer();
+    const p: any = await buf.findOne(Parent, {
+      where: { id: (parent as any).id } as any,
+    });
+    expect(p).not.toBeNull();
+
+    // Materialize the lazy collection — this must capture the baseline {c1, c2}.
+    const children = await p.children;
+    expect(children).toHaveLength(2);
+
+    // Mutate the now-loaded collection.
+    const newChild = new Child();
+    (newChild as any).title = "c3";
+    p.children.push(newChild);
+
+    const result = await buf.flush();
+    expect(result.inserts).toBe(1);
+
+    const rows: any[] = await conn.em.query(
+      `SELECT * FROM "${childName}" WHERE parentfk = ?`,
+      [(parent as any).id],
+    );
+    expect(rows).toHaveLength(3);
+    expect(rows.map((r) => r.title).sort()).toEqual(["c1", "c2", "c3"]);
+  });
+});

--- a/__tests__/integration/sqlite/buffer-orphan-reparent.test.ts
+++ b/__tests__/integration/sqlite/buffer-orphan-reparent.test.ts
@@ -1,0 +1,185 @@
+/**
+ * SQLite In-Memory: WriteBuffer orphanRemoval must not delete a REPARENTED child.
+ *
+ * Audited data-loss defect: with orphanRemoval enabled, moving a child from
+ * parent A to parent B makes the child appear in A's collection diff as
+ * `removed`. The flush orphan-removal step DELETEs every removed child, so the
+ * reparented child is destroyed even though it was merely handed to another
+ * parent (it appears in B's diff as `added`). A child that still belongs to a
+ * tracked parent is not an orphan and must survive.
+ *
+ * SQLite does not support ALTER TABLE ADD CONSTRAINT, so synchronize:false and
+ * every table is created by hand.
+ */
+
+import "reflect-metadata";
+import {
+  createTestConnection,
+  type TestConnectionResult,
+} from "../helpers/test-connection";
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  ManyToOne,
+  OneToMany,
+  RelationColumn,
+} from "../../../src";
+import { bufferPlugin } from "../../../src/core/plugin/buffer/bufferPlugin";
+import type { WriteBuffer } from "../../../src/core/plugin/buffer/WriteBuffer";
+import { getScannerInstance } from "../../../src/scanner/ScannerContainer";
+import {
+  ColumnScanner,
+  ManyToOneScanner,
+  OneToManyScanner,
+  ManyToManyScanner,
+  OneToOneScanner,
+} from "../../../src/scanner";
+import { DatabaseClient } from "../../../src/DatabaseClient";
+
+function shortName(prefix: string): string {
+  return `${prefix}_${String(Date.now()).slice(-7)}`;
+}
+
+describe("[Integration] SQLite: WriteBuffer orphanRemoval reparenting", () => {
+  let conn: TestConnectionResult;
+  let Parent: new () => any;
+  let Child: new () => any;
+
+  const parentName = shortName("orphanp");
+  const childName = shortName("orphanc");
+
+  beforeAll(async () => {
+    conn = await createTestConnection(
+      {
+        type: "sqlite",
+        database: ":memory:",
+        synchronize: false,
+        logging: false,
+        plugins: [bufferPlugin({ orphanRemoval: true })],
+      },
+      () => {
+        getScannerInstance(ColumnScanner).clear();
+        getScannerInstance(ManyToOneScanner).clear();
+        getScannerInstance(OneToManyScanner).clear();
+        getScannerInstance(ManyToManyScanner).clear();
+        getScannerInstance(OneToOneScanner).clear();
+
+        const ParentC = class {} as any;
+        Object.defineProperty(ParentC, "name", { value: parentName });
+        Reflect.defineMetadata("design:type", Number, ParentC.prototype, "id");
+        PrimaryGeneratedColumn()(ParentC.prototype, "id");
+        Reflect.defineMetadata("design:type", String, ParentC.prototype, "name");
+        Column()(ParentC.prototype, "name");
+        Reflect.defineMetadata("design:type", Array, ParentC.prototype, "children");
+
+        const ChildC = class {} as any;
+        Object.defineProperty(ChildC, "name", { value: childName });
+        Reflect.defineMetadata("design:type", Number, ChildC.prototype, "id");
+        PrimaryGeneratedColumn()(ChildC.prototype, "id");
+        Reflect.defineMetadata("design:type", String, ChildC.prototype, "label");
+        Column()(ChildC.prototype, "label");
+        Reflect.defineMetadata("design:type", ParentC, ChildC.prototype, "parent");
+        ManyToOne(
+          () => ParentC,
+          (p: any) => p.children,
+        )(ChildC.prototype, "parent");
+        RelationColumn({ name: "parent_id" })(ChildC.prototype, "parent");
+        Entity()(ChildC);
+        Child = ChildC;
+
+        OneToMany(() => ChildC, {
+          mappedBy: "parent",
+          cascade: true,
+        })(ParentC.prototype, "children");
+        Entity()(ParentC);
+        Parent = ParentC;
+
+        return { entities: [ParentC, ChildC] };
+      },
+    );
+
+    const connector = DatabaseClient.getInstance().getConnection();
+    await connector.query(
+      `CREATE TABLE IF NOT EXISTS "${parentName}" ("id" INTEGER PRIMARY KEY AUTOINCREMENT, "name" TEXT)`,
+    );
+    await connector.query(
+      `CREATE TABLE IF NOT EXISTS "${childName}" ("id" INTEGER PRIMARY KEY AUTOINCREMENT, "label" TEXT, "parent_id" INTEGER)`,
+    );
+  }, 30000);
+
+  afterAll(async () => {
+    if (conn) await conn.cleanup();
+  });
+
+  beforeEach(async () => {
+    const connector = DatabaseClient.getInstance().getConnection();
+    await connector.query(`DELETE FROM "${childName}"`);
+    await connector.query(`DELETE FROM "${parentName}"`);
+  });
+
+  it("keeps a child moved from parent A to parent B (reparent, not orphan)", async () => {
+    // Seed: parent A with child c1, parent B empty.
+    const a: any = await conn.em.save(Parent, { name: "A" } as any);
+    const b: any = await conn.em.save(Parent, { name: "B" } as any);
+    const c1: any = await conn.em.save(Child, {
+      label: "c1",
+      parentId: a.id,
+    } as any);
+
+    const buf: WriteBuffer = (conn.em as any).buffer();
+
+    // Track both parents WITH their current collection state as the baseline.
+    const parentA = new Parent();
+    parentA.id = a.id;
+    parentA.name = "A";
+    parentA.children = [c1];
+    buf.track(parentA);
+
+    const parentB = new Parent();
+    parentB.id = b.id;
+    parentB.name = "B";
+    parentB.children = [];
+    buf.track(parentB);
+
+    // Reparent: move c1 from A to B (same instance).
+    parentA.children = [];
+    parentB.children = [c1];
+
+    await buf.flush();
+
+    // c1 must still exist, now pointing at B — not orphan-deleted.
+    const rows: any[] = await conn.em.query(
+      `SELECT id, parent_id FROM "${childName}" WHERE id = ?`,
+      [c1.id],
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].parent_id).toBe(b.id);
+  });
+
+  it("still orphan-deletes a child removed from its only parent", async () => {
+    const a: any = await conn.em.save(Parent, { name: "A" } as any);
+    const c1: any = await conn.em.save(Child, {
+      label: "c1",
+      parentId: a.id,
+    } as any);
+
+    const buf: WriteBuffer = (conn.em as any).buffer();
+    const parentA = new Parent();
+    parentA.id = a.id;
+    parentA.name = "A";
+    parentA.children = [c1];
+    buf.track(parentA);
+
+    // Remove c1 from A, not added anywhere → genuine orphan.
+    parentA.children = [];
+
+    await buf.flush();
+
+    const rows: any[] = await conn.em.query(
+      `SELECT COUNT(*) AS c FROM "${childName}" WHERE id = ?`,
+      [c1.id],
+    );
+    expect(Number(rows[0].c)).toBe(0);
+  });
+});

--- a/__tests__/integration/sqlite/buffer-relation-column-cascade.test.ts
+++ b/__tests__/integration/sqlite/buffer-relation-column-cascade.test.ts
@@ -1,0 +1,186 @@
+/**
+ * SQLite In-Memory: WriteBuffer cascade with @RelationColumn-declared FKs.
+ *
+ * The buffer's cascade paths resolve the child FK via `resolveFkColumn`, which
+ * only knows the deprecated `@ManyToOne({ joinColumn })` option and otherwise
+ * falls back to the relation property name (`mappedBy`). When the FK is declared
+ * with `@RelationColumn({ name })` and NO backing `@Column` (the documented
+ * nestjs-blog pattern), that fallback is the relation property itself — not the
+ * shadow accessor (`${prop}Id`) the save/where path actually reads. Two audited
+ * data-loss defects follow:
+ *
+ *  1. Cascade INSERT leaves the child FK NULL. The buffer writes only
+ *     `child["author"] = parentPk` (a scalar on the relation prop); the save
+ *     path ignores it (not an object, no `authorId` shadow) so author_id stays
+ *     NULL in the DB.
+ *
+ *  2. Cascade DELETE fails the whole flush. collectCascadeDeletes builds the
+ *     child criteria as `{ author: parentPk }` and runs it through
+ *     txEm.find/delete, which cannot resolve the relation property to a real
+ *     column — the flush throws.
+ *
+ * SQLite does not support ALTER TABLE ADD CONSTRAINT, so synchronize:false and
+ * every table is created by hand.
+ */
+
+import "reflect-metadata";
+import {
+  createTestConnection,
+  type TestConnectionResult,
+} from "../helpers/test-connection";
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  ManyToOne,
+  OneToMany,
+  RelationColumn,
+} from "../../../src";
+import { bufferPlugin } from "../../../src/core/plugin/buffer/bufferPlugin";
+import type { WriteBuffer } from "../../../src/core/plugin/buffer/WriteBuffer";
+import { getScannerInstance } from "../../../src/scanner/ScannerContainer";
+import {
+  ColumnScanner,
+  ManyToOneScanner,
+  OneToManyScanner,
+  ManyToManyScanner,
+  OneToOneScanner,
+} from "../../../src/scanner";
+import { DatabaseClient } from "../../../src/DatabaseClient";
+
+function shortName(prefix: string): string {
+  return `${prefix}_${String(Date.now()).slice(-7)}`;
+}
+
+describe("[Integration] SQLite: WriteBuffer @RelationColumn cascade", () => {
+  let conn: TestConnectionResult;
+  let Author: new () => any;
+  let Post: new () => any;
+
+  const authorName = shortName("rcauthor");
+  const postName = shortName("rcpost");
+
+  beforeAll(async () => {
+    conn = await createTestConnection(
+      {
+        type: "sqlite",
+        database: ":memory:",
+        synchronize: false,
+        logging: false,
+        plugins: [bufferPlugin()],
+      },
+      () => {
+        getScannerInstance(ColumnScanner).clear();
+        getScannerInstance(ManyToOneScanner).clear();
+        getScannerInstance(OneToManyScanner).clear();
+        getScannerInstance(ManyToManyScanner).clear();
+        getScannerInstance(OneToOneScanner).clear();
+
+        // ── Author (O2M → Post, cascade insert+delete) ──
+        const AuthorC = class {} as any;
+        Object.defineProperty(AuthorC, "name", { value: authorName });
+        Reflect.defineMetadata("design:type", Number, AuthorC.prototype, "id");
+        PrimaryGeneratedColumn()(AuthorC.prototype, "id");
+        Reflect.defineMetadata("design:type", String, AuthorC.prototype, "name");
+        Column()(AuthorC.prototype, "name");
+        Reflect.defineMetadata("design:type", Array, AuthorC.prototype, "posts");
+
+        // ── Post (M2O → Author via @RelationColumn, no backing @Column) ──
+        const PostC = class {} as any;
+        Object.defineProperty(PostC, "name", { value: postName });
+        Reflect.defineMetadata("design:type", Number, PostC.prototype, "id");
+        PrimaryGeneratedColumn()(PostC.prototype, "id");
+        Reflect.defineMetadata("design:type", String, PostC.prototype, "title");
+        Column()(PostC.prototype, "title");
+        Reflect.defineMetadata("design:type", AuthorC, PostC.prototype, "author");
+        ManyToOne(
+          () => AuthorC,
+          (a: any) => a.posts,
+        )(PostC.prototype, "author");
+        RelationColumn({ name: "author_id" })(PostC.prototype, "author");
+        Entity()(PostC);
+        Post = PostC;
+
+        OneToMany(() => PostC, {
+          mappedBy: "author",
+          cascade: true,
+        })(AuthorC.prototype, "posts");
+        Entity()(AuthorC);
+        Author = AuthorC;
+
+        return { entities: [AuthorC, PostC] };
+      },
+    );
+
+    const connector = DatabaseClient.getInstance().getConnection();
+    await connector.query(
+      `CREATE TABLE IF NOT EXISTS "${authorName}" ("id" INTEGER PRIMARY KEY AUTOINCREMENT, "name" TEXT)`,
+    );
+    await connector.query(
+      `CREATE TABLE IF NOT EXISTS "${postName}" ("id" INTEGER PRIMARY KEY AUTOINCREMENT, "title" TEXT, "author_id" INTEGER)`,
+    );
+  }, 30000);
+
+  afterAll(async () => {
+    if (conn) await conn.cleanup();
+  });
+
+  beforeEach(async () => {
+    const connector = DatabaseClient.getInstance().getConnection();
+    await connector.query(`DELETE FROM "${postName}"`);
+    await connector.query(`DELETE FROM "${authorName}"`);
+  });
+
+  it("persists the child FK on O2M cascade insert (no backing @Column)", async () => {
+    const buf: WriteBuffer = (conn.em as any).buffer();
+    const author = new Author();
+    (author as any).name = "kim";
+    const post = new Post();
+    (post as any).title = "hello";
+    (author as any).posts = [post];
+
+    buf.persist(author);
+    await buf.flush();
+
+    expect((author as any).id).toBeDefined();
+    expect((post as any).id).toBeDefined();
+
+    const rows: any[] = await conn.em.query(
+      `SELECT author_id FROM "${postName}" WHERE id = ?`,
+      [(post as any).id],
+    );
+    expect(rows).toHaveLength(1);
+    // The regression: author_id stayed NULL because the buffer wrote the FK to
+    // the relation property ("author") rather than the shadow ("authorId").
+    expect(rows[0].author_id).toBe((author as any).id);
+  });
+
+  it("cascade-deletes children through a @RelationColumn FK without throwing", async () => {
+    const author: any = await conn.em.save(Author, { name: "kim" } as any);
+    await conn.em.save(Post, { title: "p1", author } as any);
+    await conn.em.save(Post, { title: "p2", author } as any);
+
+    // Sanity: both children were seeded with the FK set.
+    const seeded: any[] = await conn.em.query(
+      `SELECT COUNT(*) AS c FROM "${postName}" WHERE author_id = ?`,
+      [author.id],
+    );
+    expect(Number(seeded[0].c)).toBe(2);
+
+    const buf: WriteBuffer = (conn.em as any).buffer();
+    buf.remove(author);
+    await buf.flush();
+
+    const remaining: any[] = await conn.em.query(
+      `SELECT COUNT(*) AS c FROM "${postName}" WHERE author_id = ?`,
+      [author.id],
+    );
+    expect(Number(remaining[0].c)).toBe(0);
+
+    const parent: any[] = await conn.em.query(
+      `SELECT COUNT(*) AS c FROM "${authorName}" WHERE id = ?`,
+      [author.id],
+    );
+    expect(Number(parent[0].c)).toBe(0);
+  });
+});

--- a/__tests__/unit/buffer-plugin.test.ts
+++ b/__tests__/unit/buffer-plugin.test.ts
@@ -2776,6 +2776,12 @@ describe("Buffer Plugin", () => {
         ...data,
         id: data.id ?? insertId++,
       }));
+      // The owning-side FK is persisted to the already-inserted parent row via
+      // a targeted UPDATE (the parent was INSERTed before the related entity
+      // had a PK).
+      const updateSpy = jest
+        .spyOn(em, "update")
+        .mockResolvedValue({ affected: 1 } as any);
 
       const mut = em.buffer();
 
@@ -2792,6 +2798,13 @@ describe("Buffer Plugin", () => {
       // Parent + profile cascade insert
       expect(result.inserts).toBe(2);
       expect(profile.id).toBeDefined();
+      // FK resolved on the instance AND written back to the parent row.
+      expect((user as any).profileId).toBe(profile.id);
+      expect(updateSpy).toHaveBeenCalledWith(
+        UserWithProfile,
+        { id: (user as any).id },
+        { profileId: profile.id },
+      );
     });
   });
 

--- a/src/core/plugin/buffer/CascadeProcessor.ts
+++ b/src/core/plugin/buffer/CascadeProcessor.ts
@@ -8,9 +8,20 @@ import { PluginContext } from "../PluginContext";
 import { TrackedEntry, DeleteEntry } from "./BufferEntry";
 import { BufferFlushResult, BufferPluginOptions, ResolvedBufferOptions } from "./BufferPreview";
 import { CollectionDiff } from "./CollectionTracker";
-import { resolveFkColumn } from "./CollectionTracker";
+import { resolveFkColumn, resolveFkWriteKeys, assignFkValue } from "./CollectionTracker";
 import { IdentityMapManager, EntityInstance, ColumnValueMap } from "./IdentityMapManager";
 import type { EntityManager } from "../../EntityManager";
+
+/**
+ * Children added to some tracked parent's O2M collection during a flush,
+ * indexed by instance identity and by PK (per child entity name). Used to spare
+ * reparented children from orphan removal — a child moved from parent A to
+ * parent B appears in A.removed AND B.added, and must not be deleted.
+ */
+export interface ReparentedChildren {
+  instances: Set<EntityInstance>;
+  pks: Map<string, Set<any>>;
+}
 
 /**
  * Handles cascade insert/update/delete propagation for WriteBuffer.
@@ -35,6 +46,12 @@ export class CascadeProcessor {
 
   /**
    * Process cascade insert/update for @OneToMany, @OneToOne, and @ManyToMany relations.
+   *
+   * @param isNewParent — true when `instance` was just INSERTed (persist path).
+   *   A new parent's collections have no snapshot baseline (it was never
+   *   tracked), so the collection-diff flush step never writes its M2M pivot
+   *   rows. When set, this method links every M2M child here instead. Cascade
+   *   recursion always sets it (cascaded children are freshly saved).
    */
   async processCascadeInsertUpdate(
     txEm: EntityManager,
@@ -42,6 +59,7 @@ export class CascadeProcessor {
     instance: EntityInstance,
     visited: Set<EntityInstance>,
     result: BufferFlushResult,
+    isNewParent = false,
   ): Promise<void> {
     if (!this.options.cascade.persist) return;
 
@@ -56,21 +74,21 @@ export class CascadeProcessor {
       if (!Array.isArray(children) || children.length === 0) continue;
 
       const ChildEntity = rel.getRelatedEntity();
-      const fkColumn = resolveFkColumn(rel, ChildEntity);
+      const fkKeys = resolveFkWriteKeys(rel.mappedBy, ChildEntity);
       const parentPk = this.idMap.getParentPkValue(instance, entityClass);
 
       for (const child of children) {
         if (visited.has(child)) continue;
         visited.add(child);
 
-        child[fkColumn] = parentPk;
+        assignFkValue(child, fkKeys, parentPk);
 
         const childInfo = this.idMap.getColumnInfo(ChildEntity);
         const childData: ColumnValueMap = {};
         for (const col of childInfo.columnNames) {
           if (child[col] !== undefined) childData[col] = child[col];
         }
-        childData[fkColumn] = parentPk;
+        assignFkValue(childData, fkKeys, parentPk);
 
         const savedChild = await txEm.save(ChildEntity, childData);
         if (savedChild) {
@@ -81,7 +99,7 @@ export class CascadeProcessor {
         }
         result.inserts++;
 
-        await this.processCascadeInsertUpdate(txEm, ChildEntity, child, visited, result);
+        await this.processCascadeInsertUpdate(txEm, ChildEntity, child, visited, result, true);
       }
     }
 
@@ -117,9 +135,28 @@ export class CascadeProcessor {
       if (rel.joinColumn) {
         const relatedPk = this.idMap.getParentPkValue(related, RelatedEntity);
         instance[rel.joinColumn] = relatedPk;
+
+        // The parent row was already written (INSERT on the persist path /
+        // UPDATE on the dirty-tracked path) BEFORE this cascade ran, with the
+        // FK still null or stale — the related entity did not have a PK yet.
+        // Persist the now-resolved FK to the parent row with a targeted UPDATE
+        // so it is not silently lost.
+        const parentInfo = this.idMap.getColumnInfo(entityClass);
+        const parentPkValue = this.idMap.getParentPkValue(instance, entityClass);
+        if (
+          parentInfo.pkColumns.length === 1 &&
+          parentPkValue != null &&
+          relatedPk != null
+        ) {
+          await txEm.update(
+            entityClass,
+            { [parentInfo.pkColumns[0]]: parentPkValue } as any,
+            { [rel.joinColumn]: relatedPk } as any,
+          );
+        }
       }
 
-      await this.processCascadeInsertUpdate(txEm, RelatedEntity, related, visited, result);
+      await this.processCascadeInsertUpdate(txEm, RelatedEntity, related, visited, result, true);
     }
 
     // @ManyToMany cascade persist (owning side - has joinTable, no mappedBy)
@@ -160,7 +197,41 @@ export class CascadeProcessor {
           result.inserts++;
         }
       }
+
+      // A NEW parent's collection has no snapshot baseline (it was never
+      // tracked), so the collection-diff flush step never writes its pivot
+      // rows. Link every child here — all of them are "added" relative to an
+      // empty original set. Existing (tracked) parents are handled by
+      // processManyToManyCollectionDiff instead, so skip them to avoid
+      // double-inserting.
+      if (isNewParent && this.options.manyToManySync && rel.joinTable) {
+        const parentPk = this.idMap.getParentPkValue(instance, entityClass);
+        if (parentPk != null && relatedPkColumns.length === 1) {
+          for (const child of children) {
+            const childPk = child[relatedPkColumns[0]];
+            if (childPk == null) continue;
+            await this.insertPivotRow(txEm, rel.joinTable, parentPk, childPk);
+            result.inserts++;
+          }
+        }
+      }
     }
+  }
+
+  /**
+   * Insert a single M2M pivot (join table) row linking a parent PK to a child PK.
+   */
+  private async insertPivotRow(
+    txEm: EntityManager,
+    joinTable: { name: string; joinColumn: string; inverseJoinColumn: string },
+    parentPk: any,
+    childPk: any,
+  ): Promise<void> {
+    const wrappedTable = this.ctx.wrapTable(joinTable.name);
+    const wrappedJoinCol = this.ctx.wrap(joinTable.joinColumn);
+    const wrappedInverseCol = this.ctx.wrap(joinTable.inverseJoinColumn);
+    const sql = `INSERT INTO ${wrappedTable} (${wrappedJoinCol}, ${wrappedInverseCol}) VALUES (?, ?)`;
+    await txEm.query(sql, [parentPk, childPk]);
   }
 
   /**
@@ -172,19 +243,21 @@ export class CascadeProcessor {
     diff: CollectionDiff,
     visited: Set<EntityInstance>,
     result: BufferFlushResult,
+    reparented?: ReparentedChildren,
   ): Promise<void> {
     const { snapshot } = diff;
     const parentPk = this.idMap.getParentPkValue(parentEntry.instance, parentEntry.entity);
 
     // Added children - cascade insert if cascade includes insert
     if (this.options.cascade.persist && hasCascade(snapshot.cascade, "insert")) {
+      const fkKeys = snapshot.mappedBy
+        ? resolveFkWriteKeys(snapshot.mappedBy, snapshot.relatedEntity)
+        : undefined;
       for (const child of diff.added) {
         if (visited.has(child)) continue;
         visited.add(child);
 
-        if (snapshot.fkColumn) {
-          child[snapshot.fkColumn] = parentPk;
-        }
+        if (fkKeys) assignFkValue(child, fkKeys, parentPk);
 
         const ChildEntity = snapshot.relatedEntity;
         const childInfo = this.idMap.getColumnInfo(ChildEntity);
@@ -192,9 +265,7 @@ export class CascadeProcessor {
         for (const col of childInfo.columnNames) {
           if (child[col] !== undefined) childData[col] = child[col];
         }
-        if (snapshot.fkColumn) {
-          childData[snapshot.fkColumn] = parentPk;
-        }
+        if (fkKeys) assignFkValue(childData, fkKeys, parentPk);
 
         const saved = await txEm.save(ChildEntity, childData);
         if (saved) {
@@ -211,16 +282,30 @@ export class CascadeProcessor {
     if (this.options.orphanRemoval) {
       const ChildEntity = snapshot.relatedEntity;
       const childInfo = this.idMap.getColumnInfo(ChildEntity);
+      const reparentedPks = reparented?.pks.get(ChildEntity.name);
       for (const child of diff.removed) {
+        // A child re-added to another tracked parent was reparented, not
+        // orphaned — deleting it would destroy a row that still has an owner.
+        if (reparented?.instances.has(child)) continue;
+
         const criteria: ColumnValueMap = {};
         for (const pk of childInfo.pkColumns) {
           const v = child[pk];
           if (v !== undefined && v !== null) criteria[pk] = v;
         }
-        if (Object.keys(criteria).length > 0) {
-          await txEm.delete(ChildEntity, criteria);
-          result.deletes++;
+        if (Object.keys(criteria).length === 0) continue;
+
+        // Same row moved as a fresh instance (reloaded) — match by PK too.
+        if (
+          reparentedPks &&
+          childInfo.pkColumns.length === 1 &&
+          reparentedPks.has(criteria[childInfo.pkColumns[0]])
+        ) {
+          continue;
         }
+
+        await txEm.delete(ChildEntity, criteria);
+        result.deletes++;
       }
     }
   }
@@ -251,8 +336,7 @@ export class CascadeProcessor {
     for (const child of diff.added) {
       const childPk = childPkColumns.length === 1 ? child[childPkColumns[0]] : null;
       if (childPk == null) continue;
-      const sql = `INSERT INTO ${wrappedTable} (${wrappedJoinCol}, ${wrappedInverseCol}) VALUES (?, ?)`;
-      await txEm.query(sql, [parentPk, childPk]);
+      await this.insertPivotRow(txEm, snapshot.joinTable, parentPk, childPk);
       result.inserts++;
     }
 

--- a/src/core/plugin/buffer/CollectionTracker.ts
+++ b/src/core/plugin/buffer/CollectionTracker.ts
@@ -3,6 +3,8 @@ import { ClazzType } from "../../../utils";
 import { ONE_TO_MANY_TOKEN, OneToManyMetadata } from "../../../decorators/OneToMany";
 import { MANY_TO_MANY_TOKEN, ManyToManyMetadata } from "../../../decorators/ManyToMany";
 import { MANY_TO_ONE_TOKEN } from "../../../decorators/ManyToOne";
+import { RELATION_COLUMN_TOKEN, RelationColumnMetadata } from "../../../decorators/RelationColumn";
+import { COLUMN_TOKEN } from "../../../decorators/Column";
 
 /**
  * Snapshot of a collection (O2M or M2M array) at track() time.
@@ -118,17 +120,99 @@ export function diffCollection(
 }
 
 /**
- * Resolve the FK column name on the child entity for a given @OneToMany relation.
+ * Resolve the child entity's foreign-key DB column name for a @OneToMany
+ * relation, mirroring RelationMetadataResolver.resolveManyToOneMetadata so that
+ * query paths (lazy load, cascade-delete criteria) target the real column.
+ *
+ * Resolution order for the inverse @ManyToOne (matched by `mappedBy`):
+ *   1. @RelationColumn({ name }) → its name (or `${prop}Id` when omitted)
+ *   2. deprecated @ManyToOne({ joinColumn }) option
+ *   3. a backing @Column named `${prop}Id` → its DB name
+ *   4. fallback: the relation property name (legacy column-name == property key)
+ *
+ * NOTE: this returns the DB column, suitable for WHERE/criteria. To WRITE the FK
+ * on a cascade-inserted child (which goes through em.save, not a raw column),
+ * use {@link resolveFkWriteKeys} — save reads the shadow accessor, not the raw
+ * column.
+ *
  * Exported for reuse by CascadeProcessor and LazyRelationInjector.
  */
 export function resolveFkColumn(
   rel: OneToManyMetadata<any>,
   ChildEntity: ClazzType<any>,
 ): string {
+  const mappedBy = rel.mappedBy;
+
+  // 1. @RelationColumn wins (may declare an FK with no backing @Column).
+  const relationColumns: RelationColumnMetadata[] =
+    Reflect.getMetadata(RELATION_COLUMN_TOKEN, ChildEntity) ?? [];
+  const relCol = relationColumns.find((rc) => rc.propertyKey === mappedBy);
+  if (relCol) return relCol.name ?? `${mappedBy}Id`;
+
+  // 2. Deprecated joinColumn option.
   const manyToOneMeta: any[] =
     Reflect.getMetadata(MANY_TO_ONE_TOKEN, ChildEntity) ?? [];
-  const match = manyToOneMeta.find(
-    (m: any) => m.columnName === rel.mappedBy,
-  );
-  return match?.joinColumn ?? rel.mappedBy;
+  const match = manyToOneMeta.find((m: any) => m.columnName === mappedBy);
+  if (match?.joinColumn) return match.joinColumn;
+
+  // 3. Backing @Column following the `${prop}Id` convention.
+  const columnsMeta: any[] =
+    Reflect.getMetadata(COLUMN_TOKEN, ChildEntity) ?? [];
+  const fkProp = `${mappedBy}Id`;
+  const colMatch = columnsMeta.find((c: any) => c.propertyKey === fkProp);
+  if (colMatch) return colMatch.name ?? fkProp;
+
+  // 4. Legacy fallback.
+  return mappedBy;
+}
+
+/**
+ * FK write targets for setting a cascade-inserted child's foreign key.
+ *
+ * em.save resolves a @ManyToOne FK from (in order) the relation object, the
+ * shadow accessor `${prop}Id`, or an explicit `option.fkProperty` — never from
+ * the raw join-column DB name. So a cascade insert must write the shadow (and
+ * fkProperty), not just the raw column, or the FK is silently dropped when the
+ * FK is declared via @RelationColumn with no backing @Column.
+ * Mirrors CascadeHandler.cascadeSaveOneToMany.
+ */
+export interface FkWriteKeys {
+  /** Legacy raw target: joinColumn option, else the relation property name. */
+  fkColumn: string;
+  /** Shadow accessor `${manyToOneProp}Id` — the key em.save actually reads. */
+  shadowKey: string;
+  /** Explicit @ManyToOne({ fkProperty }) backing property, when configured. */
+  fkPropertyKey?: string;
+}
+
+/**
+ * Resolve the FK write targets for the inverse @ManyToOne of a @OneToMany
+ * relation (matched by `mappedBy`).
+ */
+export function resolveFkWriteKeys(
+  mappedBy: string,
+  ChildEntity: ClazzType<any>,
+): FkWriteKeys {
+  const manyToOneMeta: any[] =
+    Reflect.getMetadata(MANY_TO_ONE_TOKEN, ChildEntity) ?? [];
+  const match = manyToOneMeta.find((m: any) => m.columnName === mappedBy);
+  return {
+    fkColumn: match?.joinColumn ?? mappedBy,
+    shadowKey: `${match?.columnName ?? mappedBy}Id`,
+    fkPropertyKey: match?.option?.fkProperty,
+  };
+}
+
+/**
+ * Write a resolved parent PK to every FK target of a cascade-inserted child so
+ * the FK survives em.save regardless of how it is declared.
+ */
+export function assignFkValue(
+  target: any,
+  keys: FkWriteKeys,
+  value: any,
+): void {
+  target[keys.fkColumn] = value;
+  target[keys.shadowKey] = value;
+  if (keys.fkPropertyKey) target[keys.fkPropertyKey] = value;
 }

--- a/src/core/plugin/buffer/FlushExecutor.ts
+++ b/src/core/plugin/buffer/FlushExecutor.ts
@@ -159,7 +159,7 @@ export class FlushExecutor {
           }
           result.inserts++;
           visited.add(entry.instance);
-          await this.cascade.processCascadeInsertUpdate(txEm, entry.entity, entry.instance, visited, result);
+          await this.cascade.processCascadeInsertUpdate(txEm, entry.entity, entry.instance, visited, result, true);
         }
         continue;
       }
@@ -216,7 +216,7 @@ export class FlushExecutor {
       result.inserts += entries.length;
       for (const entry of entries) {
         visited.add(entry.instance);
-        await this.cascade.processCascadeInsertUpdate(txEm, entry.entity, entry.instance, visited, result);
+        await this.cascade.processCascadeInsertUpdate(txEm, entry.entity, entry.instance, visited, result, true);
       }
     }
   }
@@ -396,14 +396,34 @@ export class FlushExecutor {
     entry: BulkDeleteEntry,
     trackedEntries: Map<EntityInstance, TrackedEntry>,
   ): void {
-    if (!this.idMap.isPureEqualityWhere(entry.where)) {
-      this.detachAllTrackedOfEntity(entry.entity, trackedEntries);
+    this.evictTrackedMatching(entry.entity, entry.where, trackedEntries);
+  }
+
+  /**
+   * Evict the Identity-Map entries a DELETE of `entity` WHERE `where` removed.
+   *
+   * A plain equality WHERE evicts exactly the matching tracked instances; an
+   * operator/combinator WHERE conservatively detaches every tracked instance of
+   * this entity (the DB decided which rows were deleted, and keeping a stale
+   * identity-map entry risks a later phantom cache hit of a deleted row).
+   *
+   * Shared by the bulk-DELETE path and the regular queued-DELETE path
+   * (`buf.delete(entity, criteria)` and cascade deletes) so both keep the
+   * first-level cache consistent with the database.
+   */
+  evictTrackedMatching(
+    entity: ClazzType<any>,
+    where: ColumnValueMap,
+    trackedEntries: Map<EntityInstance, TrackedEntry>,
+  ): void {
+    if (!this.idMap.isPureEqualityWhere(where)) {
+      this.detachAllTrackedOfEntity(entity, trackedEntries);
       return;
     }
     const toEvict: EntityInstance[] = [];
     for (const tracked of trackedEntries.values()) {
-      if (tracked.entity !== entry.entity) continue;
-      if (!this.idMap.matchesWhere(tracked.instance, entry.where)) continue;
+      if (tracked.entity !== entity) continue;
+      if (!this.idMap.matchesWhere(tracked.instance, where)) continue;
       toEvict.push(tracked.instance);
     }
     for (const instance of toEvict) {

--- a/src/core/plugin/buffer/LazyRelationInjector.ts
+++ b/src/core/plugin/buffer/LazyRelationInjector.ts
@@ -19,6 +19,12 @@ import type { ManyToManyMetadata } from "../../../decorators/ManyToMany";
 export type ResolveIdentityFn = (entityClass: ClazzType<any>, instance: EntityInstance) => EntityInstance;
 
 /**
+ * Callback fired when a lazy O2M/M2M collection proxy first materializes,
+ * so the buffer can capture the loaded items as a change-tracking baseline.
+ */
+export type CollectionMaterializedFn = (instance: EntityInstance, propertyKey: string) => void;
+
+/**
  * Injects lazy-loading proxies on unloaded relation properties.
  *
  * When a proxied property is accessed:
@@ -32,15 +38,18 @@ export class LazyRelationInjector {
   private readonly ctx: PluginContext;
   private readonly idMap: IdentityMapManager;
   private readonly resolveIdentity: ResolveIdentityFn;
+  private readonly onCollectionMaterialized?: CollectionMaterializedFn;
 
   constructor(
     ctx: PluginContext,
     idMap: IdentityMapManager,
     resolveIdentity: ResolveIdentityFn,
+    onCollectionMaterialized?: CollectionMaterializedFn,
   ) {
     this.ctx = ctx;
     this.idMap = idMap;
     this.resolveIdentity = resolveIdentity;
+    this.onCollectionMaterialized = onCollectionMaterialized;
   }
 
   /**
@@ -246,6 +255,7 @@ export class LazyRelationInjector {
                 configurable: true, enumerable: true, writable: true,
                 value: cachedValue,
               });
+              this.onCollectionMaterialized?.(instance, propertyKey);
               return cachedValue;
             });
         }
@@ -312,6 +322,7 @@ export class LazyRelationInjector {
             Object.defineProperty(instance, propertyKey, {
               configurable: true, enumerable: true, writable: true, value: [],
             });
+            this.onCollectionMaterialized?.(instance, propertyKey);
             return [];
           }
 
@@ -329,6 +340,7 @@ export class LazyRelationInjector {
           Object.defineProperty(instance, propertyKey, {
             configurable: true, enumerable: true, writable: true, value: resolvedResults,
           });
+          this.onCollectionMaterialized?.(instance, propertyKey);
           return resolvedResults;
         });
         return loadPromise;

--- a/src/core/plugin/buffer/WriteBuffer.ts
+++ b/src/core/plugin/buffer/WriteBuffer.ts
@@ -16,13 +16,23 @@ import { BufferStrategy, SnapshotStrategy } from "./BufferStrategy";
 import { EntityState } from "./EntityUnitState";
 import { sortForInsert, sortForDelete, buildTopologicalIndexMap, sortByIndex } from "./DependencyGraph";
 import { snapshotCollections, diffCollection } from "./CollectionTracker";
+import type { CollectionSnapshot, CollectionDiff } from "./CollectionTracker";
 import { createPersistentCollection } from "./PersistentCollection";
 import { IdentityMapManager } from "./IdentityMapManager";
 import { CascadeProcessor } from "./CascadeProcessor";
+import type { ReparentedChildren } from "./CascadeProcessor";
 import { FlushExecutor } from "./FlushExecutor";
 import { EntityValidator } from "../../EntityValidator";
 import { LazyRelationInjector } from "./LazyRelationInjector";
 import type { EntityManager } from "../../EntityManager";
+
+/**
+ * Sentinel snapshot value used by merge() to force a detached instance's
+ * defined columns to diff as changed. It is a unique Symbol, so `deepEquals`
+ * never reports it equal to a real column value — guaranteeing an UPDATE of
+ * exactly the columns the detached instance carries.
+ */
+const MERGE_DIRTY_SENTINEL = Symbol("stingerloom.buffer.mergeDirty");
 
 /**
  * WriteBuffer — buffers entity writes and flushes them in a single transaction.
@@ -114,7 +124,35 @@ export class WriteBuffer {
     );
     this.lazyInjector = new LazyRelationInjector(
       ctx, this.idMap, this.resolveIdentity.bind(this),
+      this.captureLoadedCollectionSnapshot.bind(this),
     );
+  }
+
+  /**
+   * Capture a collection's baseline snapshot the moment its lazy proxy
+   * materializes.
+   *
+   * track() snapshots collections eagerly, but it runs BEFORE lazy proxies are
+   * injected — so an unloaded (proxy) O2M/M2M collection has no snapshot
+   * baseline. Without one, the flush collection-diff step skips the property
+   * entirely and a later add/remove on the loaded collection is silently
+   * dropped. Recording the baseline here (from the freshly loaded items) lets
+   * the diff detect those mutations.
+   */
+  private captureLoadedCollectionSnapshot(instance: any, propertyKey: string): void {
+    const entry = this.trackedEntries.get(instance);
+    if (!entry) return;
+    // The property now holds the loaded array, so snapshotCollections captures
+    // exactly the loaded items as the originalItems baseline.
+    const snaps = snapshotCollections(instance, entry.entity);
+    const match = snaps.find((s) => s.propertyKey === propertyKey);
+    if (!match) return;
+    const existing = entry.collectionSnapshots ?? [];
+    // Only fill the gap left by a lazy load — never clobber a baseline already
+    // captured for this property (e.g. an eagerly-loaded collection).
+    if (existing.some((s) => s.propertyKey === propertyKey)) return;
+    existing.push(match);
+    entry.collectionSnapshots = existing;
   }
 
   // ── Entity State ─────────────────────────────────────────────
@@ -679,6 +717,7 @@ export class WriteBuffer {
     this.idMap.validateEntity(entityClass);
     const { columnNames, pkColumns } = this.idMap.getColumnInfo(entityClass);
 
+    let mergedIntoExisting = false;
     try {
       const key = this.idMap.buildIdentityKey(entityClass, instance, pkColumns);
       const existing = this.idMap.identityMap.get(key);
@@ -686,24 +725,28 @@ export class WriteBuffer {
         for (const col of columnNames) {
           if (instance[col] !== undefined) existing[col] = instance[col];
         }
-        // Cascade merge
-        if (this.options.cascade.merge) {
-          this.cascade.propagateToRelations(instance, entityClass, (child) => {
-            try { this.merge(child, seen); } catch (err) {
-              // Only swallow "not registered" errors
-              if (err instanceof Error && /not.*registered|no.*entity|table.*not/i.test(err.message)) return;
-              throw err;
-            }
-          });
-        }
-        return this;
+        mergedIntoExisting = true;
       }
     } catch (err) {
       // PK missing → track as new; only swallow identity key errors
       if (!(err instanceof Error && /PK column/.test(err.message))) throw err;
     }
 
-    this.track(instance);
+    if (!mergedIntoExisting) {
+      // Not in the identity map. A full PK means this is a DETACHED entity
+      // representing an existing row, so its columns must be written back on
+      // flush — plain track() snapshots the current values and yields a zero
+      // diff, silently dropping the detached edits. Track it with a
+      // forced-dirty baseline so exactly the columns it carries are UPDATEd.
+      const hasFullPk =
+        pkColumns.length > 0 &&
+        pkColumns.every((pk) => instance[pk] !== undefined && instance[pk] !== null);
+      if (hasFullPk && !this.trackedEntries.has(instance)) {
+        this.trackAsMergedDetached(instance, entityClass, columnNames, pkColumns);
+      } else {
+        this.track(instance);
+      }
+    }
 
     // Cascade merge
     if (this.options.cascade.merge) {
@@ -717,6 +760,37 @@ export class WriteBuffer {
     }
 
     return this;
+  }
+
+  /**
+   * Track a detached instance for merge() so that every column it actually
+   * defines is written back on flush.
+   *
+   * A normal track() snapshots the instance's current values, so the flush
+   * dirty-check finds no difference and the detached edits are lost. Here the
+   * snapshot is seeded with {@link MERGE_DIRTY_SENTINEL} for each defined
+   * non-PK column, which never equals a real value — forcing those columns
+   * dirty. Columns the caller left undefined keep an undefined baseline and are
+   * not touched, so unset columns are never accidentally nulled out.
+   */
+  private trackAsMergedDetached(
+    instance: any,
+    entityClass: ClazzType<any>,
+    columnNames: string[],
+    pkColumns: string[],
+  ): void {
+    this.track(instance);
+    const entry = this.trackedEntries.get(instance);
+    if (!entry) return;
+    const forced: Record<string, any> = {};
+    for (const col of columnNames) {
+      if (pkColumns.includes(col)) {
+        forced[col] = instance[col];
+      } else {
+        forced[col] = instance[col] === undefined ? undefined : MERGE_DIRTY_SENTINEL;
+      }
+    }
+    entry.snapshot = forced;
   }
 
   /**
@@ -1080,7 +1154,7 @@ export class WriteBuffer {
             result.inserts++;
             visited.add(entry.instance);
             await this.flushExec.emitFlushEvent("postInsert", entry.entity, entry.instance);
-            await this.cascade.processCascadeInsertUpdate(txEm, entry.entity, entry.instance, visited, result);
+            await this.cascade.processCascadeInsertUpdate(txEm, entry.entity, entry.instance, visited, result, true);
           }
         }
 
@@ -1091,16 +1165,40 @@ export class WriteBuffer {
         }
 
         // 4. Collection diffs (O2M orphan removal + M2M pivot sync)
+        // First pass: compute every diff and collect the children ADDED to any
+        // parent's O2M collection (by identity and PK). A child moved from
+        // parent A to B lands in A.removed AND B.added — it was reparented, not
+        // orphaned, so orphan removal below must spare it.
+        const reparented: ReparentedChildren = { instances: new Set(), pks: new Map() };
+        const pendingDiffs: Array<{ entry: TrackedEntry; colSnap: CollectionSnapshot; diff: CollectionDiff }> = [];
         for (const entry of sortedTracked) {
           if (!entry.collectionSnapshots) continue;
           for (const colSnap of entry.collectionSnapshots) {
             const diff = diffCollection(entry.instance, colSnap);
             if (!diff) continue;
+            pendingDiffs.push({ entry, colSnap, diff });
             if (colSnap.relationType === "oneToMany") {
-              await this.cascade.processOneToManyCollectionDiff(txEm, entry, diff, visited, result);
-            } else if (colSnap.relationType === "manyToMany") {
-              await this.cascade.processManyToManyCollectionDiff(txEm, entry, diff, result);
+              const childPks = this.idMap.getColumnInfo(colSnap.relatedEntity).pkColumns;
+              for (const child of diff.added) {
+                reparented.instances.add(child);
+                if (childPks.length === 1) {
+                  const pk = child[childPks[0]];
+                  if (pk != null) {
+                    const name = colSnap.relatedEntity.name;
+                    let set = reparented.pks.get(name);
+                    if (!set) { set = new Set(); reparented.pks.set(name, set); }
+                    set.add(pk);
+                  }
+                }
+              }
             }
+          }
+        }
+        for (const { entry, colSnap, diff } of pendingDiffs) {
+          if (colSnap.relationType === "oneToMany") {
+            await this.cascade.processOneToManyCollectionDiff(txEm, entry, diff, visited, result, reparented);
+          } else if (colSnap.relationType === "manyToMany") {
+            await this.cascade.processManyToManyCollectionDiff(txEm, entry, diff, result);
           }
         }
 
@@ -1121,6 +1219,10 @@ export class WriteBuffer {
           await this.flushExec.emitFlushEvent("preDelete", del.entity, undefined, undefined, del.criteria);
           await txEm.delete(del.entity, del.criteria);
           result.deletes++;
+          // Keep the first-level cache honest: a criteria delete (or cascade
+          // delete) must not leave a matching tracked instance behind, or a
+          // later PK findOne would return the just-deleted row from cache.
+          this.flushExec.evictTrackedMatching(del.entity, del.criteria, this.trackedEntries);
           await this.flushExec.emitFlushEvent("postDelete", del.entity, undefined, undefined, del.criteria);
         }
 


### PR DESCRIPTION
Continues the WriteBuffer (Unit of Work) data-loss audit backlog. Seven cascade/tracking/cache defects, each reproduced against real SQL first, then fixed.

## Cascade persistence
- **M2M pivot rows** — a newly `persist()`ed parent lands in the persist queue (not the tracked set), so the collection-diff step never wrote its join-table rows. New parents now link every M2M child (`isNewParent`).
- **O2O owning-side FK** — the parent row was INSERTed before the cascaded relation was saved, leaving the FK NULL in the DB. A targeted UPDATE now writes the resolved FK back.
- **@RelationColumn FKs** — buffer FK resolution only knew the deprecated `joinColumn` option and otherwise fell back to the relation property name. For the `@RelationColumn({ name })` pattern (no backing `@Column`) this left cascade-inserted children with a NULL FK and made cascade delete fail the whole flush. Split into query-path resolution (real DB column, for cascade-delete criteria and lazy O2M load) and write-path resolution (the shadow accessor `${prop}Id` that `em.save` actually reads).

## Change tracking
- **Lazy collection loss** — `track()` snapshots collections before lazy proxies are injected, so an unloaded O2M/M2M collection had no baseline and later add/remove was dropped. The baseline is now captured the moment the proxy materializes.
- **orphanRemoval reparenting** — moving a child from parent A to parent B made it appear in A's `removed` set and get deleted. Children added to any tracked parent are now collected first and spared from orphan removal.

## Merge / cache correctness
- **Detached merge** — `merge()` of an instance the buffer had never seen fell through to `track()`, snapshotting current values so the diff was empty and edits were lost. Detached instances with a full PK are now tracked with a forced-dirty baseline.
- **delete(criteria) stale cache** — a criteria delete never evicted matching tracked instances, so a later PK `findOne()` returned the deleted row from the first-level cache. Both the queued-delete and cascade-delete paths now evict matching Identity-Map entries.

## Verification
- Unit: 5,326 passed (0 failures); tsc CJS + ESM clean
- SQLite integration: 544 passed (55 suites, incl. 5 new in-memory repro files)
- Real PostgreSQL buffer-plugin: 33 passed · real MariaDB buffer-plugin: 33 passed