### PR TITLE
test(core): backfill mock-only write-path suites with real SQL (#404)

### DIFF
--- a/__tests__/integration/buffer-plugin.test.ts
+++ b/__tests__/integration/buffer-plugin.test.ts
@@ -324,6 +324,44 @@ describe.each(drivers)("[Integration] $label: Buffer Plugin", ({ type, options }
   });
 
   // ═══════════════════════════════════════════════════════════════
+  // Batch INSERT (multi-row SQL path)
+  // ═══════════════════════════════════════════════════════════════
+
+  describe("batchInsert (multi-row INSERT)", () => {
+    // Backfills the unit test "should batch INSERT multiple entities of same
+    // type (MySQL)", which mocks query → { insertId: 10 } and asserts the
+    // sequential `insertId + i` writeback in memory only (issue #404). Here
+    // the multi-row SQL runs for real: on MySQL the PKs come from
+    // LAST_INSERT_ID() arithmetic, on PostgreSQL from RETURNING order — an
+    // off-by-one or reversed writeback would attach the WRONG row to each
+    // instance, which the per-id row lookup below catches.
+    it("writes back a correct, distinct PK to each persisted instance", async () => {
+      const buf: WriteBuffer = (em as any).buffer({ batchInsert: true });
+      const make = (name: string, age: number) =>
+        Object.assign(Object.create(testEntity.EntityClass.prototype), { name, age });
+      const u1 = make("batch-a", 1);
+      const u2 = make("batch-b", 2);
+      const u3 = make("batch-c", 3);
+
+      buf.persist(u1).persist(u2).persist(u3);
+      const result = await buf.flush();
+      expect(result.inserts).toBe(3);
+
+      const ids = [u1.id, u2.id, u3.id];
+      expect(ids.every((id) => typeof id === "number" && id > 0)).toBe(true);
+      expect(new Set(ids).size).toBe(3);
+
+      // Each instance's PK must point at ITS OWN row.
+      for (const inst of [u1, u2, u3]) {
+        const row = await findById(inst.id);
+        expect(row).not.toBeNull();
+        expect(row.name).toBe(inst.name);
+        expect(row.age).toBe(inst.age);
+      }
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════════
   // DELETE: delete() queue
   // ═══════════════════════════════════════════════════════════════
 

--- a/__tests__/integration/sqlite/buffer-validate-before-flush.test.ts
+++ b/__tests__/integration/sqlite/buffer-validate-before-flush.test.ts
@@ -1,0 +1,146 @@
+/**
+ * SQLite In-Memory: WriteBuffer validateBeforeFlush against real SQL
+ * (issue #404).
+ *
+ * Backfills the buffer-plugin.test.ts "validateBeforeFlush" describe, which
+ * mocks em.transaction/em.save entirely — suppression of DB work on a
+ * validation failure was proven only by "the save spy was not called", and
+ * the happy path only by a mocked result counter. Zero integration coverage
+ * existed for the option. A fail-open bug (invalid data persisted anyway) or
+ * a fail-closed bug (valid entities silently dropped from the flush) would
+ * both have passed. Here every claim is checked against real table state.
+ */
+
+import "reflect-metadata";
+import {
+  createTestConnection,
+  type TestConnectionResult,
+} from "../helpers/test-connection";
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  NotNull,
+  Min,
+} from "../../../src";
+import { ValidationError } from "../../../src/errors/ValidationError";
+import { bufferPlugin } from "../../../src/core/plugin/buffer/bufferPlugin";
+import type { WriteBuffer } from "../../../src/core/plugin/buffer/WriteBuffer";
+import { getScannerInstance } from "../../../src/scanner/ScannerContainer";
+import { ColumnScanner } from "../../../src/scanner";
+import { MetadataLayerRegistry } from "../../../src/scanner/MetadataScanner";
+
+describe("[Integration] SQLite: WriteBuffer validateBeforeFlush", () => {
+  let conn: TestConnectionResult;
+  let VUser: any;
+  const tableName = `vbf_user_${String(Date.now()).slice(-6)}`;
+
+  beforeAll(async () => {
+    conn = await createTestConnection(
+      {
+        type: "sqlite",
+        database: ":memory:",
+        synchronize: true,
+        logging: false,
+        plugins: [bufferPlugin({ validateBeforeFlush: true })],
+      },
+      () => {
+        MetadataLayerRegistry.reset();
+        getScannerInstance(ColumnScanner).clear();
+
+        @Entity({ name: tableName })
+        class VUserEntity {
+          @PrimaryGeneratedColumn() id!: number;
+          @NotNull() @Column() name!: string;
+          @Min(0) @Column({ type: "int" }) age!: number;
+        }
+
+        VUser = VUserEntity;
+        return { entities: [VUserEntity] };
+      },
+    );
+  }, 30000);
+
+  afterAll(async () => {
+    if (conn) await conn.cleanup();
+  });
+
+  beforeEach(async () => {
+    await conn.em.query(`DELETE FROM "${tableName}"`);
+  });
+
+  async function rowCount(): Promise<number> {
+    const rows = (await conn.em.query(
+      `SELECT COUNT(*) AS c FROM "${tableName}"`,
+    )) as any[];
+    return Number(rows[0].c);
+  }
+
+  it("rejects an invalid persist and writes NOTHING to the table", async () => {
+    const buf: WriteBuffer = (conn.em as any).buffer();
+    const ok = new VUser();
+    ok.name = "valid";
+    ok.age = 1;
+    const bad = new VUser();
+    bad.name = undefined; // @NotNull violation
+    bad.age = 2;
+    buf.persist(ok).persist(bad);
+
+    await expect(buf.flush()).rejects.toThrow(ValidationError);
+
+    // Validation aborts BEFORE any DB write — including the VALID sibling.
+    expect(await rowCount()).toBe(0);
+  });
+
+  it("rejects a dirty tracked entity that became invalid and leaves the row unchanged", async () => {
+    const seeded: any = await conn.em.save(VUser, { name: "a", age: 5 } as any);
+
+    const buf: WriteBuffer = (conn.em as any).buffer();
+    const loaded: any = await buf.findOne(VUser, { where: { id: seeded.id } as any });
+    loaded.age = -1; // @Min(0) violation
+
+    await expect(buf.flush()).rejects.toThrow(ValidationError);
+
+    const rows = (await conn.em.query(
+      `SELECT "age" FROM "${tableName}" WHERE "id" = ?`,
+      [seeded.id],
+    )) as any[];
+    expect(rows[0].age).toBe(5);
+  });
+
+  it("persists everything when validation passes (no silent drop)", async () => {
+    const buf: WriteBuffer = (conn.em as any).buffer();
+    const u1 = new VUser();
+    u1.name = "alice";
+    u1.age = 30;
+    const u2 = new VUser();
+    u2.name = "bob";
+    u2.age = 0; // boundary: Min(0) inclusive
+    buf.persist(u1).persist(u2);
+
+    const result = await buf.flush();
+    expect(result.inserts).toBe(2);
+
+    const rows = (await conn.em.query(
+      `SELECT "name", "age" FROM "${tableName}" ORDER BY "name"`,
+    )) as any[];
+    expect(rows).toEqual([
+      { name: "alice", age: 30 },
+      { name: "bob", age: 0 },
+    ]);
+  });
+
+  it("a failed flush is retryable after the entity is fixed", async () => {
+    const buf: WriteBuffer = (conn.em as any).buffer();
+    const u = new VUser();
+    u.name = undefined; // invalid
+    u.age = 1;
+    buf.persist(u);
+    await expect(buf.flush()).rejects.toThrow(ValidationError);
+
+    u.name = "fixed";
+    const result = await buf.flush();
+    expect(result.inserts).toBe(1);
+    expect(await rowCount()).toBe(1);
+  });
+});

--- a/__tests__/integration/sqlite/core-cascade-write-path.test.ts
+++ b/__tests__/integration/sqlite/core-cascade-write-path.test.ts
@@ -1,0 +1,192 @@
+/**
+ * SQLite In-Memory: core (non-buffer) cascade write paths (issue #404).
+ *
+ * Backfills __tests__/unit/cascade-handler.test.ts, which mocks
+ * ctx.save/ctx.delete and asserts only call counts / criteria shapes:
+ *
+ *  1. cascadeSaveManyToOne — em.save(Child, { parent: {...} }) with cascade
+ *     insert must INSERT the parent row and write the child's FK column.
+ *     The unit test proves `ctx.save` was called and `childItem.parentId`
+ *     was set IN MEMORY; whether either value reaches a real table was
+ *     verified nowhere outside the WriteBuffer plugin path.
+ *  2. cascadeDeleteOneToMany, multi-parent IN branch — deleting several
+ *     parents in one call must delete the children of ALL of them (single
+ *     `WHERE fk IN (...)`), and only those. The unit test asserts the mocked
+ *     criteria object `{ parentId: [10, 20] }` and nothing else.
+ */
+
+import "reflect-metadata";
+import {
+  createTestConnection,
+  type TestConnectionResult,
+} from "../helpers/test-connection";
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  ManyToOne,
+  OneToMany,
+} from "../../../src";
+import { getScannerInstance } from "../../../src/scanner/ScannerContainer";
+import {
+  ColumnScanner,
+  ManyToOneScanner,
+  OneToManyScanner,
+  ManyToManyScanner,
+  OneToOneScanner,
+} from "../../../src/scanner";
+import { DatabaseClient } from "../../../src/DatabaseClient";
+
+function shortName(prefix: string): string {
+  return `${prefix}_${String(Date.now()).slice(-7)}`;
+}
+
+describe("[Integration] SQLite: core cascade write paths (non-buffer)", () => {
+  let conn: TestConnectionResult;
+  let Parent: new () => any;
+  let Child: new () => any;
+
+  const parentName = shortName("ccparent");
+  const childName = shortName("ccchild");
+
+  beforeAll(async () => {
+    conn = await createTestConnection(
+      {
+        type: "sqlite",
+        database: ":memory:",
+        synchronize: false,
+        logging: false,
+      },
+      () => {
+        getScannerInstance(ColumnScanner).clear();
+        getScannerInstance(ManyToOneScanner).clear();
+        getScannerInstance(OneToManyScanner).clear();
+        getScannerInstance(ManyToManyScanner).clear();
+        getScannerInstance(OneToOneScanner).clear();
+
+        const ParentC = class {} as any;
+        Object.defineProperty(ParentC, "name", { value: parentName });
+        Reflect.defineMetadata("design:type", Number, ParentC.prototype, "id");
+        PrimaryGeneratedColumn()(ParentC.prototype, "id");
+        Reflect.defineMetadata("design:type", String, ParentC.prototype, "name");
+        Column()(ParentC.prototype, "name");
+        Reflect.defineMetadata("design:type", String, ParentC.prototype, "grp");
+        Column()(ParentC.prototype, "grp");
+        Reflect.defineMetadata("design:type", Array, ParentC.prototype, "children");
+
+        const ChildC = class {} as any;
+        Object.defineProperty(ChildC, "name", { value: childName });
+        Reflect.defineMetadata("design:type", Number, ChildC.prototype, "id");
+        PrimaryGeneratedColumn()(ChildC.prototype, "id");
+        Reflect.defineMetadata("design:type", String, ChildC.prototype, "label");
+        Column()(ChildC.prototype, "label");
+        // FK via the `${prop}Id` backing-column convention.
+        Reflect.defineMetadata("design:type", Number, ChildC.prototype, "parentId");
+        Column({ nullable: true })(ChildC.prototype, "parentId");
+        Reflect.defineMetadata("design:type", ParentC, ChildC.prototype, "parent");
+        ManyToOne(
+          () => ParentC,
+          (p: any) => p.children,
+          { cascade: ["insert"] },
+        )(ChildC.prototype, "parent");
+        Entity()(ChildC);
+        Child = ChildC;
+
+        OneToMany(() => ChildC, {
+          mappedBy: "parent",
+          cascade: true,
+        })(ParentC.prototype, "children");
+        Entity()(ParentC);
+        Parent = ParentC;
+
+        return { entities: [ParentC, ChildC] };
+      },
+    );
+
+    const connector = DatabaseClient.getInstance().getConnection();
+    await connector.query(
+      `CREATE TABLE IF NOT EXISTS "${parentName}" ("id" INTEGER PRIMARY KEY AUTOINCREMENT, "name" TEXT, "grp" TEXT)`,
+    );
+    await connector.query(
+      `CREATE TABLE IF NOT EXISTS "${childName}" ("id" INTEGER PRIMARY KEY AUTOINCREMENT, "label" TEXT, "parentId" INTEGER)`,
+    );
+  }, 30000);
+
+  afterAll(async () => {
+    if (conn) await conn.cleanup();
+  });
+
+  beforeEach(async () => {
+    const connector = DatabaseClient.getInstance().getConnection();
+    await connector.query(`DELETE FROM "${childName}"`);
+    await connector.query(`DELETE FROM "${parentName}"`);
+  });
+
+  it("em.save(Child, { parent: {...} }) INSERTs the parent row and writes the child FK", async () => {
+    const savedChild: any = await conn.em.save(Child, {
+      label: "c1",
+      parent: { name: "new-parent", grp: "g" },
+    } as any);
+
+    // The parent row must exist in the database.
+    const parents = (await conn.em.query(
+      `SELECT "id", "name" FROM "${parentName}"`,
+    )) as any[];
+    expect(parents).toHaveLength(1);
+    expect(parents[0].name).toBe("new-parent");
+
+    // The child's FK COLUMN (not just the in-memory property) must point at it.
+    const children = (await conn.em.query(
+      `SELECT "label", "parentId" FROM "${childName}"`,
+    )) as any[];
+    expect(children).toHaveLength(1);
+    expect(children[0].label).toBe("c1");
+    expect(children[0].parentId).toBe(parents[0].id);
+    expect(savedChild.parentId).toBe(parents[0].id);
+  });
+
+  // KNOWN DEFECT (#414): cascadeDeleteOneToMany issues the child deletes
+  // through ctx.delete WITHOUT the outer delete's session, so they open a
+  // NEW transaction. On SQLite's single shared connection the nested BEGIN
+  // throws ("cannot start a transaction within a transaction"), so core
+  // cascade delete fails entirely; on PG/MySQL the children commit in a
+  // separate transaction (atomicity violation). `it.failing` keeps the repro
+  // green in CI and flips to a hard failure the moment #414 fixes it —
+  // remove `.failing` then.
+  it.failing("em.delete(Parent, pk) cascade-deletes the single parent's children (#414)", async () => {
+    const a: any = await conn.em.save(Parent, { name: "A", grp: "del" } as any);
+    await conn.em.save(Child, { label: "a1", parentId: a.id } as any);
+
+    await conn.em.delete(Parent, { id: a.id } as any);
+
+    const children = (await conn.em.query(
+      `SELECT "label" FROM "${childName}"`,
+    )) as any[];
+    expect(children).toHaveLength(0);
+  });
+
+  it.failing("em.delete(Parent, criteria) matching MULTIPLE parents cascade-deletes all their children via IN (#414)", async () => {
+    const a: any = await conn.em.save(Parent, { name: "A", grp: "del" } as any);
+    const b: any = await conn.em.save(Parent, { name: "B", grp: "del" } as any);
+    const keep: any = await conn.em.save(Parent, { name: "C", grp: "keep" } as any);
+    await conn.em.save(Child, { label: "a1", parentId: a.id } as any);
+    await conn.em.save(Child, { label: "a2", parentId: a.id } as any);
+    await conn.em.save(Child, { label: "b1", parentId: b.id } as any);
+    await conn.em.save(Child, { label: "k1", parentId: keep.id } as any);
+
+    await conn.em.delete(Parent, { grp: "del" } as any);
+
+    const parents = (await conn.em.query(
+      `SELECT "name" FROM "${parentName}"`,
+    )) as any[];
+    expect(parents.map((p) => p.name)).toEqual(["C"]);
+
+    // Children of BOTH deleted parents are gone; the survivor's child remains.
+    const children = (await conn.em.query(
+      `SELECT "label", "parentId" FROM "${childName}"`,
+    )) as any[];
+    expect(children).toHaveLength(1);
+    expect(children[0].label).toBe("k1");
+    expect(children[0].parentId).toBe(keep.id);
+  });
+});

--- a/__tests__/integration/sqlite/update-many-sql-expression.test.ts
+++ b/__tests__/integration/sqlite/update-many-sql-expression.test.ts
@@ -1,0 +1,140 @@
+/**
+ * SQLite In-Memory: updateMany() with raw Sql expressions in SET (issue #404).
+ *
+ * Backfills __tests__/unit/update-many-sql-expression.test.ts, which asserts
+ * only that the generated SQL STRING contains "pos + 1" against a mocked
+ * session — the statement is never executed, so a builder bug that
+ * parameterizes the expression, maps it to the wrong column, or applies it
+ * twice would corrupt every matched row while the unit test stays green.
+ * Here the same scenarios run against a real database and assert row state.
+ */
+
+import "reflect-metadata";
+import sql from "sql-template-tag";
+import {
+  createTestConnection,
+  type TestConnectionResult,
+} from "../helpers/test-connection";
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  UpdateTimestamp,
+} from "../../../src";
+import { getScannerInstance } from "../../../src/scanner/ScannerContainer";
+import { ColumnScanner } from "../../../src/scanner";
+import { MetadataLayerRegistry } from "../../../src/scanner/MetadataScanner";
+
+describe("[Integration] SQLite: updateMany with Sql expressions in SET", () => {
+  let conn: TestConnectionResult;
+  let Comment: any;
+  let Doc: any;
+  const commentTable = `ume_comment_${String(Date.now()).slice(-6)}`;
+  const docTable = `ume_doc_${String(Date.now()).slice(-6)}`;
+
+  beforeAll(async () => {
+    conn = await createTestConnection(
+      {
+        type: "sqlite",
+        database: ":memory:",
+        synchronize: true,
+        logging: false,
+      },
+      () => {
+        MetadataLayerRegistry.reset();
+        getScannerInstance(ColumnScanner).clear();
+
+        @Entity({ name: commentTable })
+        class CommentEntity {
+          @PrimaryGeneratedColumn() id!: number;
+          @Column({ type: "int" }) pos!: number;
+          @Column() content!: string;
+          @Column({ type: "int" }) postId!: number;
+        }
+
+        @Entity({ name: docTable })
+        class DocEntity {
+          @PrimaryGeneratedColumn() id!: number;
+          @Column({ type: "int" }) hits!: number;
+          @UpdateTimestamp() updatedAt!: Date;
+        }
+
+        Comment = CommentEntity;
+        Doc = DocEntity;
+        return { entities: [CommentEntity, DocEntity] };
+      },
+    );
+  }, 30000);
+
+  afterAll(async () => {
+    if (conn) await conn.cleanup();
+  });
+
+  beforeEach(async () => {
+    await conn.em.query(`DELETE FROM "${commentTable}"`);
+    await conn.em.query(`DELETE FROM "${docTable}"`);
+  });
+
+  async function commentRows(): Promise<any[]> {
+    return (await conn.em.query(
+      `SELECT "id", "pos", "content", "postId" FROM "${commentTable}" ORDER BY "id"`,
+    )) as any[];
+  }
+
+  it("applies a self-referential expression (pos = pos + 1) to matched rows only", async () => {
+    await conn.em.save(Comment, { pos: 1, content: "a", postId: 5 } as any);
+    await conn.em.save(Comment, { pos: 2, content: "b", postId: 5 } as any);
+    await conn.em.save(Comment, { pos: 3, content: "c", postId: 5 } as any);
+    await conn.em.save(Comment, { pos: 9, content: "other", postId: 7 } as any);
+
+    const result = await conn.em.updateMany(
+      Comment,
+      { pos: sql`pos + 1` } as any,
+      { where: { postId: 5 } as any },
+    );
+    expect(result.affected).toBe(3);
+
+    const rows = await commentRows();
+    // Each matched row incremented exactly once, relative to ITS OWN value;
+    // the non-matched row (postId 7) is untouched.
+    expect(rows.map((r) => r.pos)).toEqual([2, 3, 4, 9]);
+  });
+
+  it("applies mixed literal values and Sql expressions in one statement", async () => {
+    await conn.em.save(Comment, { pos: 10, content: "before", postId: 1 } as any);
+    await conn.em.save(Comment, { pos: 20, content: "before", postId: 1 } as any);
+
+    await conn.em.updateMany(
+      Comment,
+      { content: "moved", pos: sql`pos + 100` } as any,
+      { where: { postId: 1 } as any },
+    );
+
+    const rows = await commentRows();
+    expect(rows.map((r) => r.pos)).toEqual([110, 120]);
+    expect(rows.map((r) => r.content)).toEqual(["moved", "moved"]);
+  });
+
+  it("coexists with the automatic @UpdateTimestamp column", async () => {
+    const seeded: any = await conn.em.save(Doc, { hits: 1 } as any);
+    // Backdate the timestamp so the auto-stamp is observable.
+    await conn.em.query(
+      `UPDATE "${docTable}" SET "updatedAt" = '2000-01-01 00:00:00' WHERE "id" = ?`,
+      [seeded.id],
+    );
+
+    await conn.em.updateMany(
+      Doc,
+      { hits: sql`hits + 1` } as any,
+      { where: { id: seeded.id } as any },
+    );
+
+    const rows = (await conn.em.query(
+      `SELECT "hits", "updatedAt" FROM "${docTable}" WHERE "id" = ?`,
+      [seeded.id],
+    )) as any[];
+    expect(rows[0].hits).toBe(2);
+    // The expression must not suppress the @UpdateTimestamp auto-stamp.
+    expect(String(rows[0].updatedAt)).not.toContain("2000-01-01");
+  });
+});

--- a/__tests__/integration/sqlite/usability-write-edges.test.ts
+++ b/__tests__/integration/sqlite/usability-write-edges.test.ts
@@ -1,0 +1,166 @@
+/**
+ * SQLite In-Memory: increment/decrement edge arguments and batchUpsert
+ * heterogeneous rows (issue #404).
+ *
+ * Backfills __tests__/unit/increment-decrement.test.ts and upsert.test.ts,
+ * which assert only generated-SQL substrings / flattened parameter arrays
+ * against a mocked session:
+ *
+ *  - A negative or fractional `by`, and a WHERE matching zero rows, were
+ *    verified nowhere against a real database (unit + integration only used
+ *    positive integers). Sign flips, integer truncation, or a wrong
+ *    affected count would pass silently.
+ *  - batchUpsert's null fallback for a missing optional column was asserted
+ *    only as "the flattened params contain null" — per-row/per-column
+ *    alignment of the multi-row VALUES was never executed, so a misaligned
+ *    NULL (landing in the wrong row or column) would pass silently.
+ */
+
+import "reflect-metadata";
+import {
+  createTestConnection,
+  type TestConnectionResult,
+} from "../helpers/test-connection";
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  PrimaryColumn,
+} from "../../../src";
+import { getScannerInstance } from "../../../src/scanner/ScannerContainer";
+import { ColumnScanner } from "../../../src/scanner";
+import { MetadataLayerRegistry } from "../../../src/scanner/MetadataScanner";
+
+describe("[Integration] SQLite: increment/decrement edges + batchUpsert null alignment", () => {
+  let conn: TestConnectionResult;
+  let Counter: any;
+  let Sku: any;
+  const counterTable = `uwe_counter_${String(Date.now()).slice(-6)}`;
+  const skuTable = `uwe_sku_${String(Date.now()).slice(-6)}`;
+
+  beforeAll(async () => {
+    conn = await createTestConnection(
+      {
+        type: "sqlite",
+        database: ":memory:",
+        synchronize: true,
+        logging: false,
+      },
+      () => {
+        MetadataLayerRegistry.reset();
+        getScannerInstance(ColumnScanner).clear();
+
+        @Entity({ name: counterTable })
+        class CounterEntity {
+          @PrimaryGeneratedColumn() id!: number;
+          @Column({ type: "float" }) score!: number;
+        }
+
+        @Entity({ name: skuTable })
+        class SkuEntity {
+          @PrimaryColumn({ type: "varchar", length: 32 }) sku!: string;
+          @Column() name!: string;
+          @Column({ type: "varchar", nullable: true }) note!: string | null;
+        }
+
+        Counter = CounterEntity;
+        Sku = SkuEntity;
+        return { entities: [CounterEntity, SkuEntity] };
+      },
+    );
+  }, 30000);
+
+  afterAll(async () => {
+    if (conn) await conn.cleanup();
+  });
+
+  beforeEach(async () => {
+    await conn.em.query(`DELETE FROM "${counterTable}"`);
+    await conn.em.query(`DELETE FROM "${skuTable}"`);
+  });
+
+  async function scoreOf(id: number): Promise<number> {
+    const rows = (await conn.em.query(
+      `SELECT "score" FROM "${counterTable}" WHERE "id" = ?`,
+      [id],
+    )) as any[];
+    return rows[0].score;
+  }
+
+  it("increment() with a negative `by` subtracts (sign is preserved end-to-end)", async () => {
+    const c: any = await conn.em.save(Counter, { score: 10 } as any);
+
+    const result = await conn.em.increment(Counter, { id: c.id } as any, "score", -3);
+    expect(result.affected).toBe(1);
+    expect(await scoreOf(c.id)).toBe(7);
+  });
+
+  it("decrement() with a negative `by` adds (double negation)", async () => {
+    const c: any = await conn.em.save(Counter, { score: 10 } as any);
+
+    await conn.em.decrement(Counter, { id: c.id } as any, "score", -4);
+    expect(await scoreOf(c.id)).toBe(14);
+  });
+
+  it("increment() with a fractional `by` applies the exact delta", async () => {
+    const c: any = await conn.em.save(Counter, { score: 1 } as any);
+
+    await conn.em.increment(Counter, { id: c.id } as any, "score", 0.5);
+    expect(await scoreOf(c.id)).toBeCloseTo(1.5, 10);
+  });
+
+  it("increment() matching zero rows reports affected: 0 and writes nothing", async () => {
+    const c: any = await conn.em.save(Counter, { score: 5 } as any);
+
+    const result = await conn.em.increment(
+      Counter,
+      { id: c.id + 999 } as any,
+      "score",
+      1,
+    );
+    expect(result.affected).toBe(0);
+    expect(await scoreOf(c.id)).toBe(5);
+  });
+
+  it("batchUpsert() aligns a missing optional column as NULL in the RIGHT row", async () => {
+    const result = await conn.em.batchUpsert(Sku, [
+      { sku: "a", name: "Alpha", note: "has-note" },
+      { sku: "b", name: "Beta" }, // note omitted → NULL for THIS row only
+      { sku: "c", name: "Gamma", note: "also-note" },
+    ] as any);
+    expect(result.affected).toBeGreaterThanOrEqual(3);
+
+    const rows = (await conn.em.query(
+      `SELECT "sku", "name", "note" FROM "${skuTable}" ORDER BY "sku"`,
+    )) as any[];
+    expect(rows).toEqual([
+      { sku: "a", name: "Alpha", note: "has-note" },
+      { sku: "b", name: "Beta", note: null },
+      { sku: "c", name: "Gamma", note: "also-note" },
+    ]);
+  });
+
+  it("batchUpsert() with heterogeneous rows keeps alignment on the conflict-update path", async () => {
+    await conn.em.batchUpsert(Sku, [
+      { sku: "a", name: "Alpha", note: "old" },
+      { sku: "b", name: "Beta", note: "keep-me" },
+    ] as any);
+
+    // Re-upsert: row a updates note, row b omits note (→ NULL overwrite),
+    // row d is a fresh insert without note.
+    await conn.em.batchUpsert(Sku, [
+      { sku: "a", name: "Alpha2", note: "new" },
+      { sku: "b", name: "Beta2" },
+      { sku: "d", name: "Delta" },
+    ] as any);
+
+    const rows = (await conn.em.query(
+      `SELECT "sku", "name", "note" FROM "${skuTable}" ORDER BY "sku"`,
+    )) as any[];
+    expect(rows).toEqual([
+      { sku: "a", name: "Alpha2", note: "new" },
+      { sku: "b", name: "Beta2", note: null },
+      { sku: "d", name: "Delta", note: null },
+    ]);
+  });
+});

--- a/__tests__/write-path-mock-inventory.md
+++ b/__tests__/write-path-mock-inventory.md
@@ -1,0 +1,80 @@
+# Write-Path Mock-Test Inventory (issue #404)
+
+Audit date: 2026-07-14. Scope: every `__tests__/unit/` suite that replaces
+`em.save` / `em.update` / `em.delete` / `em.query` / `em.transaction` (or the
+`TransactionSessionManager`) with a mock AND asserts via `toHaveBeenCalled*`.
+49 files matched; each was classified by what its assertions can actually
+prove.
+
+Assertion styles:
+
+- **CALL_COUNT_ONLY** — asserts only that a mocked write fn was called (count
+  / args). A silent data-loss bug passes.
+- **SQL_STRING** — asserts the generated SQL text/params handed to a mocked
+  session. Catches builder regressions, but the statement never executes, so
+  semantic bugs (wrong row selected, misaligned params, transaction escape)
+  pass.
+- **BEHAVIOR** — asserts real logic output (metadata, state machines,
+  deserialization). Fine as unit tests.
+
+The structural conclusion of the 2026-07-03 UoW audit holds for the core
+write path too: wherever a scenario existed ONLY as CALL_COUNT_ONLY /
+SQL_STRING, real-SQL execution had never been verified — and backfilling
+those spots immediately surfaced a live defect (#414).
+
+## High-risk clusters and their disposition
+
+| unit suite (cluster) | style | real-SQL coverage before | disposition |
+|---|---|---|---|
+| `update-many-sql-expression.test.ts` — raw `` sql`col + 1` `` in SET | SQL_STRING | NONE | backfilled: `integration/sqlite/update-many-sql-expression.test.ts` (3) — no defect |
+| `cascade-handler.test.ts` — `cascadeDeleteOneToMany` single + multi-parent IN | CALL_COUNT_ONLY | NONE (non-buffer) | backfilled: `integration/sqlite/core-cascade-write-path.test.ts` — **defect found, #414** (child deletes escape the parent delete's transaction; SQLite nested-BEGIN crash, PG/MySQL non-atomic). Repros committed as `it.failing` |
+| `cascade-handler.test.ts` — `cascadeSaveManyToOne` parent INSERT + child FK | CALL_COUNT_ONLY + in-memory FK | NONE (non-buffer) | backfilled: same file (1) — no defect |
+| `buffer-plugin.test.ts` — `validateBeforeFlush` (throw, suppress-DB-work, happy path) | CALL_COUNT_ONLY | NONE | backfilled: `integration/sqlite/buffer-validate-before-flush.test.ts` (4) — no defect |
+| `increment-decrement.test.ts` — negative / fractional `by`, zero-row WHERE | SQL_STRING (edges untested anywhere) | NONE for edges | backfilled: `integration/sqlite/usability-write-edges.test.ts` (4) — no defect |
+| `upsert.test.ts` — `batchUpsert` null fallback for missing optional column | SQL_STRING (flattened params only) | NONE for heterogeneous rows | backfilled: same file (2) — no defect |
+| `buffer-plugin.test.ts` — batchInsert MySQL `insertId + i` sequential PK writeback | CALL_COUNT_ONLY (mocked insertId) | NONE on real MySQL | backfilled: dual-driver `integration/buffer-plugin.test.ts` "batchInsert (multi-row INSERT)" — runs on real PG + MySQL in CI |
+
+## Clusters already covered by real SQL (no action)
+
+- **Buffer flush/cascade/identity-map** (`buffer-plugin.test.ts`, most
+  describes): the 2026-07 batch A/B sweeps left 20 SQLite `buffer-*` suites +
+  the dual-driver `buffer-plugin` file covering flush order, M2M pivot sync
+  (tracked-parent add/remove and new-parent persist are both flush-asserted in
+  `buffer-preview-parity`), orphan reparenting, batch events, naming-strategy
+  tokens, nested savepoints, rollback restoration.
+- **Batch operations / soft delete / upsert basics / insertManyAndReturn /
+  pluck / findBy / aggregates**: dual-driver `batch-operations`, `soft-delete`,
+  `upsert` + `sqlite/usability-methods`, `sqlite/write-path-parity`.
+- **Lifecycle hooks / subscribers / entity events**: `sqlite/lifecycle-hooks-queries`
+  asserts hook mutations reach the DB; dual-driver `lifecycle-hooks`,
+  `entity-subscriber`. (The `em.on()` save-path insert/update events are
+  DB-verified only via the subscriber equivalent — acceptable overlap.)
+- **Transactions / connections / drivers / migrations plumbing**: unit mocks
+  are appropriate (no persisted-data claim); real transaction semantics are
+  covered by `sqlite/transactions`, `p3-transaction-rollback`.
+
+## Known thin spots, accepted for now (not backfilled)
+
+Ranked; revisit if the area churns.
+
+1. `migration.test.ts` — the "recorded in `__migrations` → skipped/reverted
+   next run" contract is proven by a self-consistent mock (the SELECT is
+   stubbed with the name the test expects). The emitted SQL is asserted
+   concretely, so MED. A SQLite MigrationRunner roundtrip would close it.
+2. `entity-subscriber.test.ts` — `databaseEntity` before-image on UPDATE
+   (pre-read row) is mock-fed; not asserted against a real UPDATE anywhere.
+3. Pessimistic `PESSIMISTIC_READ` lock pass-through — only PESSIMISTIC_WRITE
+   is integration-tested; SQLite cannot enforce row locks regardless.
+4. `delete-operation.test.ts` — asserts a locally re-declared `buildDeleteSql`
+   copy, not the shipped builder (false-confidence smell; the real delete path
+   itself is covered by integration).
+5. Tx-lifecycle subscriber events (`beforeTransactionCommit` order, rollback
+   firing) — asserted only against mocked sessions.
+
+## Defects surfaced by this sweep
+
+- **#414** — core (non-buffer) `em.delete` cascade-delete children run outside
+  the parent delete's transaction. SQLite: hard crash; PG/MySQL: children
+  commit independently (data loss on outer rollback). Repro: `it.failing`
+  tests in `integration/sqlite/core-cascade-write-path.test.ts` — remove
+  `.failing` when fixing.


### PR DESCRIPTION
Closes #404

The 2026-07-03 UoW audit identified the structural root cause of the long-hidden T0 defects: write-path unit suites mock `em.save`/`em.update`/`em.delete`/`transaction` and assert only call counts or generated-SQL substrings, so real execution was never verified. This PR is the detection + backfill pass for the core write path.

## Inventory

49 unit files match the mock+call-count pattern; each cluster was classified (CALL_COUNT_ONLY / SQL_STRING / BEHAVIOR) and cross-referenced against existing integration coverage. Full result: `__tests__/write-path-mock-inventory.md` (committed).

## Backfill — 20 new real-SQL tests

- `sqlite/update-many-sql-expression.test.ts` (3) — raw `` sql`pos + 1` `` in `updateMany` SET: self-referential increment per matched row, mixed literal+expression, @UpdateTimestamp coexistence. Previously asserted only as an unexecuted SQL substring.
- `sqlite/core-cascade-write-path.test.ts` (3) — core (non-buffer) `em.save(child, { parent })` cascade INSERT + FK write; single- and multi-parent cascade DELETE. **Surfaced defect #414** (see below) — the two delete repros are committed as `it.failing` and flip when #414 lands.
- `sqlite/buffer-validate-before-flush.test.ts` (4) — `validateBeforeFlush` had ZERO integration coverage: invalid persist/dirty aborts with no DB write (valid siblings included), happy path persists, failed flush is retryable.
- `sqlite/usability-write-edges.test.ts` (6) — increment/decrement with negative/fractional `by` and zero-row WHERE; batchUpsert per-row NULL alignment for heterogeneous rows on both insert and conflict-update paths.
- dual-driver `buffer-plugin.test.ts` (+1) — batchInsert multi-row PK writeback verified against real PostgreSQL (RETURNING order) and MySQL (`insertId + i` arithmetic); previously only a mocked `{ insertId: 10 }`.

## Defect found (not fixed here, per issue ground rules)

- **#414** — `WriteExecutor.delete()` calls `cascadeDeleteOneToMany` inside its transaction without the session; child deletes open a NEW transaction. SQLite: nested-BEGIN crash (cascade delete unusable); PG/MySQL: children commit independently of the parent delete (atomicity violation). Hidden precisely because the only tests mocked `ctx.delete`.

Accepted thin spots (migration-record roundtrip, subscriber before-image, PESSIMISTIC_READ pass-through, tx-lifecycle event order) are ranked in the inventory doc for future passes.

Verified: unit 5,327 (0 failures) / SQLite integration 620 / real PostgreSQL 543 / real MariaDB 468 / dual CJS+ESM build clean.
