### PR TITLE
fix(core/em): keep cascade child writes inside the parent operation's transaction (#414)

### DIFF
--- a/__tests__/integration/cascade-delete-atomicity.test.ts
+++ b/__tests__/integration/cascade-delete-atomicity.test.ts
@@ -1,0 +1,160 @@
+/**
+ * core (non-buffer) cascade delete — 세션 재사용 & 원자성 통합 테스트 (#414)
+ *
+ * WriteExecutor.delete()의 cascadeDeleteOneToMany는 자식 DELETE(와 부모 PK
+ * SELECT)를 공용 ctx.delete/ctx.find로 발행합니다. #414 이전에는 이 호출들이
+ * 바깥 delete의 세션에 합류하지 못하고 별도 트랜잭션을 열어, 부모 delete가
+ * 롤백돼도 자식은 이미 커밋된 채 사라졌습니다(원자성 위반). 수정 후에는
+ * 바깥 세션이 ALS로 전파되어 부모+자식이 한 트랜잭션으로 묶입니다.
+ *
+ * 검증 항목 (MySQL / PostgreSQL 공통):
+ * - 단일 부모 cascade delete — 자식까지 삭제
+ * - 다중 부모 criteria — 매칭된 모든 부모의 자식 삭제 (IN), 무관한 행 보존
+ * - 원자성 — afterDelete subscriber가 던지면 부모/자식 모두 복원
+ */
+
+import "reflect-metadata";
+import { EntityManager } from "../../src/core/EntityManager";
+import {
+  createTestConnection,
+  dropTestTable,
+  truncateTestTable,
+  rawQuery,
+  type TestConnectionResult,
+} from "./helpers/test-connection";
+import {
+  createCascadeDeleteTestEntities,
+  type RelatedEntitiesResult,
+} from "./helpers/create-relation-entity";
+import {
+  getTestDrivers,
+  type TestDriverConfig,
+} from "./helpers/driver-config";
+import {
+  qi,
+  disableFkChecksSql,
+  enableFkChecksSql,
+} from "./helpers/driver-helpers";
+import type { EntitySubscriber } from "../../src/core/EntitySubscriber";
+
+describe.each(getTestDrivers())(
+  "[Integration] $label: core cascade delete — 세션 재사용 & 원자성 (#414)",
+  ({ type, options }: TestDriverConfig) => {
+    let conn: TestConnectionResult;
+    let em: EntityManager;
+    let entities: RelatedEntitiesResult;
+
+    beforeAll(async () => {
+      conn = await createTestConnection(
+        { synchronize: true, logging: false, ...options },
+        () => {
+          entities = createCascadeDeleteTestEntities();
+          return {
+            entities: [entities.ParentClass, entities.ChildClass],
+          };
+        },
+      );
+      em = conn.em;
+    }, 30000);
+
+    afterAll(async () => {
+      try {
+        await rawQuery(disableFkChecksSql(type));
+        if (entities) await dropTestTable(entities.childTableName);
+        if (entities) await dropTestTable(entities.parentTableName);
+        await rawQuery(enableFkChecksSql(type));
+      } catch {
+        // ignore
+      }
+      if (conn) await conn.cleanup();
+    }, 15000);
+
+    beforeEach(async () => {
+      await truncateTestTable(entities.childTableName);
+      await truncateTestTable(entities.parentTableName);
+    });
+
+    async function countRows(tableName: string): Promise<number> {
+      const rows = (await em.query(
+        `SELECT COUNT(*) AS cnt FROM ${qi(type, tableName)}`,
+      )) as any[];
+      return Number(rows[0].cnt);
+    }
+
+    it("단일 부모 cascade delete — 자식이 같은 트랜잭션에서 삭제된다", async () => {
+      const a: any = await em.save(entities.ParentClass, {
+        name: "A",
+        grp: "del",
+      } as any);
+      await em.save(entities.ChildClass, { title: "a1", parentFk: a.id } as any);
+      await em.save(entities.ChildClass, { title: "a2", parentFk: a.id } as any);
+
+      const result = await em.delete(entities.ParentClass, { id: a.id } as any);
+      expect(result.affected).toBe(1);
+
+      expect(await countRows(entities.parentTableName)).toBe(0);
+      expect(await countRows(entities.childTableName)).toBe(0);
+    });
+
+    it("다중 부모 criteria — 매칭된 부모들의 자식만 IN으로 삭제된다", async () => {
+      const a: any = await em.save(entities.ParentClass, {
+        name: "A",
+        grp: "del",
+      } as any);
+      const b: any = await em.save(entities.ParentClass, {
+        name: "B",
+        grp: "del",
+      } as any);
+      const keep: any = await em.save(entities.ParentClass, {
+        name: "C",
+        grp: "keep",
+      } as any);
+      await em.save(entities.ChildClass, { title: "a1", parentFk: a.id } as any);
+      await em.save(entities.ChildClass, { title: "b1", parentFk: b.id } as any);
+      await em.save(entities.ChildClass, { title: "k1", parentFk: keep.id } as any);
+
+      await em.delete(entities.ParentClass, { grp: "del" } as any);
+
+      const parents = (await em.query(
+        `SELECT ${qi(type, "name")} AS name FROM ${qi(type, entities.parentTableName)}`,
+      )) as any[];
+      expect(parents.map((p) => p.name)).toEqual(["C"]);
+
+      const children = (await em.query(
+        `SELECT ${qi(type, "title")} AS title, ${qi(type, "parentFk")} AS pfk FROM ${qi(type, entities.childTableName)}`,
+      )) as any[];
+      expect(children).toHaveLength(1);
+      expect(children[0].title).toBe("k1");
+      expect(Number(children[0].pfk)).toBe(keep.id);
+    });
+
+    it("원자성 — afterDelete subscriber가 던지면 부모와 자식이 모두 복원된다", async () => {
+      const a: any = await em.save(entities.ParentClass, {
+        name: "A",
+        grp: "del",
+      } as any);
+      await em.save(entities.ChildClass, { title: "a1", parentFk: a.id } as any);
+
+      // afterDelete는 delete 트랜잭션 안에서(자식·부모 삭제 후) 실행되므로,
+      // 여기서 던지면 전체가 롤백되어야 한다. #414 이전에는 자식 DELETE가
+      // 별도 트랜잭션에서 이미 커밋되어 자식만 유실됐다.
+      const failing: EntitySubscriber<any> = {
+        listenTo: () => entities.ParentClass as any,
+        afterDelete: async () => {
+          throw new Error("afterDelete boom");
+        },
+      };
+      em.addSubscriber(failing);
+      try {
+        await expect(
+          em.delete(entities.ParentClass, { id: a.id } as any),
+        ).rejects.toThrow("afterDelete boom");
+      } finally {
+        em.removeSubscriber(failing);
+      }
+
+      expect(await countRows(entities.parentTableName)).toBe(1);
+      expect(await countRows(entities.childTableName)).toBe(1);
+    });
+  },
+);

