### PR TITLE
feat(core/em): add create/merge/preload/findOneByOrFail entity-construction helpers

### DIFF
--- a/__tests__/integration/sqlite/entity-factory.test.ts
+++ b/__tests__/integration/sqlite/entity-factory.test.ts
@@ -1,0 +1,245 @@
+/**
+ * SQLite In-Memory: EntityManager entity-construction helpers.
+ *
+ * Exercises the new usability methods end-to-end against real SQL:
+ *   - create()          builds a hydrated instance WITHOUT persisting
+ *   - merge()           combines partial patches into an instance (in-memory)
+ *   - preload()         loads a row by PK and merges a patch onto it
+ *   - findOneByOrFail() filter-first "get or throw" read
+ *
+ * The audit lesson applies: mock-based unit tests hid real data bugs, so these
+ * assertions go through a live better-sqlite3 database and re-read persisted
+ * rows rather than trusting return values.
+ */
+
+import "reflect-metadata";
+import {
+  createTestConnection,
+  type TestConnectionResult,
+} from "../helpers/test-connection";
+import { Entity, Column, PrimaryGeneratedColumn, EntityNotFoundError } from "../../../src";
+import { getScannerInstance } from "../../../src/scanner/ScannerContainer";
+import { ColumnScanner } from "../../../src/scanner";
+import { generateTableName } from "../helpers/create-test-entity";
+
+describe("[Integration] SQLite: EntityManager construction helpers", () => {
+  let conn: TestConnectionResult;
+  let User: new () => any;
+
+  beforeAll(async () => {
+    const className = generateTableName("factory_user");
+
+    conn = await createTestConnection(
+      {
+        type: "sqlite",
+        database: ":memory:",
+        synchronize: true,
+        logging: false,
+      },
+      () => {
+        getScannerInstance(ColumnScanner).clear();
+
+        const U = class {
+          // Prototype method — proves create()/preload() return real instances,
+          // not plain objects.
+          greeting(): string {
+            return `Hi ${(this as any).name}`;
+          }
+        } as any;
+        Object.defineProperty(U, "name", { value: className, writable: false });
+
+        Reflect.defineMetadata("design:type", Number, U.prototype, "id");
+        PrimaryGeneratedColumn()(U.prototype, "id");
+
+        Reflect.defineMetadata("design:type", String, U.prototype, "name");
+        Column()(U.prototype, "name");
+
+        Reflect.defineMetadata("design:type", String, U.prototype, "email");
+        Column({ type: "varchar", nullable: true })(U.prototype, "email");
+
+        Reflect.defineMetadata("design:type", String, U.prototype, "role");
+        Column({ type: "varchar", nullable: true })(U.prototype, "role");
+
+        Entity()(U);
+
+        User = U;
+        return { entities: [U] };
+      },
+    );
+  }, 30000);
+
+  afterAll(async () => {
+    if (conn) await conn.cleanup();
+  });
+
+  beforeEach(async () => {
+    await conn.em.clear(User);
+  });
+
+  // ── create ────────────────────────────────────────────────
+  describe("create()", () => {
+    it("builds a real instance without persisting it", async () => {
+      const user = conn.em.create(User, { name: "Alice", email: "a@x.com" });
+
+      expect(user).toBeInstanceOf(User);
+      expect(user.name).toBe("Alice");
+      expect(user.email).toBe("a@x.com");
+      expect(user.greeting()).toBe("Hi Alice"); // prototype method survives
+
+      // Nothing was written.
+      expect(await conn.em.count(User)).toBe(0);
+    });
+
+    it("builds an empty instance when no data is given", () => {
+      const user = conn.em.create(User);
+      expect(user).toBeInstanceOf(User);
+      expect(user.name).toBeUndefined();
+    });
+
+    it("builds an array of instances from an array of data", () => {
+      const users = conn.em.create(User, [{ name: "A" }, { name: "B" }]);
+      expect(Array.isArray(users)).toBe(true);
+      expect(users).toHaveLength(2);
+      expect(users[0]).toBeInstanceOf(User);
+      expect(users.map((u: any) => u.name)).toEqual(["A", "B"]);
+    });
+
+    it("a created instance can be handed to save() and persists", async () => {
+      const user = conn.em.create(User, { name: "Alice", email: "a@x.com" });
+      const saved = await conn.em.save(User, user);
+
+      expect(saved.id).toBeDefined();
+      const row = await conn.em.findByPK(User, saved.id);
+      expect(row?.name).toBe("Alice");
+      expect(row?.email).toBe("a@x.com");
+    });
+  });
+
+  // ── merge ─────────────────────────────────────────────────
+  describe("merge()", () => {
+    it("applies later patches over earlier ones and returns the target", () => {
+      const user = conn.em.create(User, { name: "A", email: "a@x.com" });
+      const result = conn.em.merge(user, { name: "B" }, { role: "admin" });
+
+      expect(result).toBe(user); // same reference, mutated in place
+      expect(user.name).toBe("B");
+      expect(user.role).toBe("admin");
+      expect(user.email).toBe("a@x.com"); // untouched key preserved
+    });
+
+    it("skips undefined source values but assigns explicit null", () => {
+      const user = conn.em.create(User, { name: "A", email: "a@x.com" });
+      conn.em.merge(user, { email: undefined as any, role: null as any });
+
+      expect(user.email).toBe("a@x.com"); // undefined did not null it out
+      expect(user.role).toBeNull(); // explicit null assigned
+    });
+
+    it("deep-merges nested plain objects instead of replacing them", () => {
+      const target: any = { profile: { bio: "old", age: 30 } };
+      conn.em.merge(target, { profile: { bio: "new" } } as any);
+
+      expect(target.profile).toEqual({ bio: "new", age: 30 });
+    });
+
+    it("replaces arrays and Date values wholesale", () => {
+      const d1 = new Date("2020-01-01");
+      const d2 = new Date("2021-01-01");
+      const target: any = { tags: ["a", "b"], at: d1 };
+      conn.em.merge(target, { tags: ["c"], at: d2 } as any);
+
+      expect(target.tags).toEqual(["c"]);
+      expect(target.at).toBe(d2);
+    });
+  });
+
+  // ── preload ───────────────────────────────────────────────
+  describe("preload()", () => {
+    it("loads the row by PK and merges the patch, preserving unspecified columns", async () => {
+      const saved = await conn.em.save(User, {
+        name: "Alice",
+        email: "a@x.com",
+        role: "user",
+      });
+
+      const preloaded = await conn.em.preload(User, {
+        id: saved.id,
+        name: "Renamed",
+      });
+
+      expect(preloaded).toBeInstanceOf(User);
+      expect(preloaded!.id).toBe(saved.id);
+      expect(preloaded!.name).toBe("Renamed"); // patched
+      expect(preloaded!.email).toBe("a@x.com"); // preserved from DB
+      expect(preloaded!.role).toBe("user"); // preserved from DB
+    });
+
+    it("the preloaded instance persists a partial update via save()", async () => {
+      const saved = await conn.em.save(User, {
+        name: "Alice",
+        email: "a@x.com",
+      });
+
+      const preloaded = await conn.em.preload(User, {
+        id: saved.id,
+        name: "Renamed",
+      });
+      await conn.em.save(User, preloaded!);
+
+      const row = await conn.em.findByPK(User, saved.id);
+      expect(row?.name).toBe("Renamed");
+      expect(row?.email).toBe("a@x.com"); // untouched column intact after update
+    });
+
+    it("returns undefined when no row matches the primary key", async () => {
+      const result = await conn.em.preload(User, { id: 999999, name: "x" });
+      expect(result).toBeUndefined();
+    });
+
+    it("returns undefined (no query) when the patch lacks a primary key", async () => {
+      const result = await conn.em.preload(User, { name: "x" });
+      expect(result).toBeUndefined();
+    });
+  });
+
+  // ── findOneByOrFail ───────────────────────────────────────
+  describe("findOneByOrFail()", () => {
+    it("returns the matching row", async () => {
+      await conn.em.save(User, { name: "Alice", email: "a@x.com" });
+      const user = await conn.em.findOneByOrFail(User, { name: "Alice" });
+      expect(user.name).toBe("Alice");
+    });
+
+    it("throws EntityNotFoundError when nothing matches", async () => {
+      await expect(
+        conn.em.findOneByOrFail(User, { name: "nobody" }),
+      ).rejects.toBeInstanceOf(EntityNotFoundError);
+    });
+  });
+
+  // ── Repository parity ─────────────────────────────────────
+  describe("BaseRepository parity", () => {
+    it("exposes create/merge/preload/findOneByOrFail delegating to the EM", async () => {
+      const repo = conn.em.getRepository(User);
+
+      const built = repo.create({ name: "Repo", email: "r@x.com" });
+      expect(built).toBeInstanceOf(User);
+      expect(built.name).toBe("Repo");
+
+      repo.merge(built, { role: "admin" });
+      expect(built.role).toBe("admin");
+
+      const saved = await repo.save(built);
+      const preloaded = await repo.preload({ id: saved.id, name: "Repo2" });
+      expect(preloaded!.name).toBe("Repo2");
+      expect(preloaded!.email).toBe("r@x.com");
+
+      const found = await repo.findOneByOrFail({ name: "Repo" });
+      expect(found.id).toBe(saved.id);
+
+      await expect(
+        repo.findOneByOrFail({ name: "ghost" }),
+      ).rejects.toBeInstanceOf(EntityNotFoundError);
+    });
+  });
+});

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -31,6 +31,7 @@ const em = new EntityManager();
 | `findOne` | `<T>(entity, option): Promise<T \| null>` | Single record query |
 | `findOneBy` | `<T>(entity, where): Promise<T \| null>` | Filter-first single query (sugar over `findOne({ where })`) |
 | `findOneOrFail` | `<T>(entity, option): Promise<T>` | Single record query (throws `EntityNotFoundError`) |
