### PR TITLE
fix(core): robustness hardening — toposort asserts, liveness probing, FK names (#411)

### DIFF
--- a/__tests__/unit/buffer-plugin.test.ts
+++ b/__tests__/unit/buffer-plugin.test.ts
@@ -4372,7 +4372,7 @@ describe("Buffer Plugin", () => {
 
       const result = topologicalSort([CycleX, CycleY]);
       expect(warnSpy).toHaveBeenCalledWith(
-        expect.stringContaining("Dependency cycle detected"),
+        expect.stringContaining("Circular FK dependency"),
       );
       // Fallback: returns original order
       expect(result).toEqual([CycleX, CycleY]);

--- a/__tests__/unit/robustness-hardening-411.test.ts
+++ b/__tests__/unit/robustness-hardening-411.test.ts
@@ -1,0 +1,310 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/**
+ * #411 robustness hardening regression tests.
+ *
+ * 1. DependencyGraph toposort — no non-null assertions: cycles fall back with
+ *    a diagnosable warning, duplicate/self-referencing/foreign inputs cannot
+ *    make the sort throw mid-flush.
+ * 2. Connection liveness probing — pg/mysql2 undocumented internals are read
+ *    through readInternalFlag() with an "assume alive" fallback.
+ * 3. User-defined FK names — drivers honor an explicit constraint name and
+ *    SchemaRegistrar passes the NamingStrategy-derived name to addForeignKey
+ *    (previously only the existence check used it).
+ */
+import "reflect-metadata";
+
+jest.mock("../../src/scanner/ScannerContainer", () => ({
+  getScannerInstance: jest.fn(() => ({
+    scan: (entity: any) => mockEntityScans.get(entity),
+  })),
+}));
+
+import { topologicalSort } from "../../src/core/plugin/buffer/DependencyGraph";
+import { MANY_TO_ONE_TOKEN } from "../../src/decorators/ManyToOne";
+import { COLUMN_TOKEN } from "../../src/decorators";
+import { readInternalFlag } from "../../src/dialects/connection-liveness";
+import { PostgresConnection } from "../../src/dialects/postgres/PostgresConnection";
+import { MysqlConnection } from "../../src/dialects/mysql/MysqlConnection";
+import { MySqlDriver } from "../../src/dialects/mysql/MySqlDriver";
+import { PostgresDriver } from "../../src/dialects/postgres/PostgresDriver";
+import { SchemaRegistrar } from "../../src/core/SchemaRegistrar";
+import { DefaultNamingStrategy } from "../../src/core/generators/NamingStrategy";
+import type { NamingStrategy } from "../../src/core/generators/NamingStrategy";
+import type { RelationMetadataResolver } from "../../src/core/RelationMetadataResolver";
+import type { EntityManagerInternals } from "../../src/core/EntityManagerInternals";
+
+const mockEntityScans = new Map<any, any>();
+
+// ──────────────────────────────────────────────
+// 1. DependencyGraph toposort hardening
+// ──────────────────────────────────────────────
+
+function defineM2O(child: any, parent: any) {
+  const existing: any[] = Reflect.getMetadata(MANY_TO_ONE_TOKEN, child) ?? [];
+  Reflect.defineMetadata(
+    MANY_TO_ONE_TOKEN,
+    [
+      ...existing,
+      {
+        target: child,
+        type: parent,
+        columnName: "p",
+        joinColumn: "pId",
+        getMappingEntity: () => parent,
+        option: {},
+      },
+    ],
+    child,
+  );
+}
+
+describe("DependencyGraph toposort hardening (#411)", () => {
+  // Logger.warn is an instance field bound at construction, so intercept at
+  // the console.log sink it prints through.
+  let logSpy: jest.SpyInstance;
+
+  const cycleWarnings = () =>
+    logSpy.mock.calls.filter((call) =>
+      call.map(String).join(" ").includes("Circular FK dependency"),
+    );
+
+  beforeEach(() => {
+    logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  it("falls back to input order on a cycle and names the entities involved", () => {
+    class RingA {}
+    class RingB {}
+    defineM2O(RingA, RingB);
+    defineM2O(RingB, RingA);
+
+    const sorted = topologicalSort([RingA, RingB]);
+
+    expect(sorted).toEqual([RingA, RingB]);
+    expect(cycleWarnings()).toHaveLength(1);
+    const message = cycleWarnings()[0].map(String).join(" ");
+    expect(message).toContain("RingA");
+    expect(message).toContain("RingB");
+  });
+
+  it("duplicate input entries do not trigger a false cycle warning", () => {
+    class DupParent {}
+    class DupChild {}
+    defineM2O(DupChild, DupParent);
+
+    const sorted = topologicalSort([DupChild, DupParent, DupChild]);
+
+    expect(cycleWarnings()).toHaveLength(0);
+    expect(sorted.indexOf(DupParent)).toBeLessThan(sorted.indexOf(DupChild));
+  });
+
+  it("ignores a self-referencing relation instead of dying", () => {
+    class SelfRef {}
+    defineM2O(SelfRef, SelfRef);
+
+    expect(topologicalSort([SelfRef, class Other {}])).toHaveLength(2);
+    expect(cycleWarnings()).toHaveLength(0);
+  });
+
+  it("ignores a parent outside the sorted set", () => {
+    class Outside {}
+    class InsideChild {}
+    defineM2O(InsideChild, Outside);
+
+    const sorted = topologicalSort([InsideChild, class Peer {}]);
+    expect(sorted).toContain(InsideChild);
+    expect(sorted).toHaveLength(2);
+    expect(cycleWarnings()).toHaveLength(0);
+  });
+
+  it("tolerates malformed relation metadata (getMappingEntity returning null)", () => {
+    class Broken {}
+    Reflect.defineMetadata(
+      MANY_TO_ONE_TOKEN,
+      [{ getMappingEntity: () => null, option: {} }],
+      Broken,
+    );
+
+    expect(() => topologicalSort([Broken, class Peer2 {}])).not.toThrow();
+  });
+});
+
+// ──────────────────────────────────────────────
+// 2. Connection liveness probing isolation
+// ──────────────────────────────────────────────
+
+describe("connection liveness probing (#411)", () => {
+  it("readInternalFlag treats a missing field / non-object as flag-not-set", () => {
+    expect(readInternalFlag(null, "_ending")).toBe(false);
+    expect(readInternalFlag(undefined, "_ending")).toBe(false);
+    expect(readInternalFlag("client", "_ending")).toBe(false);
+    expect(readInternalFlag({}, "_ending")).toBe(false);
+    expect(readInternalFlag({ _ending: true }, "_ending")).toBe(true);
+    expect(readInternalFlag({ _ending: false }, "_ending")).toBe(false);
+    // truthy-but-not-boolean internals do not count as the flag
+    expect(readInternalFlag({ _ending: 1 }, "_ending")).toBe(false);
+  });
+
+  it("PostgresConnection.isAlive: alive on unknown client shape, dead once _ending or released", async () => {
+    const alive = new PostgresConnection({ release: jest.fn() } as any);
+    expect(alive.isAlive()).toBe(true);
+
+    const ending = new PostgresConnection({ release: jest.fn(), _ending: true } as any);
+    expect(ending.isAlive()).toBe(false);
+
+    await alive.release();
+    expect(alive.isAlive()).toBe(false);
+  });
+
+  it("MysqlConnection.isAlive: alive on unknown client shape, dead once destroyed or released", async () => {
+    const alive = new MysqlConnection({ release: jest.fn() } as any);
+    expect(alive.isAlive()).toBe(true);
+
+    const destroyed = new MysqlConnection({ release: jest.fn(), destroyed: true } as any);
+    expect(destroyed.isAlive()).toBe(false);
+
+    await alive.release();
+    expect(alive.isAlive()).toBe(false);
+  });
+});
+
+// ──────────────────────────────────────────────
+// 3. User-defined FK constraint names
+// ──────────────────────────────────────────────
+
+function makeConnector() {
+  return { query: jest.fn(async () => ({})), getVersion: () => undefined } as any;
+}
+
+describe("user-defined FK constraint names (#411)", () => {
+  it("MySqlDriver.addForeignKey uses the explicit name, wrapped", async () => {
+    const connector = makeConnector();
+    const driver = new MySqlDriver(connector);
+
+    await driver.addForeignKey("child", "parent_id", "parent", "id", "fk_custom_name");
+
+    const ddl = connector.query.mock.calls[0][0] as string;
+    expect(ddl).toContain("ADD CONSTRAINT `fk_custom_name`");
+    expect(ddl).toContain("FOREIGN KEY (`parent_id`) REFERENCES `parent`(`id`)");
+  });
+
+  it("MySqlDriver.addForeignKey falls back to the hash-based name when omitted", async () => {
+    const connector = makeConnector();
+    const driver = new MySqlDriver(connector);
+
+    await driver.addForeignKey("child", "parent_id", "parent", "id");
+
+    const expected = driver.generateForeignKeyName("child", "parent", "parent_id");
+    const ddl = connector.query.mock.calls[0][0] as string;
+    expect(ddl).toContain(`ADD CONSTRAINT \`${expected}\``);
+  });
+
+  it("PostgresDriver.addForeignKey uses the explicit name, wrapped", async () => {
+    const connector = makeConnector();
+    const driver = new PostgresDriver(connector);
+
+    await driver.addForeignKey("child", "parent_id", "parent", "id", "fk_custom_name");
+
+    const ddl = connector.query.mock.calls[0][0] as string;
+    expect(ddl).toContain('ADD CONSTRAINT "fk_custom_name"');
+    expect(ddl).toContain('FOREIGN KEY ("parent_id")');
+  });
+
+  // ── SchemaRegistrar passes the NamingStrategy name through ──
+
+  class FkParent {}
+  class FkChild {}
+
+  beforeAll(() => {
+    Reflect.defineMetadata(
+      COLUMN_TOKEN,
+      [{ name: "id", propertyKey: "id", options: { primary: true, type: "int" } }],
+      FkParent.prototype,
+    );
+    mockEntityScans.set(FkParent, {
+      name: "fk_parent",
+      columns: [{ name: "id", options: { primary: true, type: "int" } }],
+    });
+  });
+
+  function makeDriver() {
+    return {
+      castType: (t: string) => t.toUpperCase(),
+      hasColumn: jest.fn(async () => true),
+      addColumn: jest.fn(async () => {}),
+      hasForeignKey: jest.fn(async () => false),
+      addForeignKey: jest.fn(async () => {}),
+    } as any;
+  }
+
+  function makeCtx(driver: any): EntityManagerInternals {
+    return {
+      wrap: (c: string) => `\`${c}\``,
+      wrapTable: (t: string) => `\`${t}\``,
+      isMySqlFamily: () => true,
+      isPostgres: () => false,
+      isSqlite: () => false,
+      getDriver: () => driver,
+      getSynchronize: () => true,
+      getDialect: () => "mysql",
+      getNameStrategy: (e: any) => mockEntityScans.get(e)?.name ?? e.name,
+    } as unknown as EntityManagerInternals;
+  }
+
+  function makeResolver(): RelationMetadataResolver {
+    return {
+      resolveManyToOneMetadata: () => [
+        { joinColumn: "parent_id", getMappingEntity: () => FkParent, option: {} },
+      ],
+      resolveOneToOneMetadata: () => [],
+    } as unknown as RelationMetadataResolver;
+  }
+
+  it("registerForeignKeys passes the default NamingStrategy name to addForeignKey", async () => {
+    const driver = makeDriver();
+    const registrar = new SchemaRegistrar(makeResolver(), makeCtx(driver));
+
+    await registrar.registerForeignKeys(FkChild, "fk_child");
+
+    const expected = new DefaultNamingStrategy().foreignKeyName(
+      "fk_child",
+      "parent_id",
+      "fk_parent",
+    );
+    expect(driver.hasForeignKey).toHaveBeenCalledWith("fk_child", expected);
+    expect(driver.addForeignKey).toHaveBeenCalledWith(
+      "fk_child",
+      "parent_id",
+      "fk_parent",
+      "id",
+      expected,
+    );
+  });
+
+  it("registerForeignKeys checks AND creates under a custom NamingStrategy name", async () => {
+    const driver = makeDriver();
+    const custom: NamingStrategy = {
+      ...new DefaultNamingStrategy(),
+      foreignKeyName: (table, column, refTable) => `FK_${table}_${column}_${refTable}`,
+    } as NamingStrategy;
+    const registrar = new SchemaRegistrar(makeResolver(), makeCtx(driver), custom);
+
+    await registrar.registerForeignKeys(FkChild, "fk_child");
+
+    expect(driver.hasForeignKey).toHaveBeenCalledWith(
+      "fk_child",
+      "FK_fk_child_parent_id_fk_parent",
+    );
+    expect(driver.addForeignKey).toHaveBeenCalledWith(
+      "fk_child",
+      "parent_id",
+      "fk_parent",
+      "id",
+      "FK_fk_child_parent_id_fk_parent",
+    );
+  });
+});

--- a/src/core/SchemaRegistrar.ts
+++ b/src/core/SchemaRegistrar.ts
@@ -480,6 +480,7 @@ export class SchemaRegistrar {
                       pk.name!,
                       rootTableName,
                       rootPk.name!,
+                      fkName,
                     );
                   }
                 } catch (err) {
@@ -1101,14 +1102,16 @@ export class SchemaRegistrar {
           }
         }
 
-        // Skip adding the FK constraint if it already exists.
+        // The NamingStrategy name is both checked for existence AND passed to
+        // addForeignKey — a custom strategy previously only affected the
+        // check while the DDL fell back to the hash-based name (#411).
+        const m2oFkName = this.namingStrategy.foreignKeyName(
+          tableName,
+          joinColumn,
+          mappingTableName,
+        );
         if (driver) {
-          const fkName = this.namingStrategy.foreignKeyName(
-            tableName,
-            joinColumn,
-            mappingTableName,
-          );
-          const fkExists = await driver.hasForeignKey(tableName, fkName);
+          const fkExists = await driver.hasForeignKey(tableName, m2oFkName);
           if (fkExists) continue;
         }
 
@@ -1121,6 +1124,7 @@ export class SchemaRegistrar {
           mappingTableName,
           // Target table's primary key
           mappingTablePrimaryKey,
+          m2oFkName,
         );
       }
     }
@@ -1166,14 +1170,15 @@ export class SchemaRegistrar {
       const relatedTableName =
         relatedMetadata.name || this.ctx.getNameStrategy(RelatedEntity);
 
-      // Skip adding the FK constraint if it already exists.
+      // Same as the ManyToOne path: check and create under the SAME
+      // NamingStrategy-derived constraint name (#411).
+      const o2oFkName = this.namingStrategy.foreignKeyName(
+        tableName,
+        joinColumn,
+        relatedTableName,
+      );
       if (driver) {
-        const fkName = this.namingStrategy.foreignKeyName(
-          tableName,
-          joinColumn,
-          relatedTableName,
-        );
-        const fkExists = await driver.hasForeignKey(tableName, fkName);
+        const fkExists = await driver.hasForeignKey(tableName, o2oFkName);
         if (fkExists) continue;
       }
 
@@ -1182,6 +1187,7 @@ export class SchemaRegistrar {
         joinColumn,
         relatedTableName,
         relatedPrimaryKey,
+        o2oFkName,
       );
     }
   }

