### PR TITLE
chore(core): deprecated / dead-code cleanup sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ Releases: https://github.com/biud436/stingerloom-orm/releases
 
   `__tests__/unit/public-api-surface.test.ts` now pins every entry point's exported surface against a checked-in fixture and fails on any wildcard re-export, so a new internal symbol can no longer widen the published API by accident.
 
+- **Deprecation audit (#408).** All 13 `@deprecated` symbols were checked for real usage before being touched. Two changes came out of it, neither breaking:
+  - `SchemaGenerator.generateForeignKeyName()` carried its own copy of the SHA1 FK-naming algorithm, identical to `DefaultNamingStrategy.foreignKeyName()`. The static now forwards to the strategy, so one implementation backs both entry points and the two can no longer drift.
+  - `joinColumn` on `@ManyToOne` / `@OneToOne` is no longer marked `@deprecated`. It is tier 2 of FK resolution (`@RelationColumn` > `joinColumn` > `{propertyName}Id` `@Column`) and the form the relation docs use throughout, so the tag contradicted both the implementation and the documentation. `@RelationColumn` remains the recommendation for new code because it also carries the FK's type and nullability.
+
+  The other eleven are load-bearing and stay as they are: `EntityResult` is the internal `findInternal` return type, `deserializeEntity` is the ORM's own hydration entry point, `connectionLimit` and both `transform` options are read on live paths, `MetadataScanner.mapper` is iterated by six in-tree scanners, and `setContext` / `switchContext` back the layer test harness. Each now records whether it is scheduled for removal in 2.0 or has no removal date, instead of an unqualified "will be removed".
+
 ---
 
 ## [1.1.0] — 2026-07-17

--- a/src/core/DatabaseClientOptions.ts
+++ b/src/core/DatabaseClientOptions.ts
@@ -119,7 +119,8 @@ interface BaseDatabaseClientOptions {
 
   /**
    * Maximum number of connections in the pool.
-   * @deprecated Use `pool.max` instead. This is kept for backward compatibility.
+   * @deprecated Removal target: 2.0. Use `pool.max` instead — it wins when
+   * both are set, and this option is only read as its fallback.
    */
   connectionLimit?: number;
 

--- a/src/core/deserializer/DeserializeEntity.ts
+++ b/src/core/deserializer/DeserializeEntity.ts
@@ -20,7 +20,10 @@ const registry = DeserializerRegistry.getInstance();
  *
  * Internally delegates to the DeserializerRegistry singleton's strategy.
  *
- * @deprecated Use DeserializerRegistry.getInstance().deserialize() instead.
+ * @deprecated Removal target: 2.0. Use
+ * `DeserializerRegistry.getInstance().deserialize()` instead. The function
+ * remains the ORM's own hydration entry point, so only the public export is
+ * scheduled to go.
  */
 export function deserializeEntity<T, V extends object>(
   cls: MyClassConstructor<T>,

--- a/src/core/generators/SchemaGenerator.ts
+++ b/src/core/generators/SchemaGenerator.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import crypto from "crypto";
 import { ClazzType } from "../../utils";
 import { COLUMN_TOKEN, ColumnOption, ColumnType } from "../../decorators/Column";
 import { ENTITY_TOKEN, EntityMetadata } from "../../decorators/Entity";
@@ -54,6 +53,13 @@ import {
 } from "../../dialects/ColumnDefinitionBuilder";
 import type { CommonCapabilities } from "../../dialects/DialectCapabilities";
 import type { DbVersion } from "../../dialects/DbVersion";
+
+/**
+ * Shared stateless strategy backing the deprecated static
+ * {@link SchemaGenerator.generateForeignKeyName} forwarder, so the SHA1 FK
+ * naming algorithm lives in exactly one place.
+ */
+const DEFAULT_NAMING_STRATEGY = new DefaultNamingStrategy();
 
 export type SchemaDialect = "mysql" | "postgres" | "sqlite";
 
@@ -900,8 +906,10 @@ export class SchemaGenerator {
    * Uses the first 8 characters of a SHA1 hash to guarantee uniqueness
    * while fitting within MySQL's 64-char and PostgreSQL's 63-char identifier limits.
    *
-   * @deprecated Use `NamingStrategy.foreignKeyName()` instead.
-   * This static method is kept for backward compatibility with existing driver code.
+   * @deprecated Use `NamingStrategy.foreignKeyName()` instead. Removal target: 2.0.
+   * This static method is kept for backward compatibility with existing driver
+   * code and now forwards to {@link DefaultNamingStrategy.foreignKeyName} so a
+   * single hash implementation backs both entry points.
    *
    * @param tableName - Source table name
    * @param column - FK column name
@@ -909,11 +917,7 @@ export class SchemaGenerator {
    * @returns A unique FK name no longer than 63 characters
    */
   static generateForeignKeyName(tableName: string, column: string, refTable: string): string {
-    const raw = `${tableName}_${column}_${refTable}`;
-    const hash = crypto.createHash("sha1").update(raw).digest("hex").slice(0, 8);
-    const base = `fk_${tableName}_${hash}`;
-    // MySQL allows up to 64 chars; PostgreSQL up to 63 → standardize on 63
-    return base.length > 63 ? `fk_${hash}` : base;
+    return DEFAULT_NAMING_STRATEGY.foreignKeyName(tableName, column, refTable);
   }
 }
 

--- a/src/core/plugin/buffer/BufferPreview.ts
+++ b/src/core/plugin/buffer/BufferPreview.ts
@@ -79,8 +79,9 @@ export enum ChangeTrackingPolicy {
 export enum FlushMode {
   AUTO = "AUTO",
   /**
-   * @deprecated Alias of {@link FlushMode.MANUAL} — behaves identically.
-   * Use MANUAL; COMMIT never implemented flush-at-transaction-commit.
+   * @deprecated Removal target: 2.0. Alias of {@link FlushMode.MANUAL} —
+   * behaves identically. Use MANUAL; COMMIT never implemented
+   * flush-at-transaction-commit.
    */
   COMMIT = "COMMIT",
   MANUAL = "MANUAL",

--- a/src/decorators/Column.ts
+++ b/src/decorators/Column.ts
@@ -103,7 +103,8 @@ export interface ColumnOption {
 
   /**
    * Function that converts the column value when reading from the database into the entity.
-   * @deprecated Use `transformer` instead for bidirectional transforms.
+   * @deprecated Removal target: 2.0. Use `transformer` instead for
+   * bidirectional transforms.
    */
   transform?: <T = any>(raw: unknown) => T;
 

--- a/src/decorators/ManyToOne.ts
+++ b/src/decorators/ManyToOne.ts
@@ -22,7 +22,11 @@ export type ManyToOneOption = {
   transform?: <T = any>(raw: unknown) => T;
   /**
    * FK column name.
-   * @deprecated Use the `@RelationColumn({ name: "..." })` decorator instead.
+   *
+   * Second tier of FK resolution: `@RelationColumn({ name })` wins when
+   * present, then this option, then a `{propertyName}Id` `@Column`.
+   * Prefer `@RelationColumn` on new code — it also carries the FK's type and
+   * nullability — but this option stays fully supported.
    */
   joinColumn?: string;
   /**

--- a/src/decorators/OneToOne.ts
+++ b/src/decorators/OneToOne.ts
@@ -12,7 +12,11 @@ const logger = new Logger("OneToOne");
 export type OneToOneOption<T = any> = {
   /**
    * FK column name. Set on the owning side.
-   * @deprecated Use the `@RelationColumn({ name: "..." })` decorator instead.
+   *
+   * Second tier of FK resolution: `@RelationColumn({ name })` wins when
+   * present, then this option, then a `{propertyName}Id` `@Column`.
+   * Prefer `@RelationColumn` on new code — it also carries the FK's type and
+   * nullability — but this option stays fully supported.
    */
   joinColumn?: string;
 

--- a/src/dialects/SqlDriver.ts
+++ b/src/dialects/SqlDriver.ts
@@ -113,8 +113,11 @@ export interface ISqlDriver<T = any> {
   /**
    * Generates a name for a foreign key constraint based on the source and target tables and columns.
    *
-   * @deprecated Use `NamingStrategy.foreignKeyName()` instead.
-   * This method is kept for backward compatibility with existing driver code.
+   * @deprecated Removal target: 2.0, once every `addForeignKey` caller passes
+   * an explicit `constraintName` from `NamingStrategy.foreignKeyName()`. Until
+   * then this stays part of the interface contract — all three built-in
+   * drivers implement it and call it as their fallback, so custom drivers must
+   * keep providing it.
    *
    * @param sourceTable - The name of the source table.
    * @param targetTable - The name of the target table.

--- a/src/scanner/MetadataScanner.ts
+++ b/src/scanner/MetadataScanner.ts
@@ -74,9 +74,9 @@ export class MetadataLayerRegistry {
    * concurrent requests — a misplaced call permanently routes every async
    * caller to the wrong tenant layer until the next mutation.
    *
-   * Kept exposed because the test suite drives layer behaviour directly
-   * through the registry; production callers should instead let
-   * `MetadataContext.run` win via the AsyncLocalStorage path inside
+   * No removal scheduled: kept exposed because the test suite drives layer
+   * behaviour directly through the registry. Production callers should instead
+   * let `MetadataContext.run` win via the AsyncLocalStorage path inside
    * {@link getContext}.
    */
   setContext(context: string): void {
@@ -280,8 +280,10 @@ export class MetadataLayerRegistry {
  */
 export class MetadataScanner {
   /**
-   * @deprecated Kept for subclasses that iterate `mapper` directly.
-   * Scheduled for removal after the layer-system migration is complete.
+   * @deprecated Kept for subclasses that iterate `mapper` directly. No removal
+   * scheduled: six in-tree scanners (Entity, Column, ManyToOne, OneToMany,
+   * ManyToMany, OneToOne) still iterate it, so it can only go once they move
+   * to the layer-aware lookups.
    * Returns only the entries under this scanner's prefix in the current context layer.
    */
   protected get mapper(): Map<string, any> {
@@ -507,6 +509,7 @@ export class MetadataScanner {
    * {@link MetadataContext.run | `MetadataContext.run(tenantId, callback)`}
    * so the switch is scoped to the current async caller. Calls fire a
    * one-shot warning unless `STINGERLOOM_SUPPRESS_LEGACY_CONTEXT_WARN=1`.
+   * No removal scheduled, for the same reason as the registry method.
    */
   public switchContext(context: string): void {
     warnLegacyContextMutator("MetadataScanner.switchContext");

--- a/src/schema/EntitySchemaTypes.ts
+++ b/src/schema/EntitySchemaTypes.ts
@@ -42,8 +42,8 @@ export interface ColumnSchemaDef {
 
   /**
    * One-way read transform (DB → entity).
-   * @deprecated Use `transformer` for bidirectional transforms — mirrors
-   * the deprecation on `@Column({ transform })`.
+   * @deprecated Removal target: 2.0. Use `transformer` for bidirectional
+   * transforms — mirrors the deprecation on `@Column({ transform })`.
    */
   transform?: (raw: unknown) => any;
 

--- a/src/types/EntityResult.ts
+++ b/src/types/EntityResult.ts
@@ -1,8 +1,10 @@
 import { ClazzType } from "../utils";
 
 /**
- * @deprecated Use `T[]` directly. This type will be removed in a future version.
- * Kept for backward compatibility.
+ * @deprecated Removal target: 2.0. Public callers should use `T[]` for `find()`
+ * and `T` for `save()`; this union is still the internal return type of the
+ * `findInternal` read path, so the type itself survives as an internal detail
+ * and only the public export goes away.
  */
 export type EntityResult<T> =
   | InstanceType<ClazzType<T>>


### PR DESCRIPTION
Closes #408.

Audited all 13 `@deprecated` symbols for real usage before touching any of them. Twelve turned out to be live code; the sweep produced two substantive changes and a documentation pass, none of them breaking.

## Consolidated

`SchemaGenerator.generateForeignKeyName()` held its own copy of the SHA1 FK-naming algorithm, character-for-character identical to `DefaultNamingStrategy.foreignKeyName()`. The deprecated static now forwards to the strategy, so a single implementation backs both entry points and the two cannot drift. `naming-strategy.test.ts:72` already pinned their equivalence, so the refactor is covered.

## Un-deprecated

`joinColumn` on `@ManyToOne` / `@OneToOne` was tagged `@deprecated Use @RelationColumn`, but it is tier 2 of FK resolution in `RelationMetadataResolver` (`@RelationColumn` > `joinColumn` > `{propertyName}Id` `@Column`) and the form `docs/relations.md` teaches in more than twenty examples. Following the docs put a strikethrough in the user's editor. The tag is replaced by a note that `@RelationColumn` wins first and is preferred on new code because it also carries the FK's type and nullability.

## Kept

The remaining eleven are load-bearing and unchanged in behavior:

| Symbol | Why it stays |
|---|---|
| `EntityResult<T>` | internal return type of the `findInternal` read path (9 sites) |
| `deserializeEntity` | the ORM's own hydration entry point (`ResultTransformer`, 11 sites) |
| `ISqlDriver.generateForeignKeyName` | interface contract; all three drivers implement and self-call it |
| `connectionLimit` | `pool.max` fallback in `MySqlConnector` / `PostgresConnector` |
| `ColumnOption.transform`, `EntitySchemaColumn.transform` | read on the live transform path |
| `MetadataScanner.mapper` | iterated by six in-tree scanners |
| `setContext` / `switchContext` | back the layer test harness |

Each now records whether it is scheduled for removal in 2.0 or has no removal date, replacing unqualified "will be removed in a future version" notes. Per the decision on the issue, no public export was dropped in 1.x.

## Verification

- Unit: 5,373 passed, 1 skipped, 0 failures (280 suites)
- SQLite integration: 624 passed (71 suites)
- `pnpm build` dual CJS/ESM clean
- Public API surface fixture unchanged, as no export was added or removed

Real PG and MySQL/MariaDB runs were not executed: the only behavioral change is a delegation with byte-identical output, already covered by the naming-strategy equivalence test and SQLite FK DDL integration. Happy to run them before merge if you want the full gate.