+| `findOneByOrFail` | `<T>(entity, where): Promise<T>` | Filter-first single query (throws `EntityNotFoundError`); mirrors `findOneBy` + `findOneOrFail` |
 | `exists` | `<T>(entity, where?, withDeleted?, onlyDeleted?): Promise<boolean>` | Check if any matching record exists |
 | `findByPK` | `<T>(entity, id: unknown): Promise<T \| null>` | Find by primary key value |
 | `findByPKs` | `<T>(entity, ids: unknown[]): Promise<T[]>` | Find by multiple primary key values |
@@ -48,6 +49,16 @@ const em = new EntityManager();
 | `updateMany` | `<T>(entity, data: UpdateData<T>, options): Promise<{ affected: number }>` | Bulk UPDATE (supports SQL expressions) |
 | `increment` | `<T>(entity, where, column: keyof T & string, by?: number): Promise<{ affected: number }>` | Atomically add `by` (default `1`) to a numeric column via `SET col = col + ?`; inherits `update()` safeguards |
 | `decrement` | `<T>(entity, where, column: keyof T & string, by?: number): Promise<{ affected: number }>` | Atomically subtract `by` (default `1`) from a numeric column; counterpart of `increment` |
+
+### Construction (no persistence)
+
+These helpers build or prepare entity instances without a hidden unit of work — hand the result to `save()` to persist.
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `create` | `<T>(entity, data?): InstanceType<ClazzType<T>>` | Build a hydrated instance from a plain object without persisting; real class instance (methods / getters / transformers apply). Pass an array to build many |
+| `merge` | `<T>(target, ...sources): T` | Merge partial patches into an existing instance and return it; nested objects merge recursively, arrays / `Date` / `Buffer` replace, `undefined` is skipped. In-memory only |
+| `preload` | `<T>(entity, partial): Promise<InstanceType<ClazzType<T>> \| undefined>` | Load the row by the PK(s) in `partial`, merge the rest onto it, and return it — ready for a read-modify-write `save()`. `undefined` when no complete PK or no matching row (mirrors TypeORM) |
 
 ### Batch
 