--- a/__tests__/integration/helpers/create-relation-entity.ts
+++ b/__tests__/integration/helpers/create-relation-entity.ts
@@ -257,3 +257,84 @@ export function createCascadeRelationEntities(
 
   return { ParentClass, ChildClass, parentTableName, childTableName };
 }
+
+/**
+ * cascade DELETE 검증용 엔티티 쌍 (#414).
+ *
+ * `createCascadeRelationEntities`와 동일한 구조에 더해:
+ * - OneToMany cascade: true (delete 포함)
+ * - 부모에 다중-부모 criteria 매칭용 `grp` 컬럼
+ */
+export function createCascadeDeleteTestEntities(
+  _baseName = "cascade_del",
+): RelatedEntitiesResult {
+  // cdp=cascade-delete parent, cdc=cascade-delete child
+  const parentTableName = shortTableName("cdp");
+  const childTableName = shortTableName("cdc");
+
+  clearRelationScanners();
+
+  // ── Parent ──────────────────────────────────────────────────────────────
+  const ParentClass = class {} as any;
+  Object.defineProperty(ParentClass, "name", {
+    value: parentTableName,
+    writable: false,
+  });
+
+  Reflect.defineMetadata("design:type", Number, ParentClass.prototype, "id");
+  PrimaryGeneratedColumn()(ParentClass.prototype, "id");
+
+  Reflect.defineMetadata("design:type", String, ParentClass.prototype, "name");
+  Column()(ParentClass.prototype, "name");
+
+  Reflect.defineMetadata("design:type", String, ParentClass.prototype, "grp");
+  Column()(ParentClass.prototype, "grp");
+
+  Reflect.defineMetadata(
+    "design:type",
+    Array,
+    ParentClass.prototype,
+    "children",
+  );
+  OneToMany(() => ChildClass, { mappedBy: "parent", cascade: true })(
+    ParentClass.prototype,
+    "children",
+  );
+
+  Entity()(ParentClass);
+
+  // ── Child ───────────────────────────────────────────────────────────────
+  const ChildClass = class {} as any;
+  Object.defineProperty(ChildClass, "name", {
+    value: childTableName,
+    writable: false,
+  });
+
+  Reflect.defineMetadata("design:type", Number, ChildClass.prototype, "id");
+  PrimaryGeneratedColumn()(ChildClass.prototype, "id");
+
+  Reflect.defineMetadata("design:type", String, ChildClass.prototype, "title");
+  Column()(ChildClass.prototype, "title");
+
+  Reflect.defineMetadata(
+    "design:type",
+    Number,
+    ChildClass.prototype,
+    "parentFk",
+  );
+  Column({ type: "int", nullable: true })(ChildClass.prototype, "parentFk");
+
+  Reflect.defineMetadata(
+    "design:type",
+    ParentClass,
+    ChildClass.prototype,
+    "parent",
+  );
+  ManyToOne(() => ParentClass, (e: any) => e.parent, {
+    joinColumn: "parentFk",
+  })(ChildClass.prototype, "parent");
+
+  Entity()(ChildClass);
+
+  return { ParentClass, ChildClass, parentTableName, childTableName };
+}

