### PR TITLE
fix(examples): bring examples up to date with 1.1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,16 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        example: [nestjs-cats, nestjs-blog, nestjs-multitenant, nestjs-todo]
+        example:
+          [
+            nestjs-cats,
+            nestjs-blog,
+            nestjs-multitenant,
+            nestjs-todo,
+            nestjs-todo-sqlite,
+            nestjs-linear-clone,
+            prisma-import-demo,
+          ]
     steps:
       - uses: actions/checkout@v4
 

--- a/__tests__/unit/prisma-import.test.ts
+++ b/__tests__/unit/prisma-import.test.ts
@@ -660,7 +660,8 @@ describe("EntityCodeGenerator", () => {
     const post = files.get("post.entity.ts")!;
     expect(post).toContain("@ManyToOne");
     expect(post).toContain("() => User");
-    expect(post).toContain('joinColumn: "authorId"');
+    expect(post).toContain('@RelationColumn({ name: "authorId" })');
+    expect(post).not.toContain('joinColumn: "authorId"');
   });
 
   it("should generate OneToMany relation", () => {
@@ -676,7 +677,8 @@ describe("EntityCodeGenerator", () => {
     const profile = files.get("profile.entity.ts")!;
     expect(profile).toContain("@OneToOne");
     expect(profile).toContain("() => User");
-    expect(profile).toContain('joinColumn: "userId"');
+    expect(profile).toContain('@RelationColumn({ name: "userId" })');
+    expect(profile).not.toContain('joinColumn: "userId"');
   });
 
   it("should generate ManyToMany with joinTable", () => {

--- a/examples/nestjs-blog/README.md
+++ b/examples/nestjs-blog/README.md
@@ -8,10 +8,10 @@ A blog REST API built with NestJS demonstrating key Stingerloom ORM features.
 - **Relations** — ManyToOne (Post→User, Post→Category), OneToMany, ManyToMany (Post↔Tag)
 - **Soft Delete / Restore** — `@DeletedAt` decorator
 - **Upsert** — INSERT ON CONFLICT UPDATE by slug/name
-- **Pagination** — Offset-based (`findAndCount`) + Cursor-based (`findWithCursor`)
+- **Pagination** — Offset-based (`findWithPage`) + Cursor-based (`findWithCursor`)
 - **EXPLAIN** — Query execution plan inspection
-- **Schema Diff** — Entity vs DB schema comparison + Migration generation
-- **GROUP BY / HAVING** — Aggregate queries via RawQueryBuilder
+- **GROUP BY / HAVING** — Aggregate queries via the typed QueryDSL (`qAlias` + `leftJoinRelation`)
+- **M2M join-table writes** — `repository.relation(id, "tags").add()/.remove()`
 - **Transactions** — `@Transactional()` decorator
 
 ## Prerequisites

--- a/examples/nestjs-blog/src/categories/categories.service.ts
+++ b/examples/nestjs-blog/src/categories/categories.service.ts
@@ -2,21 +2,15 @@ import { Injectable, NotFoundException } from "@nestjs/common";
 import { CreateCategoryDto } from "./dto/create-category.dto";
 import { UpdateCategoryDto } from "./dto/update-category.dto";
 import { Category } from "./category.entity";
-import {
-  BaseRepository,
-  Transactional,
-  EntityManager,
-  RawQueryBuilder,
-} from "@stingerloom/orm";
+import { Post } from "../posts/post.entity";
+import { BaseRepository, Transactional, qAlias } from "@stingerloom/orm";
 import { InjectRepository } from "@stingerloom/orm/nestjs";
-import sql from "sql-template-tag";
 
 @Injectable()
 export class CategoriesService {
   constructor(
     @InjectRepository(Category)
     private readonly categoryRepository: BaseRepository<Category>,
-    private readonly entityManager: EntityManager,
   ) {}
 
   @Transactional()
@@ -62,26 +56,28 @@ export class CategoriesService {
 
   /**
    * GROUP BY / HAVING demo — aggregates post count per category.
-   * Uses RawQueryBuilder to run a GROUP BY + HAVING query.
+   *
+   * Written against the typed QueryDSL rather than raw SQL: `leftJoinRelation`
+   * derives the ON clause from the @OneToMany metadata, `qAlias` resolves
+   * property names through the NamingStrategy, and `coerce` normalizes the
+   * driver's aggregate type — so there is no hardcoded table name, no
+   * `category_id` literal, and no `postCount ?? postcount` casing fallback.
    */
-  async getStats(): Promise<
-    Array<{ name: string; postCount: number }>
-  > {
-    const query = RawQueryBuilder.create()
-      .select(["c.name", "COUNT(p.id) as postCount"])
-      .from("category", "c")
-      .leftJoin("post", "p", sql`p.category_id = c.id`)
-      .groupBy(["c.name"])
-      .having([sql`COUNT(p.id) > 0`])
-      .build();
+  async getStats(): Promise<Array<{ name: string; postCount: number }>> {
+    const c = qAlias(Category, "c");
+    const p = qAlias(Post, "p");
+    const postCount = p.id.count();
 
-    const result = await this.entityManager.query<
-      { name: string; postCount: number }
-    >(query.sql, query.values);
-
-    return result.map((row: any) => ({
-      name: row.name,
-      postCount: Number(row.postCount ?? row.postcount ?? 0),
-    }));
+    return await this.categoryRepository
+      .createQueryBuilder("c")
+      .leftJoinRelation("posts", "p")
+      .select([c.name.as("name"), postCount.as("postCount")])
+      // Group by the PK too so two categories sharing a name stay separate
+      // groups and PostgreSQL's strict GROUP BY accepts the projected name.
+      .groupBy([c.id, c.name])
+      .having(postCount.gt(0))
+      .getRawMany<{ name: string; postCount: number }>({
+        coerce: { postCount: "number" },
+      });
   }
 }

--- a/examples/nestjs-blog/src/posts/posts.service.ts
+++ b/examples/nestjs-blog/src/posts/posts.service.ts
@@ -134,30 +134,30 @@ export class PostsService {
   }
 
   /**
-   * addTagToPost — inserts a (postId, tagId) row into the join table (post_tags).
+   * addTagToPost — inserts a (postId, tagId) row into the join table.
+   *
+   * `relation(...).add()` resolves the join table and its columns from the
+   * @ManyToMany metadata and picks the right idempotent spelling per dialect
+   * (`INSERT IGNORE` on MySQL, `ON CONFLICT DO NOTHING` on PostgreSQL), so
+   * this stays portable instead of hardcoding MySQL SQL and table names.
    */
   async addTagToPost(
     postId: number,
     tagId: number,
   ): Promise<{ message: string }> {
-    await this.em.query(
-      "INSERT IGNORE INTO `post_tags` (`post_id`, `tag_id`) VALUES (?, ?)",
-      [postId, tagId],
-    );
+    await this.postRepository.relation(postId, "tags").add(tagId);
     return { message: `Tag ${tagId} added to Post ${postId}` };
   }
 
   /**
    * removeTagFromPost — deletes a (postId, tagId) row from the join table.
+   * No-op when the pair is already absent.
    */
   async removeTagFromPost(
     postId: number,
     tagId: number,
   ): Promise<{ message: string }> {
-    await this.em.query(
-      "DELETE FROM `post_tags` WHERE `post_id` = ? AND `tag_id` = ?",
-      [postId, tagId],
-    );
+    await this.postRepository.relation(postId, "tags").remove(tagId);
     return { message: `Tag ${tagId} removed from Post ${postId}` };
   }
 

--- a/examples/nestjs-cats/package.json
+++ b/examples/nestjs-cats/package.json
@@ -18,7 +18,7 @@
     "@nestjs/config": "^3.3.0",
     "@nestjs/core": "^10.4.22",
     "@nestjs/platform-express": "^10.4.22",
-    "@nestjs/swagger": "^11.4.5",
+    "@nestjs/swagger": "^7.4.2",
     "@stingerloom/orm": "workspace:*",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.15.1",

--- a/examples/nestjs-linear-clone/src/modules/queue/queue.service.ts
+++ b/examples/nestjs-linear-clone/src/modules/queue/queue.service.ts
@@ -84,9 +84,14 @@ export class QueueService {
 
   @Transactional()
   async release(workerId: string, issueId: number): Promise<boolean> {
+    // `withDeleted` because releasing a lease is claim bookkeeping, not a
+    // write to the issue itself: a worker holding a claim on an issue that
+    // was trashed mid-flight must still be able to hand it back. Without
+    // this, `updateMany` skips soft-deleted rows and the claim would linger
+    // until the lease expires.
     const result = await this.repo.updateMany(
       { claimedBy: null, claimedAt: null },
-      { where: { id: issueId, claimedBy: workerId } },
+      { where: { id: issueId, claimedBy: workerId }, withDeleted: true },
     );
     if (result.affected > 0) {
       await this.activity.log({

--- a/examples/nestjs-todo/package.json
+++ b/examples/nestjs-todo/package.json
@@ -16,7 +16,7 @@
     "@nestjs/config": "^3.3.0",
     "@nestjs/core": "^10.4.22",
     "@nestjs/platform-express": "^10.4.22",
-    "@nestjs/swagger": "^11.4.5",
+    "@nestjs/swagger": "^7.4.2",
     "@stingerloom/orm": "workspace:*",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.15.1",

--- a/examples/prisma-import-demo/package.json
+++ b/examples/prisma-import-demo/package.json
@@ -20,7 +20,7 @@
     "@nestjs/config": "^3.3.0",
     "@nestjs/core": "^10.4.22",
     "@nestjs/platform-express": "^10.4.22",
-    "@nestjs/swagger": "^11.4.5",
+    "@nestjs/swagger": "^7.4.2",
     "@stingerloom/orm": "workspace:*",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.15.1",

--- a/examples/prisma-import-demo/src/generated/customer.entity.ts
+++ b/examples/prisma-import-demo/src/generated/customer.entity.ts
@@ -2,6 +2,7 @@ import { Column, CreateTimestamp, Entity, OneToMany, PrimaryGeneratedColumn, Uni
 import { Order } from "./order.entity";
 
 @Entity()
+@UniqueIndex(["email"])
 export class Customer {
   @PrimaryGeneratedColumn()
   id!: number;
@@ -20,5 +21,4 @@ export class Customer {
 
   @OneToMany(() => Order, { mappedBy: "customer" })
   orders!: Order[];
-
 }

--- a/examples/prisma-import-demo/src/generated/order.entity.ts
+++ b/examples/prisma-import-demo/src/generated/order.entity.ts
@@ -1,4 +1,4 @@
-import { Column, CreateTimestamp, Entity, ManyToOne, RelationColumn, OneToMany, PrimaryGeneratedColumn, UpdateTimestamp } from "@stingerloom/orm";
+import { Column, CreateTimestamp, Entity, ManyToOne, OneToMany, PrimaryGeneratedColumn, RelationColumn, UpdateTimestamp } from "@stingerloom/orm";
 import { Customer } from "./customer.entity";
 import { OrderItem } from "./order_item.entity";
 import { OrderStatus } from "./order_status.enum";
@@ -26,5 +26,4 @@ export class Order {
 
   @OneToMany(() => OrderItem, { mappedBy: "order" })
   items!: OrderItem[];
-
 }

--- a/examples/prisma-import-demo/src/generated/order_item.entity.ts
+++ b/examples/prisma-import-demo/src/generated/order_item.entity.ts
@@ -1,11 +1,4 @@
-import {
-  Column,
-  Entity,
-  ManyToOne,
-  RelationColumn,
-  PrimaryGeneratedColumn,
-  UniqueIndex,
-} from "@stingerloom/orm";
+import { Column, Entity, ManyToOne, PrimaryGeneratedColumn, RelationColumn, UniqueIndex } from "@stingerloom/orm";
 import { Order } from "./order.entity";
 import { Product } from "./product.entity";
 

--- a/examples/prisma-import-demo/src/generated/product.entity.ts
+++ b/examples/prisma-import-demo/src/generated/product.entity.ts
@@ -1,10 +1,4 @@
-import {
-  Column,
-  CreateTimestamp,
-  Entity,
-  OneToMany,
-  PrimaryGeneratedColumn,
-} from "@stingerloom/orm";
+import { Column, CreateTimestamp, Entity, OneToMany, PrimaryGeneratedColumn } from "@stingerloom/orm";
 import { OrderItem } from "./order_item.entity";
 import { Category } from "./category.enum";
 
@@ -20,16 +14,12 @@ export class Product {
   price!: number;
 
   @Column({ type: "text", nullable: true })
-  description!: string;
+  description!: string | null;
 
   @Column({ default: 0 })
   stock!: number;
 
-  @Column({
-    type: "enum",
-    enumName: "Category",
-    enumValues: ["ELECTRONICS", "CLOTHING", "FOOD", "BOOKS", "TOYS"],
-  })
+  @Column({ type: "enum", enumName: "Category", enumValues: ["ELECTRONICS", "CLOTHING", "FOOD", "BOOKS", "TOYS"] })
   category!: string;
 
   @CreateTimestamp()

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -183,8 +183,8 @@ importers:
         specifier: ^10.4.22
         version: 10.4.22(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)
       '@nestjs/swagger':
-        specifier: ^11.4.5
-        version: 11.4.5(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)
+        specifier: ^7.4.2
+        version: 7.4.2(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)
       '@stingerloom/orm':
         specifier: workspace:*
         version: link:../..
@@ -450,8 +450,8 @@ importers:
         specifier: ^10.4.22
         version: 10.4.22(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)
       '@nestjs/swagger':
-        specifier: ^11.4.5
-        version: 11.4.5(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)
+        specifier: ^7.4.2
+        version: 7.4.2(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)
       '@stingerloom/orm':
         specifier: workspace:*
         version: link:../..
@@ -638,8 +638,8 @@ importers:
         specifier: ^10.4.22
         version: 10.4.22(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)
       '@nestjs/swagger':
-        specifier: ^11.4.5
-        version: 11.4.5(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)
+        specifier: ^7.4.2
+        version: 7.4.2(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)
       '@stingerloom/orm':
         specifier: workspace:*
         version: link:../..
@@ -7059,14 +7059,6 @@ snapshots:
       class-transformer: 0.5.1
       class-validator: 0.15.1
 
-  '@nestjs/mapped-types@2.1.1(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)':
-    dependencies:
-      '@nestjs/common': 10.4.22(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
-      reflect-metadata: 0.2.2
-    optionalDependencies:
-      class-transformer: 0.5.1
-      class-validator: 0.15.1
-
   '@nestjs/mapped-types@2.1.1(@nestjs/common@11.1.28(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)':
     dependencies:
       '@nestjs/common': 11.1.28(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -7133,21 +7125,6 @@ snapshots:
       prettier: 3.9.5
     transitivePeerDependencies:
       - chokidar
-
-  '@nestjs/swagger@11.4.5(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)':
-    dependencies:
-      '@microsoft/tsdoc': 0.16.0
-      '@nestjs/common': 10.4.22(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
-      '@nestjs/core': 10.4.22(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@10.4.22)(reflect-metadata@0.2.2)(rxjs@7.8.2)
-      '@nestjs/mapped-types': 2.1.1(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)
-      js-yaml: 4.3.0
-      lodash: 4.18.1
-      path-to-regexp: 8.4.2
-      reflect-metadata: 0.2.2
-      swagger-ui-dist: 5.32.8
-    optionalDependencies:
-      class-transformer: 0.5.1
-      class-validator: 0.15.1
 
   '@nestjs/swagger@11.4.5(@nestjs/common@11.1.28(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.28)(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)':
     dependencies:

--- a/src/integration/prisma-import/EntityCodeGenerator.ts
+++ b/src/integration/prisma-import/EntityCodeGenerator.ts
@@ -174,7 +174,11 @@ export class EntityCodeGenerator {
       sections.push(dec);
     }
     sections.push(`export class ${model.name} {`);
-    sections.push(bodyLines.join("\n"));
+    // Each field generator appends a blank separator line; drop the trailing
+    // one so the class body does not end with a stray empty line.
+    const body = [...bodyLines];
+    while (body.length > 0 && body[body.length - 1] === "") body.pop();
+    sections.push(body.join("\n"));
     sections.push("}");
     sections.push("");
 
@@ -306,7 +310,6 @@ export class EntityCodeGenerator {
           camelToSnakeCase(rel.targetModel) + ".entity",
         );
         const opts: string[] = [];
-        if (rel.joinColumn) opts.push(`joinColumn: "${rel.joinColumn}"`);
         if (rel.references) opts.push(`references: "${rel.references}"`);
         if (rel.cascade)
           opts.push(
@@ -318,6 +321,10 @@ export class EntityCodeGenerator {
         lines.push(
           `  @ManyToOne(() => ${rel.targetModel}, (e) => e.${this.findInverseProperty(rel.targetModel, rel.propertyName)}${optsStr})`,
         );
+        if (rel.joinColumn) {
+          imports.addOrm("RelationColumn");
+          lines.push(`  @RelationColumn({ name: "${rel.joinColumn}" })`);
+        }
         lines.push(`  ${rel.propertyName}!: ${rel.targetModel};`);
         lines.push("");
         break;
@@ -344,7 +351,6 @@ export class EntityCodeGenerator {
           camelToSnakeCase(rel.targetModel) + ".entity",
         );
         const opts: string[] = [];
-        if (rel.joinColumn) opts.push(`joinColumn: "${rel.joinColumn}"`);
         if (rel.cascade)
           opts.push(
             `cascade: [${rel.cascade.map((c) => `"${c}"`).join(", ")}]`,
@@ -355,6 +361,10 @@ export class EntityCodeGenerator {
         lines.push(
           `  @OneToOne(() => ${rel.targetModel}${optsStr ? ", " + optsStr : ""})`,
         );
+        if (rel.joinColumn) {
+          imports.addOrm("RelationColumn");
+          lines.push(`  @RelationColumn({ name: "${rel.joinColumn}" })`);
+        }
         lines.push(`  ${rel.propertyName}!: ${rel.targetModel};`);
         lines.push("");
         break;


### PR DESCRIPTION
Review of the seven example projects against the 1.1.0 API surface. All of them type-checked before this branch, so nothing here was a build failure.

## Changes

**`fix(prisma-import)`** — `EntityCodeGenerator` emitted `@ManyToOne(..., { joinColumn })` / `@OneToOne(..., { joinColumn })`, which `ManyToOne.ts:132` warns about at runtime. Generated code therefore triggered the ORM's own deprecation warning on boot. Now emits `@RelationColumn({ name })`. Also drops a stray trailing blank line in generated class bodies, and resyncs `prisma-import-demo/src/generated` — the committed output had drifted from the generator, so `pnpm generate` produced a diff.

**`fix(examples)`** — three call sites:

- `queue.service.ts:87` — `release()` calls `updateMany` on `Issue`, which carries `@DeletedAt`. Under the 1.1.0 default filter, a claim held on an issue trashed mid-flight could not be handed back until the lease expired. Now passes `withDeleted: true`.
- `posts.service.ts` — M2M join-table writes used `INSERT IGNORE` / `DELETE` with backticks and hardcoded `post_tags` / `post_id` / `tag_id`. That is MySQL-only, while the example's README documents PostgreSQL support. Replaced with `relation(postId, "tags").add()/.remove()`.
- `categories.service.ts` — the GROUP BY / HAVING demo used `RawQueryBuilder` with hardcoded table names and a `postCount ?? postcount` casing fallback. Rewritten on `qAlias` + `leftJoinRelation` + `getRawMany({ coerce })`.

**`chore(examples)`** — the CI type-check matrix covered 4 of 7 examples; `nestjs-linear-clone`, `nestjs-todo-sqlite` and `prisma-import-demo` could drift unnoticed. Added. Separately, `@nestjs/swagger@11.4.5` requires Nest 11 peers but `nestjs-cats`, `nestjs-todo` and `prisma-import-demo` pin Nest 10 — aligned those three to swagger 7.

## Verification

- Unit suite: 5,340 passed, 20 skipped, 0 failures
- All 7 examples type-check against a fresh `dist`
- `pnpm generate` is idempotent against the committed output

Not verified at runtime: the blog `relation()` and QueryDSL rewrites are type-checked only — both e2e suites need MySQL/PostgreSQL.

## Deliberately left alone

`posts.service.ts` `getSchemaDiff()` never calls `SchemaDiff.diff()` and `generateMigration()` passes an empty diff literal, while the Swagger descriptions claim they compare entity metadata against the DB. The false README bullet is removed here, but the endpoints are untouched — implementing them properly needs a `QueryRunner` and live-DB verification, which this branch does not do.

## Follow-ups not in this PR

- No example uses `defineEntity`; all 33 entities are decorator-based while the docs lead with code-first. `nestjs-todo-sqlite` is the natural candidate to port.
- NestJS 10 to 11 across six examples. Swagger was aligned down here, not forward.