@@ -151,7 +162,7 @@ const userRepo = em.getRepository(User);
 const userRepo = BaseRepository.of(User, em);
 ```
 
-`find`, `findBy`, `findOne`, `findOneBy`, `findOneOrFail`, `findWithCursor`, `findAndCount`, `pluck`, `save`, `delete`, `remove`, `softDelete`, `restore`, `insertMany`, `insertManyAndReturn`, `insertIgnore`, `saveMany`, `deleteMany`, `batchUpsert`, `count`, `sum`, `avg`, `min`, `max`, `explain`, `upsert`, `persist`, `stream`, `streamBatch`, `createQueryBuilder`, `createUpdateBuilder`, `update`, `updateMany`, `increment`, `decrement` — uses the same API as EntityManager without specifying the entity.
+`find`, `findBy`, `findOne`, `findOneBy`, `findOneOrFail`, `findOneByOrFail`, `findWithCursor`, `findAndCount`, `pluck`, `create`, `merge`, `preload`, `save`, `delete`, `remove`, `softDelete`, `restore`, `insertMany`, `insertManyAndReturn`, `insertIgnore`, `saveMany`, `deleteMany`, `batchUpsert`, `count`, `sum`, `avg`, `min`, `max`, `explain`, `upsert`, `persist`, `stream`, `streamBatch`, `createQueryBuilder`, `createUpdateBuilder`, `update`, `updateMany`, `increment`, `decrement` — uses the same API as EntityManager without specifying the entity.
 
 **Repository-only helpers:**
 

--- a/docs/entity-manager.md
+++ b/docs/entity-manager.md
@@ -466,6 +466,43 @@ On `BaseRepository`, omit the entity class argument:
 const ids = await userRepo.pluck("id", { active: true });
 ```
 
+### Constructing entities -- create(), merge(), preload()
+
+These helpers build or prepare entity instances **in memory**. They persist nothing on their own — there is no hidden unit of work or change tracking — so the immediate-execution model is unchanged. When you are ready to write, hand the result to `save()`.
+
+`create()` turns a plain object into a real class instance, identical to one returned by `find()`: instance methods, getters, `@Exclude`, and column transformers all apply. Unlike `save()`, it issues no SQL.
+
+```typescript
+const user = em.create(User, { name: "Alice", email });
+user.activate();              // instance methods work
+await em.save(User, user);    // persist when ready
+
+// Build many at once
+const users = em.create(User, [{ name: "A" }, { name: "B" }]);
+```
+
+`merge()` layers one or more partial patches onto an existing instance and returns it. Nested plain objects / relations merge recursively; arrays, `Date`s, and `Buffer`s replace as a unit; `undefined` values are skipped so they never null out an existing field (pass an explicit `null` to clear one).
+
+```typescript
+em.merge(user, { name: "New name" }, { status: "active" });
+```
+
+`preload()` is the read-modify-write shortcut: it loads the row identified by the primary key(s) in the patch, merges the remaining fields onto the loaded instance, and returns it ready for `save()`. Columns you did not mention keep their database values. It returns `undefined` when the patch has no complete primary key or no row matches (mirroring TypeORM), so a partial-update endpoint can distinguish "not found" from "updated".
+
+```typescript
+// PATCH /users/1  { name: "New name" }
+const patched = await em.preload(User, { id: 1, name: "New name" });
+if (!patched) throw new NotFoundException();
+await em.save(User, patched); // email, role, ... untouched columns preserved
+```
+
+On `BaseRepository`, omit the entity class argument:
+
+```typescript
+const draft = userRepo.create({ name: "Alice" });
+const patched = await userRepo.preload({ id: 1, name: "New name" });
+```
+
 ---
 
 ## Deleting -- delete()