--- a/src/core/plugin/buffer/DependencyGraph.ts
+++ b/src/core/plugin/buffer/DependencyGraph.ts
@@ -7,11 +7,29 @@ import { ONE_TO_ONE_TOKEN } from "../../../decorators/OneToOne";
 const logger = new Logger("DependencyGraph");
 
 /**
+ * Returns the Set stored under `key`, initializing an empty one on first
+ * access. Flush must never die on a missing key: the sort runs mid-flush,
+ * so a broken seeding assumption has to degrade to "no edges", not throw.
+ */
+function edgeSet(
+  map: Map<ClazzType<any>, Set<ClazzType<any>>>,
+  key: ClazzType<any>,
+): Set<ClazzType<any>> {
+  let set = map.get(key);
+  if (!set) {
+    set = new Set();
+    map.set(key, set);
+  }
+  return set;
+}
+
+/**
  * Build a dependency graph from @ManyToOne and @OneToOne(joinColumn) metadata.
  * A child "depends on" its parent (the entity it references via FK).
  *
  * Returns entities in topological order (parents first) using Kahn's algorithm.
- * On cycle detection, logs a warning and falls back to the original order.
+ * On cycle detection, logs a warning naming the entities on the cycle and
+ * falls back to the original order.
  */
 export function topologicalSort(entityClasses: ClazzType<any>[]): ClazzType<any>[] {
   if (entityClasses.length <= 1) return [...entityClasses];
@@ -22,19 +40,14 @@ export function topologicalSort(entityClasses: ClazzType<any>[]): ClazzType<any>
   // reverse adjacency for in-degree tracking
   const dependents = new Map<ClazzType<any>, Set<ClazzType<any>>>();
 
-  for (const cls of entityClasses) {
-    deps.set(cls, new Set());
-    dependents.set(cls, new Set());
-  }
-
-  for (const cls of entityClasses) {
+  for (const cls of classSet) {
     // @ManyToOne → cls depends on parent
     const m2oMeta: any[] = Reflect.getMetadata(MANY_TO_ONE_TOKEN, cls) ?? [];
     for (const m of m2oMeta) {
       const parent = typeof m.getMappingEntity === "function" ? m.getMappingEntity() : m.type;
       if (parent && classSet.has(parent) && parent !== cls) {
-        deps.get(cls)!.add(parent);
-        dependents.get(parent)!.add(cls);
+        edgeSet(deps, cls).add(parent);
+        edgeSet(dependents, parent).add(cls);
       }
     }
 
@@ -44,42 +57,49 @@ export function topologicalSort(entityClasses: ClazzType<any>[]): ClazzType<any>
       if (m.joinColumn) {
         const target = typeof m.getRelatedEntity === "function" ? m.getRelatedEntity() : null;
         if (target && classSet.has(target) && target !== cls) {
-          deps.get(cls)!.add(target);
-          dependents.get(target)!.add(cls);
+          edgeSet(deps, cls).add(target);
+          edgeSet(dependents, target).add(cls);
         }
       }
     }
   }
 
-  // Kahn's algorithm
+  // Kahn's algorithm — every lookup tolerates an absent key (degree 0 / no
+  // dependents) instead of asserting the maps were fully pre-seeded.
   const inDegree = new Map<ClazzType<any>, number>();
-  for (const cls of entityClasses) {
-    inDegree.set(cls, deps.get(cls)!.size);
-  }
-
   const queue: ClazzType<any>[] = [];
-  for (const cls of entityClasses) {
-    if (inDegree.get(cls) === 0) queue.push(cls);
+  for (const cls of classSet) {
+    const degree = deps.get(cls)?.size ?? 0;
+    inDegree.set(cls, degree);
+    if (degree === 0) queue.push(cls);
   }
 
   const sorted: ClazzType<any>[] = [];
   while (queue.length > 0) {
-    const node = queue.shift()!;
+    const node = queue.shift() as ClazzType<any>;
     sorted.push(node);
-    for (const dep of dependents.get(node)!) {
-      const newDeg = inDegree.get(dep)! - 1;
+    for (const dep of dependents.get(node) ?? []) {
+      const newDeg = (inDegree.get(dep) ?? 0) - 1;
       inDegree.set(dep, newDeg);
       if (newDeg === 0) queue.push(dep);
     }
   }
 
-  // Cycle detected — warn and fallback to original order
-  if (sorted.length !== entityClasses.length) {
-    const missing = entityClasses.filter(c => !sorted.includes(c)).map(c => c.name);
-    logger.warn(`Dependency cycle detected: [${missing.join(', ')}]. Using original order.`);
+  // Cycle detected — warn with the entities still holding unresolved FK
+  // dependencies and fall back to the original order so flush proceeds.
+  if (sorted.length !== classSet.size) {
+    const missing = [...classSet].filter(c => !sorted.includes(c)).map(c => c.name);
+    logger.warn(
+      `Circular FK dependency between entities [${missing.join(" -> ")}] — ` +
+        `flush order cannot be derived topologically. Falling back to registration order; ` +
+        `if a FK constraint rejects this order, make one side of the cycle nullable ` +
+        `or defer it out of the cycle.`,
+    );
     return [...entityClasses];
   }
 
+  // Duplicate input entries collapse via classSet — previously they made the
+  // length check misreport a cycle. The result is the distinct class order.
   return sorted;
 }
 

--- a/src/dialects/SqlDriver.ts
+++ b/src/dialects/SqlDriver.ts
@@ -92,6 +92,9 @@ export interface ISqlDriver<T = any> {
    * @param columnName - The name of the column to set as a foreign key.
    * @param foreignTableName - The name of the referenced table.
    * @param foreignColumnName - The name of the referenced column.
+   * @param constraintName - Optional constraint name (e.g. from
+   *   `NamingStrategy.foreignKeyName()`); when omitted the driver falls back
+   *   to its hash-based `generateForeignKeyName()`.
    * @returns A promise that resolves when the operation is complete.
    */
   addForeignKey(
@@ -99,6 +102,7 @@ export interface ISqlDriver<T = any> {
     columnName: string,
     foreignTableName: string,
     foreignColumnName: string,
+    constraintName?: string,
   ): Promise<T>;
 
   /**

--- a/src/dialects/connection-liveness.ts
+++ b/src/dialects/connection-liveness.ts
@@ -1,0 +1,24 @@
+/**
+ * Single home for every probe into UNDOCUMENTED internals of the underlying
+ * DB client libraries. Nothing else in the codebase may reach into pg/mysql2
+ * private fields — when a driver upgrade renames or removes one of these
+ * flags, this file is the only place to adjust, and the fallback below keeps
+ * the ORM functional (a stale-but-alive verdict is recoverable: the pool's
+ * ping/error handling replaces a truly dead connection on next use).
+ *
+ * Known probes:
+ * - pg `PoolClient._ending` — set once `end()` starts; no public equivalent.
+ * - mysql2 `PoolConnection.destroyed` — set by `destroy()`; not in the docs
+ *   or the type definitions, but stable across mysql2 majors.
+ */
+
+/**
+ * Reads a boolean-ish internal flag off a raw client object.
+ * Returns `false` when the object is missing or the field is absent —
+ * i.e. an unknown client shape is presumed NOT to have the flag set, so
+ * `isAlive()` degrades to "alive" instead of poisoning every connection.
+ */
+export function readInternalFlag(raw: unknown, field: string): boolean {
+  if (raw === null || typeof raw !== "object") return false;
+  return (raw as Record<string, unknown>)[field] === true;
+}

--- a/src/dialects/mysql/MySqlDriver.ts
+++ b/src/dialects/mysql/MySqlDriver.ts
@@ -185,31 +185,29 @@ export class MySqlDriver implements ISqlDriver {
 
   /**
    * Adds a foreign key.
-   * TODO: allow user-defined foreign key names later.
    *
    * @param tableName
    * @param columnName
    * @param foreignTableName
    * @param foreignColumnName
+   * @param constraintName Optional user/NamingStrategy-defined constraint
+   *   name; defaults to the hash-based framework convention.
    */
   addForeignKey(
     tableName: string,
     columnName: string,
     foreignTableName: string,
     foreignColumnName: string,
+    constraintName?: string,
   ) {
-    // Generate the foreign key name using the framework convention.
-    // A custom key name may also be provided; in that case, the user-specified name should be used.
-    const foreignKeyName = this.generateForeignKeyName(
-      tableName,
-      foreignTableName,
-      columnName,
-    );
+    const foreignKeyName =
+      constraintName ??
+      this.generateForeignKeyName(tableName, foreignTableName, columnName);
 
     // We should allow ON DELETE and ON UPDATE options to be specified later.
     // For now it is set to NO ACTION.
     return this.connector.query(
-      `ALTER TABLE ${this.wrap(tableName)} ADD CONSTRAINT ${foreignKeyName} FOREIGN KEY (${this.wrap(columnName)}) REFERENCES ${this.wrap(foreignTableName)}(${this.wrap(foreignColumnName)}) ON DELETE NO ACTION ON UPDATE NO ACTION`,
+      `ALTER TABLE ${this.wrap(tableName)} ADD CONSTRAINT ${this.wrap(foreignKeyName)} FOREIGN KEY (${this.wrap(columnName)}) REFERENCES ${this.wrap(foreignTableName)}(${this.wrap(foreignColumnName)}) ON DELETE NO ACTION ON UPDATE NO ACTION`,
     );
   }
 

--- a/src/dialects/mysql/MysqlConnection.ts
+++ b/src/dialects/mysql/MysqlConnection.ts
@@ -1,5 +1,6 @@
 import type { PoolConnection } from "mysql2";
 import { IConnection } from "../IConnection";
+import { readInternalFlag } from "../connection-liveness";
 
 /**
  * MySQL IConnection implementation wrapping a mysql2 PoolConnection.
@@ -24,7 +25,7 @@ export class MysqlConnection implements IConnection<PoolConnection> {
 
   isAlive(): boolean {
     if (this.released) return false;
-    // mysql2 PoolConnection exposes a `destroyed` property
-    return !(this.raw as unknown as { destroyed?: boolean }).destroyed;
+    // Undocumented mysql2 internal — probed via connection-liveness.ts only.
+    return !readInternalFlag(this.raw, "destroyed");
   }
 }

--- a/src/dialects/postgres/PostgresConnection.ts
+++ b/src/dialects/postgres/PostgresConnection.ts
@@ -1,5 +1,6 @@
 import type { PoolClient } from "pg";
 import { IConnection } from "../IConnection";
+import { readInternalFlag } from "../connection-liveness";
 
 /**
  * PostgreSQL IConnection implementation wrapping a pg PoolClient.
@@ -24,7 +25,7 @@ export class PostgresConnection implements IConnection<PoolClient> {
 
   isAlive(): boolean {
     if (this.released) return false;
-    // pg PoolClient has an internal _ending flag when released
-    return !(this.raw as unknown as { _ending?: boolean })._ending;
+    // Undocumented pg internal — probed via connection-liveness.ts only.
+    return !readInternalFlag(this.raw, "_ending");
   }
 }

--- a/src/dialects/postgres/PostgresDriver.ts
+++ b/src/dialects/postgres/PostgresDriver.ts
@@ -336,21 +336,23 @@ export class PostgresDriver implements ISqlDriver {
 
   /**
    * Adds a foreign key.
+   *
+   * @param constraintName Optional user/NamingStrategy-defined constraint
+   *   name; defaults to the hash-based framework convention.
    */
   addForeignKey(
     tableName: string,
     columnName: string,
     foreignTableName: string,
     foreignColumnName: string,
+    constraintName?: string,
   ) {
-    const foreignKeyName = this.generateForeignKeyName(
-      tableName,
-      foreignTableName,
-      columnName,
-    );
+    const foreignKeyName =
+      constraintName ??
+      this.generateForeignKeyName(tableName, foreignTableName, columnName);
 
     return this.connector.query(
-      `ALTER TABLE ${this.wrapQualified(tableName)} ADD CONSTRAINT ${foreignKeyName} FOREIGN KEY (${this.wrap(columnName)}) REFERENCES ${this.wrapQualified(foreignTableName)}(${this.wrap(foreignColumnName)}) ON DELETE NO ACTION ON UPDATE NO ACTION`,
+      `ALTER TABLE ${this.wrapQualified(tableName)} ADD CONSTRAINT ${this.wrap(foreignKeyName)} FOREIGN KEY (${this.wrap(columnName)}) REFERENCES ${this.wrapQualified(foreignTableName)}(${this.wrap(foreignColumnName)}) ON DELETE NO ACTION ON UPDATE NO ACTION`,
     );
   }
 

--- a/src/dialects/sqlite/SqliteDriver.ts
+++ b/src/dialects/sqlite/SqliteDriver.ts
@@ -188,6 +188,7 @@ export class SqliteDriver implements ISqlDriver {
     _columnName: string,
     _foreignTableName: string,
     _foreignColumnName: string,
+    _constraintName?: string,
   ): Promise<any> {
     throw new OrmError(
       OrmErrorCode.UNSUPPORTED_OPERATION,


### PR DESCRIPTION
Closes #411

Three robustness fixes, each minimally invasive:

1. **DependencyGraph toposort** — all five non-null assertions removed: edge maps lazily initialize and Kahn lookups tolerate absent keys, so a broken seeding assumption can no longer throw mid-flush. The cycle warning now names the entities on the cycle with a resolution hint. Also fixes a false cycle warning when the input contained duplicate classes.

2. **Connection liveness probing** — the undocumented pg `_ending` / mysql2 `destroyed` internals are read through a single `readInternalFlag()` helper (`src/dialects/connection-liveness.ts`) with an assume-alive fallback, localizing driver-upgrade risk. No more `as unknown as` casts in the connection classes.

3. **User-defined FK names** — `ISqlDriver.addForeignKey` gains an optional `constraintName`; MySQL/PG drivers use it (hash-name fallback preserved, constraint name now identifier-escaped). Resolves the `MySqlDriver` TODO and a latent mismatch: `SchemaRegistrar` checked FK existence under the `NamingStrategy.foreignKeyName()` name but created the constraint under the hash name, so a custom strategy re-attempted FK creation on every boot. All three call sites (TPT/M2O/O2O) now check and create under the same name. Default and Snake strategies keep the hash name — no schema impact.

Tests: 13 new regression tests (`robustness-hardening-411.test.ts`); one existing cycle-warning assertion updated to the new message.

Verified locally: unit 5,340 passed / SQLite integration 624 passed / dual build clean. Driver DDL changes covered by the CI MySQL/PostgreSQL integration jobs.