--- a/__tests__/integration/sqlite/core-cascade-write-path.test.ts
+++ b/__tests__/integration/sqlite/core-cascade-write-path.test.ts
@@ -36,6 +36,7 @@ import {
   OneToOneScanner,
 } from "../../../src/scanner";
 import { DatabaseClient } from "../../../src/DatabaseClient";
+import type { EntitySubscriber } from "../../../src/core/EntitySubscriber";
 
 function shortName(prefix: string): string {
   return `${prefix}_${String(Date.now()).slice(-7)}`;
@@ -45,9 +46,11 @@ describe("[Integration] SQLite: core cascade write paths (non-buffer)", () => {
   let conn: TestConnectionResult;
   let Parent: new () => any;
   let Child: new () => any;
+  let Grand: new () => any;
 
   const parentName = shortName("ccparent");
   const childName = shortName("ccchild");
+  const grandName = shortName("ccgrand");
 
   beforeAll(async () => {
     conn = await createTestConnection(
@@ -89,6 +92,31 @@ describe("[Integration] SQLite: core cascade write paths (non-buffer)", () => {
           (p: any) => p.children,
           { cascade: ["insert"] },
         )(ChildC.prototype, "parent");
+
+        // Grandchild — one level below Child, same `${prop}Id` FK convention.
+        // Exercises the recursive branch: the cascade delete of Child rows
+        // re-enters WriteExecutor.delete, which must reuse the SAME session.
+        const GrandC = class {} as any;
+        Object.defineProperty(GrandC, "name", { value: grandName });
+        Reflect.defineMetadata("design:type", Number, GrandC.prototype, "id");
+        PrimaryGeneratedColumn()(GrandC.prototype, "id");
+        Reflect.defineMetadata("design:type", String, GrandC.prototype, "tag");
+        Column()(GrandC.prototype, "tag");
+        Reflect.defineMetadata("design:type", Number, GrandC.prototype, "childId");
+        Column({ nullable: true })(GrandC.prototype, "childId");
+        Reflect.defineMetadata("design:type", ChildC, GrandC.prototype, "child");
+        ManyToOne(() => ChildC, (c: any) => c.grandchildren)(
+          GrandC.prototype,
+          "child",
+        );
+        Entity()(GrandC);
+        Grand = GrandC;
+
+        Reflect.defineMetadata("design:type", Array, ChildC.prototype, "grandchildren");
+        OneToMany(() => GrandC, {
+          mappedBy: "child",
+          cascade: true,
+        })(ChildC.prototype, "grandchildren");
         Entity()(ChildC);
         Child = ChildC;
 
@@ -99,7 +127,7 @@ describe("[Integration] SQLite: core cascade write paths (non-buffer)", () => {
         Entity()(ParentC);
         Parent = ParentC;
 
-        return { entities: [ParentC, ChildC] };
+        return { entities: [ParentC, ChildC, GrandC] };
       },
     );
 
@@ -110,6 +138,14 @@ describe("[Integration] SQLite: core cascade write paths (non-buffer)", () => {
     await connector.query(
       `CREATE TABLE IF NOT EXISTS "${childName}" ("id" INTEGER PRIMARY KEY AUTOINCREMENT, "label" TEXT, "parentId" INTEGER)`,
     );
+    // UNIQUE on label gives the save-path atomicity test a way to make the
+    // batch INSERT fail after the cascade parents were already saved.
+    await connector.query(
+      `CREATE UNIQUE INDEX IF NOT EXISTS "uq_${childName}_label" ON "${childName}" ("label")`,
+    );
+    await connector.query(
+      `CREATE TABLE IF NOT EXISTS "${grandName}" ("id" INTEGER PRIMARY KEY AUTOINCREMENT, "tag" TEXT, "childId" INTEGER)`,
+    );
   }, 30000);
 
   afterAll(async () => {
@@ -118,6 +154,7 @@ describe("[Integration] SQLite: core cascade write paths (non-buffer)", () => {
 
   beforeEach(async () => {
     const connector = DatabaseClient.getInstance().getConnection();
+    await connector.query(`DELETE FROM "${grandName}"`);
     await connector.query(`DELETE FROM "${childName}"`);
     await connector.query(`DELETE FROM "${parentName}"`);
   });
@@ -145,15 +182,12 @@ describe("[Integration] SQLite: core cascade write paths (non-buffer)", () => {
     expect(savedChild.parentId).toBe(parents[0].id);
   });
 
-  // KNOWN DEFECT (#414): cascadeDeleteOneToMany issues the child deletes
-  // through ctx.delete WITHOUT the outer delete's session, so they open a
-  // NEW transaction. On SQLite's single shared connection the nested BEGIN
-  // throws ("cannot start a transaction within a transaction"), so core
-  // cascade delete fails entirely; on PG/MySQL the children commit in a
-  // separate transaction (atomicity violation). `it.failing` keeps the repro
-  // green in CI and flips to a hard failure the moment #414 fixes it —
-  // remove `.failing` then.
-  it.failing("em.delete(Parent, pk) cascade-deletes the single parent's children (#414)", async () => {
+  // #414: cascadeDeleteOneToMany used to issue the child deletes through
+  // ctx.delete WITHOUT the outer delete's session, opening a NEW transaction
+  // (nested-BEGIN crash on SQLite's single shared connection; separate-commit
+  // atomicity violation on PG/MySQL). Fixed by publishing the outer session
+  // via transactionStorage.run() in WriteExecutor.delete().
+  it("em.delete(Parent, pk) cascade-deletes the single parent's children (#414)", async () => {
     const a: any = await conn.em.save(Parent, { name: "A", grp: "del" } as any);
     await conn.em.save(Child, { label: "a1", parentId: a.id } as any);
 
@@ -165,7 +199,7 @@ describe("[Integration] SQLite: core cascade write paths (non-buffer)", () => {
     expect(children).toHaveLength(0);
   });
 
-  it.failing("em.delete(Parent, criteria) matching MULTIPLE parents cascade-deletes all their children via IN (#414)", async () => {
+  it("em.delete(Parent, criteria) matching MULTIPLE parents cascade-deletes all their children via IN (#414)", async () => {
     const a: any = await conn.em.save(Parent, { name: "A", grp: "del" } as any);
     const b: any = await conn.em.save(Parent, { name: "B", grp: "del" } as any);
     const keep: any = await conn.em.save(Parent, { name: "C", grp: "keep" } as any);
@@ -188,5 +222,114 @@ describe("[Integration] SQLite: core cascade write paths (non-buffer)", () => {
     expect(children).toHaveLength(1);
     expect(children[0].label).toBe("k1");
     expect(children[0].parentId).toBe(keep.id);
+  });
+
+  it("cascade delete recurses to grandchildren inside the same transaction (#414)", async () => {
+    const a: any = await conn.em.save(Parent, { name: "A", grp: "del" } as any);
+    const c: any = await conn.em.save(Child, { label: "c-rec", parentId: a.id } as any);
+    await conn.em.save(Grand, { tag: "g1", childId: c.id } as any);
+    await conn.em.save(Grand, { tag: "g2", childId: c.id } as any);
+
+    await conn.em.delete(Parent, { id: a.id } as any);
+
+    const children = (await conn.em.query(
+      `SELECT "id" FROM "${childName}"`,
+    )) as any[];
+    const grands = (await conn.em.query(
+      `SELECT "id" FROM "${grandName}"`,
+    )) as any[];
+    expect(children).toHaveLength(0);
+    expect(grands).toHaveLength(0);
+  });
+
+  it("cascade delete is atomic — a throwing afterDelete subscriber restores the children (#414)", async () => {
+    const a: any = await conn.em.save(Parent, { name: "A", grp: "del" } as any);
+    await conn.em.save(Child, { label: "atomic-1", parentId: a.id } as any);
+
+    // afterDelete fires inside the delete's transaction, after the children
+    // and the parent row were already deleted — throwing here must roll BOTH
+    // back. Pre-#414 the child delete had committed in its own transaction,
+    // so the child stayed lost while the parent survived.
+    const failing: EntitySubscriber<any> = {
+      listenTo: () => Parent as any,
+      afterDelete: async () => {
+        throw new Error("afterDelete boom");
+      },
+    };
+    conn.em.addSubscriber(failing);
+    try {
+      await expect(
+        conn.em.delete(Parent, { id: a.id } as any),
+      ).rejects.toThrow("afterDelete boom");
+    } finally {
+      conn.em.removeSubscriber(failing);
+    }
+
+    const parents = (await conn.em.query(
+      `SELECT "id" FROM "${parentName}"`,
+    )) as any[];
+    const children = (await conn.em.query(
+      `SELECT "label" FROM "${childName}"`,
+    )) as any[];
+    expect(parents).toHaveLength(1);
+    expect(children).toHaveLength(1);
+    expect(children[0].label).toBe("atomic-1");
+  });
+
+  it("saveMany fallback (explicit PKs) with cascade M2O parents joins the outer transaction (#414)", async () => {
+    const c1: any = await conn.em.save(Child, { label: "m1" } as any);
+    const c2: any = await conn.em.save(Child, { label: "m2" } as any);
+
+    // Explicit PKs disable the batch-INSERT path, so each item goes through
+    // saveInternal(entity, item, session) under saveMany's transaction (the
+    // UPDATE branch here). The cascade parent saves must reuse that session —
+    // pre-#414 they opened a second one, and the nested BEGIN on SQLite's
+    // single connection crashed the whole saveMany.
+    await conn.em.saveMany(Child, [
+      { id: c1.id, label: "m1", parent: { name: "MP1", grp: "g" } },
+      { id: c2.id, label: "m2", parent: { name: "MP2", grp: "g" } },
+    ] as any[]);
+
+    const parents = (await conn.em.query(
+      `SELECT "id", "name" FROM "${parentName}" ORDER BY "id"`,
+    )) as any[];
+    expect(parents.map((p) => p.name)).toEqual(["MP1", "MP2"]);
+
+    // The cascade must also have linked each child to its new parent.
+    const children = (await conn.em.query(
+      `SELECT "id", "label", "parentId" FROM "${childName}" ORDER BY "id"`,
+    )) as any[];
+    expect(children).toHaveLength(2);
+    expect(children[0].parentId).toBe(parents[0].id);
+    expect(children[1].parentId).toBe(parents[1].id);
+  });
+
+  it("saveMany batch INSERT failure rolls back the cascade-saved M2O parents (#414)", async () => {
+    // Generated PKs → batch-INSERT path. The duplicate label violates the
+    // unique index, failing the batch INSERT after both cascade parents were
+    // saved. Atomicity requires the parents to roll back with it — pre-#414
+    // they were committed before the transaction even opened.
+    // try/catch instead of `.rejects.toThrow()`: the SqliteError originates in
+    // the shared native binding, and jest's instanceof-based matcher proved
+    // order-dependent across test-file realms in the full-suite run.
+    let threw: unknown = false;
+    try {
+      await conn.em.saveMany(Child, [
+        { label: "dup", parent: { name: "RB1", grp: "g" } },
+        { label: "dup", parent: { name: "RB2", grp: "g" } },
+      ] as any[]);
+    } catch (e) {
+      threw = e ?? true;
+    }
+    expect(String(threw)).toContain("UNIQUE");
+
+    const parents = (await conn.em.query(
+      `SELECT "id" FROM "${parentName}"`,
+    )) as any[];
+    const children = (await conn.em.query(
+      `SELECT "id" FROM "${childName}"`,
+    )) as any[];
+    expect(parents).toHaveLength(0);
+    expect(children).toHaveLength(0);
   });
 });

--- a/src/core/entity-manager/WriteExecutor.ts
+++ b/src/core/entity-manager/WriteExecutor.ts
@@ -30,6 +30,7 @@ import {
 import { EntityManagerInternals } from "../EntityManagerInternals";
 import { RelationMetadataResolver } from "../RelationMetadataResolver";
 import { CascadeHandler } from "../CascadeHandler";
+import { transactionStorage } from "../../decorators/Transactional";
 import { OrmError } from "../../errors/OrmError";
 import { OrmErrorCode } from "../../errors/OrmErrorCode";
 import { DefaultNamingStrategy, NamingStrategy } from "../generators/NamingStrategy";
@@ -98,10 +99,17 @@ export class WriteExecutor {
     // Validation
     EntityValidator.validate(entity, item);
 
-    // Cascade: save the parent entity of any ManyToOne relation first
-    await this.cascadeHandler.cascadeSaveManyToOne(entity, item);
-
     return this.ctx.executeInTransaction(async (session) => {
+      // Cascade: save the parent entity of any ManyToOne relation first.
+      // Same session-escape shape as the delete path (#414): the handler
+      // saves through the public ctx.save, so publish this session via ALS
+      // for it to join — otherwise the parent commits in its own transaction
+      // (and nested-BEGINs SQLite when saveInternal runs under an existing
+      // session, e.g. the saveMany fallback or an O2M cascade child).
+      await transactionStorage.run(session, () =>
+        this.cascadeHandler.cascadeSaveManyToOne(entity, item),
+      );
+
       const pkColumns = metadata.columns.filter(
         (column: ColumnMetadata) => column.options?.primary,
       );
@@ -886,15 +894,18 @@ export class WriteExecutor {
         });
 
       if (canBatchInsert) {
-        // Validation + ManyToOne cascade (before the transaction)
         for (const item of items) {
           EntityValidator.validate(entity, item);
         }
-        for (const item of items) {
-          await this.cascadeHandler.cascadeSaveManyToOne(entity, item);
-        }
 
         return this.ctx.executeInTransaction(async (session) => {
+          // ManyToOne cascade joins this transaction via ALS (#414) so the
+          // cascade-saved parents roll back together with the batch INSERT.
+          await transactionStorage.run(session, async () => {
+            for (const item of items) {
+              await this.cascadeHandler.cascadeSaveManyToOne(entity, item);
+            }
+          });
           return this.saveManyBatchInsert(entity, pk, items, session);
         });
       }
@@ -1516,8 +1527,15 @@ export class WriteExecutor {
         manager: this.ctx.getManager(),
       } as DeleteEvent<T>);
 
-      // cascade remove
-      await this.cascadeHandler.cascadeDeleteOneToMany(entity, criteria);
+      // cascade remove — the handler issues the child deletes (and the
+      // parent-PK SELECT) through the public ctx.delete/ctx.find, which only
+      // join an ambient ALS session. Publish this transaction's session so
+      // they reuse it instead of opening a second one: a nested BEGIN crashes
+      // SQLite's single shared connection, and on pooled drivers the children
+      // would commit independently of the parent delete (#414).
+      await transactionStorage.run(session, () =>
+        this.cascadeHandler.cascadeDeleteOneToMany(entity, criteria),
+      );
 
       const deletePropToCol = this.ctx.buildPropertyToColumnMap(metadata);
       // #372: write criteria accept find-style operator objects


### PR DESCRIPTION
Closes #414

`WriteExecutor` ran cascade child writes through the public `ctx.delete`/`ctx.find`/`ctx.save` without publishing the outer transaction's session, so they opened a second `TransactionSessionManager` — a nested-BEGIN crash on SQLite's single shared connection, and children committing independently of the parent operation on PG/MySQL (orphaned data loss when the outer transaction rolled back).

Fix: publish the outer session via `transactionStorage.run(session, ...)` (the same ALS propagation `em.transaction()` uses) around:
- `cascadeDeleteOneToMany` in `delete()` — child deletes and the parent-PK SELECT join the outer transaction, including recursive (grandchild) cascades
- `cascadeSaveManyToOne` in `saveInternal()` and the `saveMany` batch path — same session-escape shape found by the audit; the calls also move inside the transaction so cascade-saved parents roll back with a failed insert

O2O has no cascade logic on the core write path (nothing to fix). `cascadeSaveOneToMany` already threads the session explicitly.

Tests: the two `it.failing` repros from #404 flip to passing; new SQLite coverage for grandchild recursion, afterDelete-rollback atomicity, and both saveMany cascade paths; new dual-driver (PG/MySQL) suite `cascade-delete-atomicity.test.ts`.

Verified locally: unit 5,327 passed / SQLite integration 624 passed / dual build clean.