--- a/docs/ko/api-reference.md
+++ b/docs/ko/api-reference.md
@@ -31,6 +31,7 @@ const em = new EntityManager();
 | `findOne` | `<T>(entity, option): Promise<T \| null>` | 단건 조회 |
 | `findOneBy` | `<T>(entity, where): Promise<T \| null>` | 필터 우선 단건 조회 (`findOne({ where })`의 단축형) |
 | `findOneOrFail` | `<T>(entity, option): Promise<T>` | 단건 조회 (없으면 `EntityNotFoundError` 발생) |
+| `findOneByOrFail` | `<T>(entity, where): Promise<T>` | 필터 우선 단건 조회 (없으면 `EntityNotFoundError` 발생); `findOneBy` + `findOneOrFail` 조합 |
 | `exists` | `<T>(entity, where?, withDeleted?, onlyDeleted?): Promise<boolean>` | 매칭되는 레코드 존재 여부 |
 | `findByPK` | `<T>(entity, pk): Promise<T \| null>` | 기본 키로 조회 |
 | `findByPKs` | `<T>(entity, pks[]): Promise<T[]>` | 여러 기본 키로 조회 |
@@ -48,6 +49,16 @@ const em = new EntityManager();
 | `updateMany` | `<T>(entity, data: UpdateData<T>, options): Promise<{ affected: number }>` | 조건별 일괄 UPDATE (SQL 표현식 지원) |
 | `increment` | `<T>(entity, where, column: keyof T & string, by?: number): Promise<{ affected: number }>` | `SET col = col + ?`로 숫자 컬럼에 `by`(기본값 `1`)를 원자적으로 더함; `update()` 안전장치 상속 |
 | `decrement` | `<T>(entity, where, column: keyof T & string, by?: number): Promise<{ affected: number }>` | 숫자 컬럼에서 `by`(기본값 `1`)를 원자적으로 뺌; `increment`의 역연산 |
+
+### 구성 (저장 없음)
+
+숨은 Unit of Work 없이 엔티티 인스턴스를 만들거나 준비하는 헬퍼입니다. 결과를 `save()`에 넘기면 저장됩니다.
+
+| 메서드 | 시그니처 | 설명 |
+|--------|-----------|-------------|
+| `create` | `<T>(entity, data?): InstanceType<ClazzType<T>>` | 평범한 객체로부터 하이드레이트된 인스턴스를 만들되 저장은 안 함; 실제 클래스 인스턴스(메서드/게터/트랜스포머 적용). 배열을 넘기면 여러 개 생성 |
+| `merge` | `<T>(target, ...sources): T` | 기존 인스턴스에 부분 패치를 병합하고 그 인스턴스를 반환; 중첩 객체는 재귀 병합, 배열/`Date`/`Buffer`는 통째로 교체, `undefined`는 건너뜀. 메모리 내 연산만 |
+| `preload` | `<T>(entity, partial): Promise<InstanceType<ClazzType<T>> \| undefined>` | `partial`의 PK로 행을 로드한 뒤 나머지를 병합해 반환 — read-modify-write `save()`에 바로 사용. 완전한 PK가 없거나 매칭 행이 없으면 `undefined` (TypeORM과 동일) |
 
 ### Batch
 
@@ -151,7 +162,7 @@ const userRepo = em.getRepository(User);
 const userRepo = BaseRepository.of(User, em);
 ```
 
-`find`, `findBy`, `findOne`, `findOneBy`, `findOneOrFail`, `findWithCursor`, `findAndCount`, `pluck`, `save`, `delete`, `remove`, `softDelete`, `restore`, `insertMany`, `insertManyAndReturn`, `insertIgnore`, `saveMany`, `deleteMany`, `batchUpsert`, `count`, `sum`, `avg`, `min`, `max`, `explain`, `upsert`, `persist`, `stream`, `streamBatch`, `createQueryBuilder`, `createUpdateBuilder`, `update`, `updateMany`, `increment`, `decrement` -- EntityManager와 동일한 API를 엔티티 지정 없이 사용할 수 있어요.
+`find`, `findBy`, `findOne`, `findOneBy`, `findOneOrFail`, `findOneByOrFail`, `findWithCursor`, `findAndCount`, `pluck`, `create`, `merge`, `preload`, `save`, `delete`, `remove`, `softDelete`, `restore`, `insertMany`, `insertManyAndReturn`, `insertIgnore`, `saveMany`, `deleteMany`, `batchUpsert`, `count`, `sum`, `avg`, `min`, `max`, `explain`, `upsert`, `persist`, `stream`, `streamBatch`, `createQueryBuilder`, `createUpdateBuilder`, `update`, `updateMany`, `increment`, `decrement` -- EntityManager와 동일한 API를 엔티티 지정 없이 사용할 수 있어요.
 
 **Repository 전용 헬퍼:**
 

--- a/docs/ko/entity-manager.md
+++ b/docs/ko/entity-manager.md
@@ -464,6 +464,43 @@ const titles = await em.pluck(Post, "title");
 const ids = await userRepo.pluck("id", { active: true });
 ```
 
+### 엔티티 구성 -- create(), merge(), preload()
+
+이 헬퍼들은 엔티티 인스턴스를 **메모리에서** 만들거나 준비합니다. 스스로 저장하지 않으며, 숨은 Unit of Work나 변경 추적도 없어서 즉시 실행 모델은 그대로예요. 쓸 준비가 되면 결과를 `save()`에 넘기면 됩니다.
+
+`create()`는 평범한 객체를 실제 클래스 인스턴스로 바꿔줍니다. `find()`가 돌려주는 것과 동일해서 인스턴스 메서드, 게터, `@Exclude`, 컬럼 트랜스포머가 모두 적용돼요. `save()`와 달리 SQL은 전혀 나가지 않습니다.
+
+```typescript
+const user = em.create(User, { name: "Alice", email });
+user.activate();              // 인스턴스 메서드 동작
+await em.save(User, user);    // 준비되면 저장
+
+// 한 번에 여러 개 생성
+const users = em.create(User, [{ name: "A" }, { name: "B" }]);
+```
+
+`merge()`는 기존 인스턴스 위에 부분 패치를 하나 이상 덮고 그 인스턴스를 반환합니다. 중첩된 일반 객체나 관계는 재귀적으로 병합하고, 배열·`Date`·`Buffer`는 통째로 교체하며, `undefined` 값은 건너뛰어 기존 필드를 지우지 않아요(비우려면 명시적으로 `null`을 넘깁니다).
+
+```typescript
+em.merge(user, { name: "New name" }, { status: "active" });
+```
+
+`preload()`는 read-modify-write를 위한 지름길입니다. 패치의 기본 키로 행을 로드한 뒤 나머지 필드를 로드된 인스턴스에 병합해서 `save()`에 바로 쓸 수 있게 돌려줘요. 지정하지 않은 컬럼은 DB 값을 그대로 유지합니다. 완전한 기본 키가 없거나 매칭 행이 없으면 `undefined`를 반환하므로(TypeORM과 동일), 부분 수정 엔드포인트가 "없음"과 "수정됨"을 구분할 수 있습니다.
+
+```typescript
+// PATCH /users/1  { name: "New name" }
+const patched = await em.preload(User, { id: 1, name: "New name" });
+if (!patched) throw new NotFoundException();
+await em.save(User, patched); // email, role 등 언급 안 한 컬럼은 보존
+```
+
+`BaseRepository`에서는 엔티티 클래스 인자를 생략합니다:
+
+```typescript
+const draft = userRepo.create({ name: "Alice" });
+const patched = await userRepo.preload({ id: 1, name: "New name" });
+```
+
 ---
 
 ## 삭제하기 -- delete()

--- a/src/core/BaseRepository.ts
+++ b/src/core/BaseRepository.ts
@@ -7,6 +7,7 @@ import {
   WhereClause,
 } from "../dialects/FindOption";
 import { EntityManager } from "./EntityManager";
+import { DeepPartial } from "../types/DeepPartial";
 import { DeleteResult } from "../types/DeleteResult";
 import { SelectQueryBuilder, isEntityRef } from "./SelectQueryBuilder";
 import type { EntityRef } from "./SelectQueryBuilder";
@@ -66,6 +67,55 @@ export class BaseRepository<T> {
    */
   async save(item: Partial<T>): Promise<InstanceType<ClazzType<T>>> {
     return await this.em.save<T>(this.entity, item);
+  }
+
+  /**
+   * Builds a hydrated entity instance from a plain object without persisting.
+   * Pass an array to build many. See {@link EntityManager.create}.
+   *
+   * @example
+   * ```ts
+   * const user = repo.create({ name: "Alice" });
+   * await repo.save(user);
+   * ```
+   */
+  create(): InstanceType<ClazzType<T>>;
+  create(data: DeepPartial<T>): InstanceType<ClazzType<T>>;
+  create(data: DeepPartial<T>[]): InstanceType<ClazzType<T>>[];
+  create(
+    data?: DeepPartial<T> | DeepPartial<T>[],
+  ): InstanceType<ClazzType<T>> | InstanceType<ClazzType<T>>[] {
+    return this.em.create<T>(this.entity, data as DeepPartial<T>);
+  }
+
+  /**
+   * Merges partial patches into an existing entity instance and returns it.
+   * Purely in-memory. See {@link EntityManager.merge}.
+   *
+   * @example
+   * ```ts
+   * repo.merge(user, { name: "New" }, { status: "active" });
+   * ```
+   */
+  merge(target: T, ...sources: DeepPartial<T>[]): T {
+    return this.em.merge<T>(target, ...sources);
+  }
+
+  /**
+   * Loads the row identified by the primary key(s) in `partial`, merges the
+   * rest of `partial` onto it, and returns the instance — or `undefined` if no
+   * complete PK is present or no row matches. See {@link EntityManager.preload}.
+   *
+   * @example
+   * ```ts
+   * const patched = await repo.preload({ id: 1, name: "New name" });
+   * if (patched) await repo.save(patched);
+   * ```
+   */
+  async preload(
+    partial: DeepPartial<T>,
+  ): Promise<InstanceType<ClazzType<T>> | undefined> {
+    return this.em.preload<T>(this.entity, partial);
   }
 
   /**
@@ -140,6 +190,19 @@ export class BaseRepository<T> {
    */
   async findOneOrFail(findOption: FindOption<T>): Promise<T> {
     return await this.em.findOneOrFail<T>(this.entity, findOption);
+  }
+
+  /**
+   * Retrieves a single entity matching `where` or throws EntityNotFoundError.
+   * Filter-first shorthand for `findOneOrFail({ where })`. See
+   * {@link EntityManager.findOneByOrFail}.
+   *
+   * @param where The filter selecting the row.
+   * @returns A promise that resolves to the found entity.
+   * @throws EntityNotFoundError if no entity matches.
+   */
+  async findOneByOrFail(where: WhereClause<T> | WhereClause<T>[]): Promise<T> {
+    return await this.em.findOneByOrFail<T>(this.entity, where);
   }
 
   /**

--- a/src/core/EntityManager.ts
+++ b/src/core/EntityManager.ts
@@ -104,6 +104,8 @@ import { DmlSqlBuilder } from "./entity-manager/DmlSqlBuilder";
 import { WriteExecutor } from "./entity-manager/WriteExecutor";
 import { ReadExecutor } from "./entity-manager/ReadExecutor";
 import { RelationExecutor } from "./entity-manager/RelationExecutor";
+import { EntityFactory } from "./entity-manager/EntityFactory";
+import { DeepPartial } from "../types/DeepPartial";
 import { MetadataViewFactory } from "./entity-manager/MetadataViewFactory";
 import { TenantScopeManager } from "./entity-manager/TenantScopeManager";
 import { SubscriberRegistry } from "./entity-manager/SubscriberRegistry";
@@ -297,6 +299,7 @@ export class EntityManager implements BaseEntityManager {
   private readonly writeExecutor = new WriteExecutor(this._ctx);
   private readonly readExecutor = new ReadExecutor(this._ctx);
   private readonly relationExecutor = new RelationExecutor(this._ctx);
+  private readonly entityFactory = new EntityFactory(this._ctx);
   private readonly metadataViewFactory = new MetadataViewFactory(this._ctx);
   private readonly tenantScope = new TenantScopeManager(this._ctx);
   private readonly transactionRunner = new TransactionRunner(this._ctx);
@@ -1023,6 +1026,30 @@ export class EntityManager implements BaseEntityManager {
     return result;
   }
 
+  /**
+   * Filter-first counterpart of {@link findOneOrFail}: retrieves the single
+   * entity matching `where` and throws `EntityNotFoundError` if none is found.
+   *
+   * Completes the read grid — `findOneBy` is to `findOne` what
+   * `findOneByOrFail` is to `findOneOrFail`, dropping the options-object
+   * ceremony for the common "get this row or blow up" case.
+   *
+   * @example
+   * ```ts
+   * const user = await em.findOneByOrFail(User, { id: 1 });
+   * ```
+   */
+  async findOneByOrFail<T>(
+    entity: ClazzType<T>,
+    where: WhereClause<T> | WhereClause<T>[],
+  ): Promise<T> {
+    const result = await this.findOneBy(entity, where);
+    if (result === null || result === undefined) {
+      throw new EntityNotFoundError(entity.name);
+    }
+    return result;
+  }
+
   async find<T>(
     entity: ClazzType<T>,
     findOption: FindOption<T> = {},
@@ -1160,6 +1187,83 @@ export class EntityManager implements BaseEntityManager {
     option: PagePaginationOption<T> = {},
   ): Promise<PagePaginationResult<T>> {
     return this.readExecutor.findWithPage(entity, option);
+  }
+
+  // ── Entity construction (no persistence) ────────────────────
+
+  /**
+   * Builds a hydrated entity instance from a plain object **without touching
+   * the database**. The result is a real class instance — indistinguishable
+   * from one returned by `find` — so class methods, getters, `@Exclude`, and
+   * column transformers all apply. Nothing is persisted and no lifecycle hooks
+   * run; hand the instance to {@link save} when you want it written.
+   *
+   * Pass an array to build many instances at once.
+   *
+   * @example
+   * ```ts
+   * const user = em.create(User, { name: "Alice", email });
+   * user.activate();               // instance methods work
+   * await em.save(User, user);     // persist when ready
+   *
+   * const users = em.create(User, [{ name: "A" }, { name: "B" }]);
+   * ```
+   */
+  create<T>(entity: ClazzType<T>): InstanceType<ClazzType<T>>;
+  create<T>(
+    entity: ClazzType<T>,
+    data: DeepPartial<T>,
+  ): InstanceType<ClazzType<T>>;
+  create<T>(
+    entity: ClazzType<T>,
+    data: DeepPartial<T>[],
+  ): InstanceType<ClazzType<T>>[];
+  create<T>(
+    entity: ClazzType<T>,
+    data?: DeepPartial<T> | DeepPartial<T>[],
+  ): InstanceType<ClazzType<T>> | InstanceType<ClazzType<T>>[] {
+    return this.entityFactory.create(entity, data as DeepPartial<T>);
+  }
+
+  /**
+   * Merges one or more partial patches into an existing entity instance,
+   * mutating and returning `target`. Nested plain objects / relations are
+   * merged recursively; arrays, `Date`s, and `Buffer`s replace wholesale.
+   * `undefined` values are skipped so they never null out an existing field.
+   *
+   * Purely in-memory — no query, no persistence. Combine with {@link save} to
+   * write the result.
+   *
+   * @example
+   * ```ts
+   * em.merge(user, { name: "New" }, { status: "active" });
+   * ```
+   */
+  merge<T>(target: T, ...sources: DeepPartial<T>[]): T {
+    return this.entityFactory.merge(target, ...sources);
+  }
+
+  /**
+   * Loads the row identified by the primary key(s) in `partial`, merges the
+   * remaining fields of `partial` onto it, and returns the hydrated instance —
+   * ready to hand to {@link save} for a read-modify-write update.
+   *
+   * Returns `undefined` when `partial` lacks a complete primary key or no row
+   * matches (mirrors TypeORM). The returned instance is detached: there is no
+   * change tracking, so the merge is applied immediately and persists only
+   * when you call {@link save}.
+   *
+   * @example
+   * ```ts
+   * const patched = await em.preload(User, { id: 1, name: "New name" });
+   * if (patched) await em.save(User, patched);
+   * ```
+   */
+  async preload<T>(
+    entity: ClazzType<T>,
+    partial: DeepPartial<T>,
+  ): Promise<InstanceType<ClazzType<T>> | undefined> {
+    return this.entityFactory.preload(entity, partial);
   }
 
   // ── CRUD: Write ────────────────────────────────────────────

--- a/src/core/entity-manager/EntityFactory.ts
+++ b/src/core/entity-manager/EntityFactory.ts
@@ -1,0 +1,128 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { ClazzType } from "../../utils";
+import { DeepPartial } from "../../types/DeepPartial";
+import { WhereClause } from "../../dialects/FindOption";
+import { ColumnMetadata } from "../../scanner";
+import { DeserializerRegistry } from "../deserializer/DeserializerRegistry";
+import { EntityManagerInternals } from "../EntityManagerInternals";
+import { EntityMetadataNotFoundError } from "../../errors/EntityMetadataNotFoundError";
+import { InvalidQueryError } from "../../errors/InvalidQueryError";
+
+type Instance<T> = InstanceType<ClazzType<T>>;
+
+/**
+ * Returns true for values that {@link EntityFactory.merge} should recurse into
+ * (deep-merge) rather than replace wholesale.
+ *
+ * Plain objects and class instances qualify so that a partial patch fills in
+ * fields of an existing nested relation without clobbering its siblings.
+ * Arrays, `Date`s, and `Buffer`s are treated as opaque leaf values and are
+ * replaced as a unit — a partial array/date merge would be surprising.
+ */
+function isMergeableObject(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== "object") return false;
+  if (Array.isArray(value)) return false;
+  if (value instanceof Date) return false;
+  if (typeof Buffer !== "undefined" && Buffer.isBuffer(value)) return false;
+  return true;
+}
+
+/**
+ * Recursively assigns own enumerable keys of `source` onto `target`.
+ *
+ * `undefined` source values are skipped (they never null out an existing
+ * field); an explicit `null` is assigned. When both sides of a key are
+ * mergeable objects the merge recurses; otherwise the source value replaces.
+ */
+function deepAssign(target: any, source: any): void {
+  for (const key of Object.keys(source)) {
+    const sourceValue = source[key];
+    if (sourceValue === undefined) continue;
+    const targetValue = target[key];
+    if (isMergeableObject(sourceValue) && isMergeableObject(targetValue)) {
+      deepAssign(targetValue, sourceValue);
+    } else {
+      target[key] = sourceValue;
+    }
+  }
+}
+
+/**
+ * Entity construction / hydration helpers for {@link EntityManager}.
+ *
+ * These methods never touch the database except {@link EntityFactory.preload},
+ * which issues a single primary-key read. None of them persist: they build,
+ * combine, or prepare entity instances that the caller later hands to
+ * `save()`. This keeps the immediate-execution model intact — there is no
+ * hidden unit-of-work or change tracking.
+ */
+export class EntityFactory {
+  constructor(private readonly ctx: EntityManagerInternals) {}
+
+  create<T>(entity: ClazzType<T>): Instance<T>;
+  create<T>(entity: ClazzType<T>, data: DeepPartial<T>): Instance<T>;
+  create<T>(entity: ClazzType<T>, data: DeepPartial<T>[]): Instance<T>[];
+  create<T>(
+    entity: ClazzType<T>,
+    data?: DeepPartial<T> | DeepPartial<T>[],
+  ): Instance<T> | Instance<T>[] {
+    if (Array.isArray(data)) {
+      return data.map((item) => this.hydrate(entity, item));
+    }
+    return this.hydrate(entity, data);
+  }
+
+  private hydrate<T>(
+    entity: ClazzType<T>,
+    data: DeepPartial<T> | undefined,
+  ): Instance<T> {
+    return DeserializerRegistry.getInstance().deserialize(
+      entity as any,
+      (data ?? {}) as any,
+    ) as Instance<T>;
+  }
+
+  merge<T>(target: T, ...sources: DeepPartial<T>[]): T {
+    for (const source of sources) {
+      if (source === undefined || source === null) continue;
+      deepAssign(target, source);
+    }
+    return target;
+  }
+
+  async preload<T>(
+    entity: ClazzType<T>,
+    partial: DeepPartial<T>,
+  ): Promise<Instance<T> | undefined> {
+    const metadata = this.ctx.getResolver().resolveEntityMetadata(entity);
+    if (!metadata) throw new EntityMetadataNotFoundError(entity.name);
+
+    const pkColumns = metadata.columns.filter(
+      (col: ColumnMetadata) => col.options?.primary,
+    );
+    if (pkColumns.length === 0) {
+      throw new InvalidQueryError(
+        `Entity "${metadata.name}" has no primary key.`,
+        "Add @PrimaryGeneratedColumn() or @PrimaryColumn() to your entity.",
+      );
+    }
+
+    // A full primary key is required to locate the row. If any PK component is
+    // absent, there is nothing to preload onto — mirror TypeORM and return
+    // undefined rather than issuing a bogus query.
+    const where: Record<string, unknown> = {};
+    for (const col of pkColumns) {
+      const prop = this.ctx.propKey(col);
+      const value = (partial as any)[prop];
+      if (value === undefined || value === null) return undefined;
+      where[prop] = value;
+    }
+
+    const existing = await this.ctx.findOne<T>(entity, {
+      where: where as WhereClause<T>,
+    });
+    if (!existing) return undefined;
+
+    return this.merge(existing as Instance<T>, partial as DeepPartial<Instance<T>>);
+  }
+}


### PR DESCRIPTION
Adds the entity-construction/hydration helpers that were missing from both `EntityManager` and `BaseRepository`. All are additive and non-breaking, and none introduce a unit of work or change tracking — the immediate-execution model is unchanged.

## Methods

- **`create(entity, data?)`** — builds a hydrated instance (via the deserializer, so it is indistinguishable from a `find()` result: instance methods, getters, `@Exclude`, transformers all apply) without persisting. Accepts an array to build many.
- **`merge(target, ...sources)`** — layers partial patches onto an existing instance and returns it. Nested plain objects merge recursively; arrays / `Date` / `Buffer` replace wholesale; `undefined` is skipped (explicit `null` clears). In-memory only.
- **`preload(entity, partial)`** — loads the row by the PK(s) in `partial`, merges the rest onto it, returns it ready for a read-modify-write `save()`. Returns `undefined` when there is no complete PK or no matching row (mirrors TypeORM).
- **`findOneByOrFail(entity, where)`** — filter-first counterpart of `findOneOrFail`, completing the `findOneBy` / `findOneOrFail` grid.

Implementation lives in a new `EntityFactory` helper (`src/core/entity-manager/EntityFactory.ts`) following the existing executor pattern; `EntityManager` delegates to it. `BaseRepository` mirrors all four with the entity argument dropped.

## Verification

- `tsc` CJS + ESM clean
- Unit suite: 5,327 passed
- SQLite integration: 563 passed, including a new `entity-factory.test.ts` (15 tests) that drives create → save → preload → save → re-read against real SQL, plus the undefined-PK / not-found paths and BaseRepository delegation.

Docs (`api-reference`, `entity-manager` guide) updated in English and Korean.