### PR TITLE
fix(core): make the ESM build loadable and fix standalone Express footguns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,17 @@ Releases: https://github.com/biud436/stingerloom-orm/releases
 
   The other eleven are load-bearing and stay as they are: `EntityResult` is the internal `findInternal` return type, `deserializeEntity` is the ORM's own hydration entry point, `connectionLimit` and both `transform` options are read on live paths, `MetadataScanner.mapper` is iterated by six in-tree scanners, and `setContext` / `switchContext` back the layer test harness. Each now records whether it is scheduled for removal in 2.0 or has no removal date, instead of an unqualified "will be removed".
 
+### Fixed
+
+- **The ESM build is now loadable by plain Node.js.** `import "@stingerloom/orm"` from a `"type": "module"` app failed at four layers, none of which bundler or NestJS (CJS) consumers ever hit: `dist/esm` was not marked `"type": "module"`; the compiled output kept extensionless relative specifiers, which Node's ESM loader rejects; runtime `require()` calls (driver/fast-glob/class-transformer lazy loading, `RawQueryBuilderFactory` cycle-breaker) threw `ReferenceError` — the driver ones surfacing as a bogus "package is required" error; and the CJS-only `sql-template-tag` default import resolved to `module.exports` instead of the tag function. A post-build step (`scripts/fix-esm.js`) now rewrites specifiers and stamps the marker, the lazy loads went through `import()`, and all `sql-template-tag` imports route through an interop wrapper (`utils/sqlTag.ts`, guarded by a unit test). Entity glob files are loaded with `import()` as well, so `.mjs`/ESM entity files now work.
+- **Registering a connection name that is already active now closes the replaced connector and logs a warning.** Previously a second `EntityManager.register()` without a distinct `connectionName` silently swapped the `"default"` connection: the first manager kept running against the second database with no signal at all, and the old connector leaked.
+- **`@Column` no longer warns about missing `design:type` metadata when an explicit `type` is given**, and such columns now default to `NOT NULL` under metadata-less builds (tsx/esbuild/swc/Vite), matching what the same source produces under `tsc`. The remaining fallback warnings now name the property (`User.name`) and diagnose the cause — missing `emitDecoratorMetadata` vs. union types erasing to `Object`.
+- **Connection-path error messages are now English** (missing-driver, connection-failed, constraint-lookup errors were Korean).
+
+### Added
+
+- **Express guide (`docs/express.md`)** — bootstrap order, repository/transaction patterns without DI, error-middleware mapping, graceful shutdown, tenant middleware, and the build-tool constraints on decorator metadata, verified against a real Express 5 app in both CJS and ESM.
+
 ### Performance
 
 - **Per-query and per-row metadata caching on the read/update hot path (#409).** Two independent caches, each measured with 5-run A/B alternating medians on the SQLite CPU bench:

--- a/__tests__/unit/column-no-design-type.test.ts
+++ b/__tests__/unit/column-no-design-type.test.ts
@@ -1,0 +1,133 @@
+import "reflect-metadata";
+import { Column, COLUMN_TOKEN, ResolvedColumnOption } from "../../src/decorators/Column";
+import { PrimaryGeneratedColumn } from "../../src/decorators/PrimaryGeneratedColumn";
+import { Logger } from "../../src/utils/Logger";
+
+/**
+ * Columns compiled without emitDecoratorMetadata (esbuild, tsx, swc, Vite —
+ * the common Express dev toolchains) have no design:type metadata at all.
+ * Applying the decorator functions manually reproduces that environment:
+ * no design:type is ever defined on the prototype.
+ */
+function columnOptions(
+  target: object,
+  propertyKey: string,
+): ResolvedColumnOption {
+  const columns = Reflect.getMetadata(COLUMN_TOKEN, target) ?? [];
+  const meta = columns.find(
+    (c: { propertyKey: string }) => c.propertyKey === propertyKey,
+  );
+  expect(meta).toBeDefined();
+  return meta.options;
+}
+
+describe("Column without design:type metadata (emitDecoratorMetadata off)", () => {
+  let logLines: string[];
+  const warnings = () => logLines.filter((l) => l.includes("WARN"));
+
+  beforeEach(() => {
+    logLines = [];
+    Logger.setOutput((msg) => logLines.push(msg));
+  });
+
+  afterEach(() => {
+    Logger.reset();
+  });
+
+  it("does not warn when an explicit type is provided", () => {
+    class NoMetaExplicit {}
+    Column({ type: "int" })(NoMetaExplicit.prototype, "balance");
+
+    expect(warnings()).toHaveLength(0);
+  });
+
+  it("keeps explicit-type columns NOT NULL by default, matching tsc builds", () => {
+    class NoMetaNullability {}
+    Column({ type: "int" })(NoMetaNullability.prototype, "balance");
+
+    const options = columnOptions(NoMetaNullability.prototype, "balance");
+    expect(options.type).toBe("int");
+    expect(options.nullable).toBe(false);
+  });
+
+  it("still honors an explicit nullable option", () => {
+    class NoMetaNullable {}
+    Column({ type: "varchar", nullable: true })(
+      NoMetaNullable.prototype,
+      "note",
+    );
+
+    const options = columnOptions(NoMetaNullable.prototype, "note");
+    expect(options.nullable).toBe(true);
+    expect(warnings()).toHaveLength(0);
+  });
+
+  it("does not warn for @PrimaryGeneratedColumn and keeps it int", () => {
+    class NoMetaPk {}
+    PrimaryGeneratedColumn()(NoMetaPk.prototype, "id");
+
+    const options = columnOptions(NoMetaPk.prototype, "id");
+    expect(options.type).toBe("int");
+    expect(options.primary).toBe(true);
+    expect(warnings()).toHaveLength(0);
+  });
+
+  it("warns with a build-tool diagnosis when no type can be inferred", () => {
+    class NoMetaInferred {}
+    Column()(NoMetaInferred.prototype, "name");
+
+    expect(warnings()).toHaveLength(1);
+    const message = warnings()[0];
+    expect(message).toContain("NoMetaInferred.name");
+    expect(message).toContain("emitDecoratorMetadata");
+    expect(message).toContain("defineEntity");
+
+    const options = columnOptions(NoMetaInferred.prototype, "name");
+    expect(options.type).toBe("text");
+    expect(options.nullable).toBe(true);
+  });
+
+  it("keeps the union-type message for design:type Object", () => {
+    class ObjectTyped {}
+    Reflect.defineMetadata(
+      "design:type",
+      Object,
+      ObjectTyped.prototype,
+      "profile",
+    );
+    Column()(ObjectTyped.prototype, "profile");
+
+    expect(warnings()).toHaveLength(1);
+    const message = warnings()[0];
+    expect(message).toContain('Unknown design:type "Object"');
+    expect(message).toContain("ObjectTyped.profile");
+  });
+
+  it("preserves nullable:true for explicit types on Object-typed properties (tsc historical behavior)", () => {
+    class JsonEntity {}
+    Reflect.defineMetadata(
+      "design:type",
+      Object,
+      JsonEntity.prototype,
+      "data",
+    );
+    Column({ type: "json" })(JsonEntity.prototype, "data");
+
+    const options = columnOptions(JsonEntity.prototype, "data");
+    expect(options.type).toBe("json");
+    expect(options.nullable).toBe(true);
+    expect(warnings()).toHaveLength(0);
+  });
+
+  it("keeps historical behavior when design:type is present", () => {
+    class WithMeta {}
+    Reflect.defineMetadata("design:type", Number, WithMeta.prototype, "count");
+    Column({ type: "int" })(WithMeta.prototype, "count");
+
+    const options = columnOptions(WithMeta.prototype, "count");
+    expect(options.type).toBe("int");
+    expect(options.length).toBe(11);
+    expect(options.nullable).toBe(false);
+    expect(warnings()).toHaveLength(0);
+  });
+});

--- a/__tests__/unit/database-client-reconnect-warning.test.ts
+++ b/__tests__/unit/database-client-reconnect-warning.test.ts
@@ -1,0 +1,61 @@
+import "reflect-metadata";
+import { DatabaseClient } from "../../src/DatabaseClient";
+import { Logger } from "../../src/utils/Logger";
+import { DatabaseClientOptions } from "../../src/core/DatabaseClientOptions";
+
+const sqliteOptions = (): DatabaseClientOptions =>
+  ({
+    type: "sqlite",
+    database: ":memory:",
+    entities: [],
+  }) as unknown as DatabaseClientOptions;
+
+/**
+ * A second EntityManager registered without a distinct connectionName
+ * replaces the connection the first one routes through. That must not be
+ * silent, and the replaced connector must be closed instead of leaking.
+ */
+describe("DatabaseClient reconnecting an already-registered name", () => {
+  const NAME = "reconnect-warning-test";
+  let logLines: string[];
+  const warnings = () => logLines.filter((l) => l.includes("WARN"));
+
+  beforeEach(() => {
+    logLines = [];
+    Logger.setOutput((msg) => logLines.push(msg));
+  });
+
+  afterEach(async () => {
+    Logger.reset();
+    await DatabaseClient.getInstance().close(NAME);
+  });
+
+  it("warns and closes the previous connector when the name is reused", async () => {
+    const client = DatabaseClient.getInstance();
+
+    const first = await client.connect(sqliteOptions(), NAME);
+    const closeSpy = jest.spyOn(first, "close");
+    expect(warnings()).toHaveLength(0);
+
+    const second = await client.connect(sqliteOptions(), NAME);
+
+    expect(second).not.toBe(first);
+    expect(closeSpy).toHaveBeenCalledTimes(1);
+    expect(warnings()).toHaveLength(1);
+    expect(warnings()[0]).toContain(`'${NAME}'`);
+    expect(warnings()[0]).toContain("connectionName");
+
+    expect(client.getConnection(NAME)).toBe(second);
+  });
+
+  it("does not warn when the name was closed before reconnecting", async () => {
+    const client = DatabaseClient.getInstance();
+
+    await client.connect(sqliteOptions(), NAME);
+    await client.close(NAME);
+    logLines = [];
+
+    await client.connect(sqliteOptions(), NAME);
+    expect(warnings()).toHaveLength(0);
+  });
+});

--- a/__tests__/unit/errors.test.ts
+++ b/__tests__/unit/errors.test.ts
@@ -37,7 +37,7 @@ describe("DatabaseConnectionFailedError", () => {
   it("should have correct message and status 500", () => {
     const error = new DatabaseConnectionFailedError();
 
-    expect(error.message).toBe("데이터베이스 연결에 실패했습니다.");
+    expect(error.message).toBe("Failed to connect to the database.");
     expect(error.status).toBe(500);
     expect(error).toBeInstanceOf(Exception);
     expect(error).toBeInstanceOf(Error);
@@ -48,7 +48,7 @@ describe("DatabaseConnectionFailedError", () => {
     const error = new DatabaseConnectionFailedError(original);
 
     expect(error.message).toBe(
-      "데이터베이스 연결에 실패했습니다: ECONNREFUSED 127.0.0.1:5432",
+      "Failed to connect to the database: ECONNREFUSED 127.0.0.1:5432",
     );
     expect((error as any).cause).toBe(original);
     expect(error.status).toBe(500);
@@ -58,7 +58,7 @@ describe("DatabaseConnectionFailedError", () => {
     const error = new DatabaseConnectionFailedError("pool exhausted");
 
     expect(error.message).toBe(
-      "데이터베이스 연결에 실패했습니다: pool exhausted",
+      "Failed to connect to the database: pool exhausted",
     );
     expect((error as any).cause).toBe("pool exhausted");
   });

--- a/__tests__/unit/fix-esm-rewrite.test.ts
+++ b/__tests__/unit/fix-esm-rewrite.test.ts
@@ -1,0 +1,98 @@
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+// Plain CJS build tool — imported with require so ts-jest does not transform it.
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { rewriteSpecifier, rewriteSource } = require("../../scripts/fix-esm.js");
+
+describe("fix-esm specifier rewriting", () => {
+  let dir: string;
+
+  beforeAll(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "fix-esm-"));
+    fs.writeFileSync(path.join(dir, "DatabaseClient.js"), "");
+    fs.mkdirSync(path.join(dir, "core"));
+    fs.writeFileSync(path.join(dir, "core", "index.js"), "");
+    fs.mkdirSync(path.join(dir, "dialects"));
+    fs.writeFileSync(path.join(dir, "dialects", "SqlDriver.js"), "");
+  });
+
+  afterAll(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  describe("rewriteSpecifier", () => {
+    it("appends .js to relative file imports", () => {
+      expect(rewriteSpecifier("./DatabaseClient", dir)).toBe(
+        "./DatabaseClient.js",
+      );
+    });
+
+    it("resolves directory imports to index.js", () => {
+      expect(rewriteSpecifier("./core", dir)).toBe("./core/index.js");
+    });
+
+    it("resolves parent-relative imports", () => {
+      expect(rewriteSpecifier("../core", path.join(dir, "dialects"))).toBe(
+        "../core/index.js",
+      );
+    });
+
+    it("leaves bare package specifiers alone", () => {
+      expect(rewriteSpecifier("reflect-metadata", dir)).toBe("reflect-metadata");
+      expect(rewriteSpecifier("sql-template-tag", dir)).toBe("sql-template-tag");
+    });
+
+    it("leaves already-extensioned specifiers alone", () => {
+      expect(rewriteSpecifier("./DatabaseClient.js", dir)).toBe(
+        "./DatabaseClient.js",
+      );
+    });
+  });
+
+  describe("rewriteSource", () => {
+    it("rewrites static import, export-from and side-effect imports", () => {
+      const source = [
+        'import "reflect-metadata";',
+        'import "./DatabaseClient";',
+        'import { A } from "./core";',
+        'export { B } from "./DatabaseClient";',
+        'export * from "./core";',
+      ].join("\n");
+
+      expect(rewriteSource(source, dir)).toBe(
+        [
+          'import "reflect-metadata";',
+          'import "./DatabaseClient.js";',
+          'import { A } from "./core/index.js";',
+          'export { B } from "./DatabaseClient.js";',
+          'export * from "./core/index.js";',
+        ].join("\n"),
+      );
+    });
+
+    it("rewrites dynamic imports (driver lazy-loading)", () => {
+      const source = 'const { X } = await import("./core");';
+      expect(rewriteSource(source, dir)).toBe(
+        'const { X } = await import("./core/index.js");',
+      );
+    });
+
+    it("does not touch generated-code templates with interpolated specifiers", () => {
+      const source =
+        "lines.push(`import { X } from \"./${refFileName.replace(/\\.ts$/, \"\")}\";`);";
+      expect(rewriteSource(source, dir)).toBe(source);
+    });
+
+    it("does not touch SQL strings containing from", () => {
+      const source = 'const sql = `select * from "user" where id = 1`;';
+      expect(rewriteSource(source, dir)).toBe(source);
+    });
+
+    it("does not touch dynamic imports of bare packages", () => {
+      const source = 'const mod = await import("better-sqlite3");';
+      expect(rewriteSource(source, dir)).toBe(source);
+    });
+  });
+});

--- a/__tests__/unit/sql-template-tag-wrapper.test.ts
+++ b/__tests__/unit/sql-template-tag-wrapper.test.ts
@@ -1,0 +1,45 @@
+import * as fs from "fs";
+import * as path from "path";
+import sqlDefault, { sql, Sql, raw, join, empty } from "../../src/utils/sqlTag";
+
+const SRC = path.join(__dirname, "..", "..", "src");
+
+function walk(dir: string, files: string[] = []): string[] {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) walk(full, files);
+    else if (entry.name.endsWith(".ts") && !entry.name.endsWith(".d.ts"))
+      files.push(full);
+  }
+  return files;
+}
+
+describe("sqlTag wrapper", () => {
+  it("unwraps the tag function in both module systems", () => {
+    expect(typeof sql).toBe("function");
+    expect(sqlDefault).toBe(sql);
+
+    const query = sql`SELECT * FROM t WHERE id = ${1}`;
+    expect(query).toBeInstanceOf(Sql);
+    expect(query.values).toEqual([1]);
+
+    expect(typeof raw).toBe("function");
+    expect(typeof join).toBe("function");
+    expect(empty).toBeInstanceOf(Sql);
+  });
+
+  /**
+   * The ESM build breaks on direct default imports of sql-template-tag (a
+   * CJS package whose default binding becomes module.exports under Node
+   * ESM). Every runtime import must go through utils/sqlTag.ts instead.
+   * Type-position `import("sql-template-tag").Sql` is fine — it is erased.
+   */
+  it("is the only module importing sql-template-tag directly", () => {
+    const offenders = walk(SRC).filter((file) => {
+      if (file.endsWith(path.join("utils", "sqlTag.ts"))) return false;
+      return fs.readFileSync(file, "utf8").includes('from "sql-template-tag"');
+    });
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -113,7 +113,10 @@ function sidebarEn() {
     {
       text: "Integration",
       collapsed: false,
-      items: [{ text: "NestJS", link: "/nestjs" }],
+      items: [
+        { text: "NestJS", link: "/nestjs" },
+        { text: "Express", link: "/express" },
+      ],
     },
     {
       text: "Tutorials",
@@ -252,7 +255,10 @@ function sidebarKo() {
     {
       text: "통합",
       collapsed: false,
-      items: [{ text: "NestJS", link: "/ko/nestjs" }],
+      items: [
+        { text: "NestJS", link: "/ko/nestjs" },
+        { text: "Express", link: "/ko/express" },
+      ],
     },
     {
       text: "튜토리얼",
@@ -317,7 +323,10 @@ export default defineConfig({
           },
           {
             text: "Integration",
-            items: [{ text: "NestJS", link: "/nestjs" }],
+            items: [
+              { text: "NestJS", link: "/nestjs" },
+              { text: "Express", link: "/express" },
+            ],
           },
           { text: "Tutorials", link: "/tutorial-iot" },
           { text: "API Reference", link: "/api-reference" },
@@ -345,7 +354,10 @@ export default defineConfig({
           },
           {
             text: "통합",
-            items: [{ text: "NestJS", link: "/ko/nestjs" }],
+            items: [
+              { text: "NestJS", link: "/ko/nestjs" },
+              { text: "Express", link: "/ko/express" },
+            ],
           },
           { text: "튜토리얼", link: "/ko/tutorial-iot" },
           { text: "API 레퍼런스", link: "/ko/api-reference" },

--- a/docs/express.md
+++ b/docs/express.md
@@ -1,0 +1,203 @@
+# Using with Express
+
+Stingerloom ORM is framework-agnostic. The `EntityManager` you use in the NestJS integration is the same class you use anywhere else — the NestJS module is only a thin dependency-injection wrapper around it. This guide shows the patterns that replace each piece of that wrapper in a plain [Express](https://expressjs.com/) application. The same patterns apply to Fastify, Koa, Hono, or any other Node.js server.
+
+Both module systems are supported: a CommonJS project (`require`) and an ESM project (`"type": "module"` with `import`) work with the same code.
+
+## Setup
+
+```bash
+npm install @stingerloom/orm reflect-metadata express
+npm install better-sqlite3   # or pg / mysql2
+```
+
+## Choose an entity style that matches your build tool
+
+This is the most common stumbling block outside NestJS, so it comes first.
+
+The decorator style (`@Entity`, `@Column`) infers column types from TypeScript's `design:type` metadata, which only exists when the code is compiled with `emitDecoratorMetadata` — that is, by `tsc` or `ts-node`. The tools most Express projects use for development — **tsx, esbuild, swc, and Vite — do not emit decorator metadata**. Under those tools an un-typed `@Column()` cannot see the property type and falls back to `"text"`, with a warning like:
+
+```
+WARN [Column] No design:type metadata for User.name — falling back to "text". ...
+```
+
+You have three reliable options:
+
+1. **Use the code-first builder (recommended).** `defineEntity` carries its column types itself and needs no decorator metadata, no `experimentalDecorators`, and no specific compiler:
+
+   ```typescript
+   import { defineEntity, t, InferEntity } from "@stingerloom/orm";
+
+   export const User = defineEntity("users", {
+     id:      t.int().primary().generated(),
+     name:    t.varchar(255),
+     balance: t.int().default(0),
+   });
+   export type User = InferEntity<typeof User>;
+   ```
+
+2. **Keep decorators, but give every column an explicit type.** `@Column({ type: "int" })` needs no inference, so it behaves identically under every build tool.
+
+3. **Keep decorators and compile with `tsc` / run with `ts-node`**, which emit the metadata the inference needs.
+
+See [Defining Entities](./define-entity.md) and [Troubleshooting](./troubleshooting.md) for details.
+
+## Bootstrap
+
+Create one `EntityManager` for the whole process, register it **before** the server starts accepting traffic, and share it across modules:
+
+```typescript
+// db.ts
+import "reflect-metadata"; // first import of the process
+import { EntityManager } from "@stingerloom/orm";
+
+export const em = new EntityManager();
+
+export async function initDb(): Promise<void> {
+  await em.register({
+    type: "sqlite",
+    database: "app.db",
+    entities: [User],
+    synchronize: true, // development only — use migrations in production
+  });
+}
+```
+
+```typescript
+// main.ts
+import express from "express";
+import { em, initDb } from "./db";
+import { User } from "./user.entity";
+
+async function main() {
+  await initDb(); // requests arriving before this would fail with DatabaseNotConnectedError
+
+  const app = express();
+  app.use(express.json());
+
+  app.post("/users", async (req, res) => {
+    res.json(await em.save(User, req.body));
+  });
+
+  app.get("/users/:id", async (req, res) => {
+    const user = await em.findOne(User, { where: { id: Number(req.params.id) } });
+    if (!user) return res.status(404).json({ error: "not found" });
+    res.json(user);
+  });
+
+  app.listen(3000);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});
+```
+
+::: warning One EntityManager per database
+`register()` without a connection name registers the `"default"` connection on a process-wide registry. If a second `EntityManager` registers under the same name, it replaces that connection — the first manager would silently start querying the second database. The ORM logs a warning when this happens:
+
+```
+WARN [DatabaseClient] Connection 'default' is already registered and will be replaced. ...
+```
+
+Share one `EntityManager` instance across your modules. If you genuinely need several databases in one process, give each one a distinct name: `em2.register(options, "analytics")`.
+:::
+
+## Repositories
+
+`@InjectRepository(User)` is NestJS DI sugar. The direct equivalent:
+
+```typescript
+const userRepository = em.getRepository(User);
+
+const users = await userRepository.find({ where: { name: "alice" } });
+```
+
+Repositories are cheap views over the `EntityManager` — fetch them where needed or export them from `db.ts` alongside `em`.
+
+## Transactions
+
+`@Transactional()` does not depend on NestJS. It tracks the active transaction with `AsyncLocalStorage`, so it works on any class whose methods you call — including plain service classes in an Express app:
+
+```typescript
+import { Transactional } from "@stingerloom/orm";
+
+class TransferService {
+  @Transactional()
+  async transfer(fromId: number, toId: number, amount: number) {
+    // every em call in here joins the same transaction;
+    // a thrown error rolls the whole thing back
+  }
+}
+```
+
+If you prefer no decorators at all, `em.transaction()` gives the same guarantees as a function:
+
+```typescript
+await em.transaction(async (txEm) => {
+  // every txEm call here shares one transaction
+});
+```
+
+## Error handling
+
+The ORM throws typed errors (`OrmError` subclasses). Express 5 forwards rejected async handlers to the error middleware automatically; on Express 4 you need an async wrapper such as `express-async-errors`. A minimal mapping middleware:
+
+```typescript
+import { OrmError, OrmErrorCode, EntityNotFoundError } from "@stingerloom/orm";
+import { NextFunction, Request, Response } from "express";
+
+app.use((err: unknown, _req: Request, res: Response, _next: NextFunction) => {
+  if (err instanceof EntityNotFoundError) {
+    return res.status(404).json({ error: err.message });
+  }
+  if (err instanceof OrmError) {
+    // err.code is an OrmErrorCode; err.suggestion often says how to fix it
+    return res.status(500).json({ error: err.message, code: err.code });
+  }
+  return res.status(500).json({ error: "internal error" });
+});
+```
+
+Without such a middleware, Express's default handler returns an HTML page that includes the stack trace — fine in development, not something to ship.
+
+## Graceful shutdown
+
+NestJS calls the ORM's shutdown hook via `app.enableShutdownHooks()`. In Express, wire the signal handlers yourself and call `propagateShutdown()` — it runs plugin shutdown hooks and closes every connection:
+
+```typescript
+const server = app.listen(3000);
+
+async function shutdown() {
+  server.close();
+  await em.propagateShutdown({ closeConnections: true });
+  process.exit(0);
+}
+
+process.on("SIGTERM", () => void shutdown());
+process.on("SIGINT", () => void shutdown());
+```
+
+## Multi-tenancy middleware
+
+The [multi-tenancy](./multi-tenancy.md) context is plain `AsyncLocalStorage`, so the Express version of the tenant middleware is just:
+
+```typescript
+import { MetadataContext } from "@stingerloom/orm";
+
+app.use((req, _res, next) => {
+  const tenantId = (req.headers["x-tenant-id"] as string) ?? "public";
+  MetadataContext.run(tenantId, () => {
+    next();
+  });
+});
+```
+
+Every handler and every ORM call in the request then runs in that tenant's context, and concurrent requests for different tenants stay isolated.
+
+## Notes on dev tooling
+
+- **tsx / nodemon restarts** are safe: metadata and connections are rebuilt on every process start.
+- **better-sqlite3 is a native module.** If `new Database()` crashes the process right after an upgrade, the installed prebuilt binary does not match your Node.js version — reinstall it (`npm rebuild better-sqlite3`) or pin a major version known to support your Node release.
+- The migration CLI (`npx stingerloom`) and the Prisma importer run as CommonJS tools; they work regardless of your app's module system.

--- a/docs/ko/express.md
+++ b/docs/ko/express.md
@@ -1,0 +1,203 @@
+# Express에서 사용하기
+
+Stingerloom ORM은 특정 프레임워크에 묶여 있지 않습니다. NestJS 통합에서 쓰는 `EntityManager`가 다른 어디에서나 그대로 쓰는 클래스이고, NestJS 모듈은 그 위에 얹힌 얇은 의존성 주입 래퍼일 뿐입니다. 이 가이드는 그 래퍼가 해주던 일을 순수 [Express](https://expressjs.com/) 애플리케이션에서 어떻게 대체하는지 패턴별로 보여줍니다. Fastify, Koa, Hono 등 다른 Node.js 서버에도 같은 패턴이 적용됩니다.
+
+CommonJS 프로젝트(`require`)와 ESM 프로젝트(`"type": "module"` + `import`) 모두 같은 코드로 동작합니다.
+
+## 설치
+
+```bash
+npm install @stingerloom/orm reflect-metadata express
+npm install better-sqlite3   # 또는 pg / mysql2
+```
+
+## 빌드 도구에 맞는 엔티티 스타일 선택
+
+NestJS 밖에서 가장 자주 겪는 문제라 제일 먼저 다룹니다.
+
+데코레이터 스타일(`@Entity`, `@Column`)은 TypeScript의 `design:type` 메타데이터로 컬럼 타입을 추론하는데, 이 메타데이터는 `emitDecoratorMetadata`로 컴파일할 때 — 즉 `tsc`나 `ts-node`를 쓸 때만 존재합니다. Express 프로젝트가 개발용으로 흔히 쓰는 **tsx, esbuild, swc, Vite는 데코레이터 메타데이터를 만들어주지 않습니다.** 이런 도구에서는 타입을 지정하지 않은 `@Column()`이 프로퍼티 타입을 알 수 없어 `"text"`로 강등되고, 다음과 같은 경고가 출력됩니다.
+
+```
+WARN [Column] No design:type metadata for User.name — falling back to "text". ...
+```
+
+확실한 선택지는 세 가지입니다.
+
+1. **코드 우선 빌더를 사용합니다(권장).** `defineEntity`는 컬럼 타입을 스스로 가지고 있어서 데코레이터 메타데이터도, `experimentalDecorators`도, 특정 컴파일러도 필요 없습니다.
+
+   ```typescript
+   import { defineEntity, t, InferEntity } from "@stingerloom/orm";
+
+   export const User = defineEntity("users", {
+     id:      t.int().primary().generated(),
+     name:    t.varchar(255),
+     balance: t.int().default(0),
+   });
+   export type User = InferEntity<typeof User>;
+   ```
+
+2. **데코레이터를 유지하되 모든 컬럼에 타입을 명시합니다.** `@Column({ type: "int" })`은 추론이 필요 없으므로 어떤 빌드 도구에서도 동일하게 동작합니다.
+
+3. **데코레이터를 유지하고 `tsc` / `ts-node`로 빌드·실행합니다.** 추론에 필요한 메타데이터가 정상적으로 생성됩니다.
+
+자세한 내용은 [엔티티 정의하기](./define-entity.md)와 [트러블슈팅](./troubleshooting.md)을 참고하세요.
+
+## 부트스트랩
+
+프로세스 전체에서 `EntityManager`를 하나만 만들고, 서버가 트래픽을 받기 **전에** 등록을 끝낸 뒤 모듈 간에 공유합니다.
+
+```typescript
+// db.ts
+import "reflect-metadata"; // 프로세스의 첫 import
+import { EntityManager } from "@stingerloom/orm";
+
+export const em = new EntityManager();
+
+export async function initDb(): Promise<void> {
+  await em.register({
+    type: "sqlite",
+    database: "app.db",
+    entities: [User],
+    synchronize: true, // 개발 전용 — 프로덕션에서는 마이그레이션 사용
+  });
+}
+```
+
+```typescript
+// main.ts
+import express from "express";
+import { em, initDb } from "./db";
+import { User } from "./user.entity";
+
+async function main() {
+  await initDb(); // 이보다 먼저 도착한 요청은 DatabaseNotConnectedError로 실패합니다
+
+  const app = express();
+  app.use(express.json());
+
+  app.post("/users", async (req, res) => {
+    res.json(await em.save(User, req.body));
+  });
+
+  app.get("/users/:id", async (req, res) => {
+    const user = await em.findOne(User, { where: { id: Number(req.params.id) } });
+    if (!user) return res.status(404).json({ error: "not found" });
+    res.json(user);
+  });
+
+  app.listen(3000);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});
+```
+
+::: warning 데이터베이스당 EntityManager는 하나
+연결 이름 없이 `register()`를 호출하면 프로세스 전역 레지스트리에 `"default"` 연결이 등록됩니다. 두 번째 `EntityManager`가 같은 이름으로 등록하면 그 연결이 교체되고, 첫 번째 매니저는 아무 오류 없이 두 번째 데이터베이스를 조회하게 됩니다. 이런 상황이 생기면 ORM이 경고를 남깁니다.
+
+```
+WARN [DatabaseClient] Connection 'default' is already registered and will be replaced. ...
+```
+
+`EntityManager` 인스턴스 하나를 모듈 간에 공유하세요. 한 프로세스에서 여러 데이터베이스가 정말 필요하다면 각각 다른 이름을 붙이면 됩니다: `em2.register(options, "analytics")`.
+:::
+
+## 리포지토리
+
+`@InjectRepository(User)`는 NestJS DI 문법 설탕입니다. 직접 쓰면 이렇게 됩니다.
+
+```typescript
+const userRepository = em.getRepository(User);
+
+const users = await userRepository.find({ where: { name: "alice" } });
+```
+
+리포지토리는 `EntityManager` 위의 가벼운 뷰라서 필요한 곳에서 그때그때 가져와도 되고, `db.ts`에서 `em`과 함께 export해도 됩니다.
+
+## 트랜잭션
+
+`@Transactional()`은 NestJS에 의존하지 않습니다. 활성 트랜잭션을 `AsyncLocalStorage`로 추적하므로 Express 앱의 평범한 서비스 클래스에서도 그대로 동작합니다.
+
+```typescript
+import { Transactional } from "@stingerloom/orm";
+
+class TransferService {
+  @Transactional()
+  async transfer(fromId: number, toId: number, amount: number) {
+    // 이 안의 모든 em 호출은 같은 트랜잭션에 참여하고,
+    // 에러가 던져지면 전체가 롤백됩니다
+  }
+}
+```
+
+데코레이터 없이 쓰고 싶다면 `em.transaction()`이 같은 보장을 함수 형태로 제공해요.
+
+```typescript
+await em.transaction(async (txEm) => {
+  // 여기서의 모든 txEm 호출은 하나의 트랜잭션을 공유합니다
+});
+```
+
+## 에러 처리
+
+ORM은 타입이 있는 에러(`OrmError` 하위 클래스)를 던집니다. Express 5는 async 핸들러의 rejection을 에러 미들웨어로 자동 전달하지만, Express 4에서는 `express-async-errors` 같은 래퍼가 필요합니다. 최소한의 매핑 미들웨어는 다음과 같습니다.
+
+```typescript
+import { OrmError, OrmErrorCode, EntityNotFoundError } from "@stingerloom/orm";
+import { NextFunction, Request, Response } from "express";
+
+app.use((err: unknown, _req: Request, res: Response, _next: NextFunction) => {
+  if (err instanceof EntityNotFoundError) {
+    return res.status(404).json({ error: err.message });
+  }
+  if (err instanceof OrmError) {
+    // err.code는 OrmErrorCode이고, err.suggestion에 해결 힌트가 담기는 경우가 많습니다
+    return res.status(500).json({ error: err.message, code: err.code });
+  }
+  return res.status(500).json({ error: "internal error" });
+});
+```
+
+이런 미들웨어가 없으면 Express 기본 핸들러가 스택 트레이스가 포함된 HTML 페이지를 반환합니다. 개발 중에는 괜찮지만 그대로 배포할 것은 아닙니다.
+
+## 우아한 종료
+
+NestJS에서는 `app.enableShutdownHooks()`가 ORM의 종료 훅을 불러줍니다. Express에서는 시그널 핸들러를 직접 연결하고 `propagateShutdown()`을 호출하세요. 플러그인 종료 훅을 실행하고 모든 연결을 닫아줍니다.
+
+```typescript
+const server = app.listen(3000);
+
+async function shutdown() {
+  server.close();
+  await em.propagateShutdown({ closeConnections: true });
+  process.exit(0);
+}
+
+process.on("SIGTERM", () => void shutdown());
+process.on("SIGINT", () => void shutdown());
+```
+
+## 멀티테넌시 미들웨어
+
+[멀티테넌시](./multi-tenancy.md) 컨텍스트는 순수 `AsyncLocalStorage`라서, Express용 테넌트 미들웨어는 이게 전부입니다.
+
+```typescript
+import { MetadataContext } from "@stingerloom/orm";
+
+app.use((req, _res, next) => {
+  const tenantId = (req.headers["x-tenant-id"] as string) ?? "public";
+  MetadataContext.run(tenantId, () => {
+    next();
+  });
+});
+```
+
+이후 요청의 모든 핸들러와 ORM 호출이 해당 테넌트 컨텍스트에서 실행되고, 서로 다른 테넌트의 동시 요청은 격리된 상태를 유지합니다.
+
+## 개발 도구 관련 메모
+
+- **tsx / nodemon 재시작**은 안전합니다. 메타데이터와 연결은 프로세스가 시작될 때마다 새로 구성됩니다.
+- **better-sqlite3는 네이티브 모듈입니다.** 업그레이드 직후 `new Database()`에서 프로세스가 죽는다면 설치된 prebuilt 바이너리가 Node.js 버전과 맞지 않는 것입니다. 재설치(`npm rebuild better-sqlite3`)하거나 사용 중인 Node 릴리스를 지원하는 메이저 버전으로 고정하세요.
+- 마이그레이션 CLI(`npx stingerloom`)와 Prisma 임포터는 CommonJS 도구로 실행되므로 앱의 모듈 시스템과 무관하게 동작합니다.

--- a/docs/ko/troubleshooting.md
+++ b/docs/ko/troubleshooting.md
@@ -89,6 +89,24 @@ await em.register({
 import "reflect-metadata";
 ```
 
+### 컬럼이 조용히 "text"가 됨 / "No design:type metadata" 경고
+
+```
+WARN [Column] No design:type metadata for User.name — falling back to "text". ...
+```
+
+데코레이터 스타일은 TypeScript의 `design:type` 메타데이터로 컬럼 타입을 추론하는데, 이 메타데이터는 `tsc`와 `ts-node`만 생성합니다(`emitDecoratorMetadata`). **tsx, esbuild, swc, Vite는 이를 생성하지 않아서** 타입을 지정하지 않은 `@Column()`이 전부 `"text"`로 강등되고, 실제 데이터베이스에서는 숫자·날짜 컬럼이 깨집니다.
+
+다음 중 하나로 해결할 수 있습니다.
+
+1. 코드 우선 빌더로 엔티티 정의 — `defineEntity`는 데코레이터 메타데이터가 아예 필요 없습니다
+2. 모든 `@Column`에 타입 명시: `@Column({ type: "int" })`
+3. `tsc`로 빌드하거나 `ts-node`로 실행해 메타데이터를 생성
+
+관련 경고인 `Unknown design:type "Object"`는 프로퍼티의 TypeScript 타입이 런타임에 `Object`로 지워진다는 뜻입니다(`string | null` 같은 유니언/옵셔널 타입). 이 경우에도 컬럼 타입을 명시하면 됩니다.
+
+NestJS 없이 사용하는 전체 설정은 [Express에서 사용하기](./express.md)를 참고하세요.
+
 ### "Primary key not found"
 
 ```

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -89,6 +89,24 @@ await em.register({
 import "reflect-metadata";
 ```
 
+### Columns silently become "text" / "No design:type metadata" warnings
+
+```
+WARN [Column] No design:type metadata for User.name — falling back to "text". ...
+```
+
+The decorator style infers column types from TypeScript's `design:type` metadata, which only `tsc` and `ts-node` emit (`emitDecoratorMetadata`). **tsx, esbuild, swc, and Vite do not emit it** — under those tools every un-typed `@Column()` falls back to `"text"`, which breaks numeric and date columns on real databases.
+
+Fixes (any one of these):
+
+1. Define entities with the code-first builder — `defineEntity` needs no decorator metadata at all
+2. Give every `@Column` an explicit type: `@Column({ type: "int" })`
+3. Build with `tsc` / run with `ts-node` so the metadata exists
+
+A related warning, `Unknown design:type "Object"`, means the property's TypeScript type erases to `Object` at runtime (union or optional types like `string | null`) — specify an explicit column type there too.
+
+See [Using with Express](./express.md) for the full non-NestJS setup.
+
 ### "Primary key not found"
 
 ```

--- a/package.json
+++ b/package.json
@@ -171,7 +171,7 @@
     "stingerloom"
   ],
   "scripts": {
-    "build": "rimraf dist && tsc && tsc -p tsconfig.esm.json",
+    "build": "rimraf dist && tsc && tsc -p tsconfig.esm.json && node scripts/fix-esm.js",
     "prepublishOnly": "pnpm run build",
     "test": "jest",
     "docs:dev": "vitepress dev docs",

--- a/scripts/fix-esm.js
+++ b/scripts/fix-esm.js
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+/**
+ * Post-build fixup for the ESM output (dist/esm).
+ *
+ * tsc emits the ESM build with the relative specifiers exactly as written in
+ * the source (extensionless, e.g. `from "./DatabaseClient"`). Bundlers resolve
+ * those, but plain Node's ESM loader does not — `import "@stingerloom/orm"`
+ * from a `"type": "module"` app fails with ERR_MODULE_NOT_FOUND. Node also
+ * needs `dist/esm` marked as `"type": "module"`, because the package root is
+ * CommonJS.
+ *
+ * This script:
+ *   1. rewrites relative import/export/dynamic-import specifiers to explicit
+ *      file paths (`./x` → `./x.js`, `./dir` → `./dir/index.js`)
+ *   2. writes `dist/esm/package.json` with `{"type": "module"}`
+ */
+const fs = require("fs");
+const path = require("path");
+
+/**
+ * Rewrites one relative specifier to an explicit file path, resolving
+ * directory imports to their index.js. Non-relative and already-extensioned
+ * specifiers are returned unchanged.
+ */
+function rewriteSpecifier(spec, fileDir) {
+  if (!spec.startsWith("./") && !spec.startsWith("../")) return spec;
+  if (/\.(js|mjs|cjs|json|node)$/.test(spec)) return spec;
+  // Template interpolation means this is generated-code text inside a
+  // template literal (e.g. introspection's EntityCodeBuilder), not a real
+  // import specifier of this module.
+  if (spec.includes("${")) return spec;
+  const abs = path.resolve(fileDir, spec);
+  if (fs.existsSync(abs) && fs.statSync(abs).isDirectory()) {
+    return `${spec.replace(/\/+$/, "")}/index.js`;
+  }
+  return `${spec}.js`;
+}
+
+/**
+ * Rewrites every relative specifier in an ESM source string.
+ * Covers `import ... from "x"`, `export ... from "x"`, side-effect
+ * `import "x"` and dynamic `import("x")`.
+ */
+function rewriteSource(source, fileDir) {
+  return source.replace(
+    /(\bfrom\s*|\bimport\s*\(\s*|^[ \t]*import\s+)(["'])((?:\.\.?\/)[^"']+)\2/gm,
+    (_m, prefix, quote, spec) =>
+      `${prefix}${quote}${rewriteSpecifier(spec, fileDir)}${quote}`,
+  );
+}
+
+function walk(dir, files = []) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) walk(full, files);
+    else if (entry.name.endsWith(".js")) files.push(full);
+  }
+  return files;
+}
+
+function main() {
+  const esmDir = path.join(__dirname, "..", "dist", "esm");
+  if (!fs.existsSync(esmDir)) {
+    console.error(`fix-esm: ${esmDir} does not exist — run the ESM build first.`);
+    process.exit(1);
+  }
+
+  let changed = 0;
+  for (const file of walk(esmDir)) {
+    const source = fs.readFileSync(file, "utf8");
+    const fixed = rewriteSource(source, path.dirname(file));
+    if (fixed !== source) {
+      fs.writeFileSync(file, fixed);
+      changed++;
+    }
+  }
+
+  fs.writeFileSync(
+    path.join(esmDir, "package.json"),
+    JSON.stringify({ type: "module" }, null, 2) + "\n",
+  );
+
+  console.log(`fix-esm: rewrote specifiers in ${changed} files, marked dist/esm as ESM.`);
+}
+
+module.exports = { rewriteSpecifier, rewriteSource };
+
+if (require.main === module) {
+  main();
+}

--- a/src/DatabaseClient.ts
+++ b/src/DatabaseClient.ts
@@ -47,6 +47,25 @@ export class DatabaseClient {
   ): Promise<IConnector> {
     const { type } = options;
 
+    // Re-connecting under a name that is still registered replaces the
+    // connection every consumer of that name routes through — a second
+    // EntityManager registered without a distinct connectionName would
+    // silently redirect the first one to the new database.
+    const previous = this.connectors.get(name);
+    if (previous) {
+      this.logger.warn(
+        `Connection '${name}' is already registered and will be replaced. ` +
+        `Every EntityManager using '${name}' now routes to the new database. ` +
+        `If this is a second EntityManager, pass a distinct connectionName to ` +
+        `register() instead, or close() the existing connection first.`,
+      );
+      try {
+        await previous.close();
+      } catch {
+        // best effort — the old connector may already be closed
+      }
+    }
+
     this.connectionsType.set(name, type);
     this.connectionsOptions.set(name, options);
 
@@ -137,7 +156,7 @@ export class DatabaseClient {
       if (name === "default") {
         throw new DatabaseNotConnectedError();
       }
-      throw new Exception(`연결 '${name}'을 찾을 수 없습니다.`, 500);
+      throw new Exception(`Connection '${name}' was not found.`, 500);
     }
 
     return connector;
@@ -152,8 +171,8 @@ export class DatabaseClient {
     if (!options) {
       throw new Exception(
         name === "default"
-          ? "옵션이 존재하지 않습니다."
-          : `연결 '${name}'의 옵션을 찾을 수 없습니다.`,
+          ? "No connection options are registered."
+          : `No options found for connection '${name}'.`,
         500,
       );
     }

--- a/src/core/AggregateQueryHandler.ts
+++ b/src/core/AggregateQueryHandler.ts
@@ -2,7 +2,7 @@
 import { ClazzType } from "../utils";
 import { WhereClause } from "../dialects/FindOption";
 import { TransactionSessionManager } from "../dialects/TransactionSessionManager";
-import sql, { Sql, join, raw } from "sql-template-tag";
+import sql, { Sql, join, raw } from "../utils/sqlTag";
 import { Conditions } from "./Conditions";
 import { resolveWhereClause } from "./WhereResolver";
 import { createDialectExpression } from "../dialects/DialectExpression";

--- a/src/core/BaseEntityManager.ts
+++ b/src/core/BaseEntityManager.ts
@@ -5,7 +5,7 @@ import { BaseRepository } from "./BaseRepository";
 import { BaseRawQueryBuilder } from "./BaseRawQueryBuilder";
 import { DeleteResult } from "../types/DeleteResult";
 import { DatabaseClientOptions } from "./DatabaseClientOptions";
-import { Sql } from "sql-template-tag";
+import { Sql } from "../utils/sqlTag";
 import {
   CursorPaginationOption,
   CursorPaginationResult,

--- a/src/core/BaseInsertQueryBuilder.ts
+++ b/src/core/BaseInsertQueryBuilder.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { ClazzType } from "../utils";
-import { Sql } from "sql-template-tag";
+import { Sql } from "../utils/sqlTag";
 
 /**
  * Interface representing a builder for constructing SQL insert queries.

--- a/src/core/BaseRawQueryBuilder.ts
+++ b/src/core/BaseRawQueryBuilder.ts
@@ -1,4 +1,4 @@
-import { Sql } from "sql-template-tag";
+import { Sql } from "../utils/sqlTag";
 import type { DatabaseType, RawQueryBuilder, RawQueryExecutor } from "./RawQueryBuilder";
 import type { CompiledQuery } from "./CompiledQuery";
 

--- a/src/core/CompiledQuery.ts
+++ b/src/core/CompiledQuery.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { Sql } from "sql-template-tag";
+import { Sql } from "../utils/sqlTag";
 import { OrmError } from "../errors/OrmError";
 import { OrmErrorCode } from "../errors/OrmErrorCode";
 

--- a/src/core/Conditions.ts
+++ b/src/core/Conditions.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import sql, { Sql, join, raw } from "sql-template-tag";
+import sql, { Sql, join, raw } from "../utils/sqlTag";
 import type { FullTextSearchOptions } from "../dialects/DialectExpression";
 import { InvalidQueryError } from "../errors/InvalidQueryError";
 

--- a/src/core/EntityManager.ts
+++ b/src/core/EntityManager.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { randomUUID } from "node:crypto";
 import { ClazzType, Logger, resolveEntityGlobs, generateUUIDv7 } from "../utils";
+import { DeserializerRegistry } from "./deserializer/DeserializerRegistry";
 import { ColumnMetadata, MetadataLayerRegistry } from "../scanner";
 import { DatabaseClient } from "../DatabaseClient";
 import { ISqlDriver } from "../dialects/SqlDriver";
@@ -10,7 +11,7 @@ import { FindOption, LockMode, UpdateData, UpdateManyOptions, WhereClause } from
 import { resolveWhereClause } from "./WhereResolver";
 import { ISelectOption } from "../dialects/ISelectOption";
 import { IDataSource } from "../dialects/IDataSource";
-import { Sql } from "sql-template-tag";
+import { Sql } from "../utils/sqlTag";
 import { BaseRepository } from "./BaseRepository";
 import { BaseEntityManager } from "./BaseEntityManager";
 import { QueryResult } from "../types/QueryResult";
@@ -362,6 +363,10 @@ export class EntityManager implements BaseEntityManager {
     connectionName = "default",
   ) {
     validateDatabaseClientOptions(databaseClientOptions);
+
+    // ESM builds cannot probe class-transformer synchronously (no require);
+    // finish the async auto-detection before any query can deserialize rows.
+    await DeserializerRegistry.ensureDefaultDetected();
 
     if (databaseClientOptions.namingStrategy) {
       this.schemaRegistrar = new SchemaRegistrar(

--- a/src/core/ExplainQueryHandler.ts
+++ b/src/core/ExplainQueryHandler.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { ClazzType } from "../utils";
 import { FindOption } from "../dialects/FindOption";
-import sql, { Sql, raw } from "sql-template-tag";
+import sql, { Sql, raw } from "../utils/sqlTag";
 import { Conditions } from "./Conditions";
 import { resolveWhereClause } from "./WhereResolver";
 import { createDialectExpression } from "../dialects/DialectExpression";

--- a/src/core/IConnector.ts
+++ b/src/core/IConnector.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { Sql } from "sql-template-tag";
+import { Sql } from "../utils/sqlTag";
 import { DatabaseClientOptions } from "./DatabaseClientOptions";
 import { TRANSACTION_ISOLATION_LEVEL } from "../dialects/IsolationLevel";
 import { IConnection } from "../dialects/IConnection";

--- a/src/core/PagePagination.ts
+++ b/src/core/PagePagination.ts
@@ -2,7 +2,7 @@
 import { WhereClause, RelationKeys } from "../dialects/FindOption";
 import { ISelectOption } from "../dialects/ISelectOption";
 import { IOrderBy } from "../dialects/IOrderBy";
-import { Sql } from "sql-template-tag";
+import { Sql } from "../utils/sqlTag";
 import { normalizePageSize } from "./CursorPagination";
 
 /**

--- a/src/core/RawQueryBuilder.ts
+++ b/src/core/RawQueryBuilder.ts
@@ -1,5 +1,6 @@
-import sql, { Sql, raw, join } from "sql-template-tag";
+import sql, { Sql, raw, join } from "../utils/sqlTag";
 import { BaseRawQueryBuilder } from "./BaseRawQueryBuilder";
+import { RawQueryBuilderFactory } from "./RawQueryBuilderFactory";
 import { OrmError } from "../errors/OrmError";
 import { OrmErrorCode } from "../errors/OrmErrorCode";
 import { CompiledQuery } from "./CompiledQuery";
@@ -581,8 +582,9 @@ export class RawQueryBuilder implements BaseRawQueryBuilder {
   protected createSubBuilder(): RawQueryBuilder {
     let sub: RawQueryBuilder;
     try {
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      const { RawQueryBuilderFactory } = require("./RawQueryBuilderFactory");
+      // Static circular import (RawQueryBuilderFactory ↔ RawQueryBuilder) is
+      // safe here because the factory is only dereferenced at call time,
+      // after both modules have finished initializing.
       sub = RawQueryBuilderFactory.subquery() as RawQueryBuilder;
     } catch {
       sub = new RawQueryBuilder();

--- a/src/core/RelationLoader.ts
+++ b/src/core/RelationLoader.ts
@@ -2,7 +2,7 @@
 import { ClazzType } from "../utils";
 import { ColumnMetadata } from "../scanner";
 import { TransactionSessionManager } from "../dialects/TransactionSessionManager";
-import sql, { Sql, raw } from "sql-template-tag";
+import sql, { Sql, raw } from "../utils/sqlTag";
 import { RawQueryBuilderFactory } from "./RawQueryBuilderFactory";
 import { ResultTransformerFactory } from "./ResultTransformerFactory";
 import { QueryResult } from "../types/QueryResult";

--- a/src/core/SelectQueryBuilder.ts
+++ b/src/core/SelectQueryBuilder.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import sql, { Sql, raw, join, type RawValue } from "sql-template-tag";
+import sql, { Sql, raw, join, type RawValue } from "../utils/sqlTag";
 import { Conditions } from "./Conditions";
 import { resolveWhereClause, type WhereResolverOptions } from "./WhereResolver";
 import type { WhereClause } from "../dialects/FindOption";

--- a/src/core/SqlRef.ts
+++ b/src/core/SqlRef.ts
@@ -1,4 +1,4 @@
-import { Sql, raw } from "sql-template-tag";
+import { Sql, raw } from "../utils/sqlTag";
 import type { ClazzType } from "../utils";
 import { camelToSnakeCase } from "../utils/camelToSnakeCase";
 import { ENTITY_TOKEN, EntityMetadata } from "../decorators/Entity";

--- a/src/core/UpdateQueryBuilder.ts
+++ b/src/core/UpdateQueryBuilder.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import sql, { Sql, raw, join } from "sql-template-tag";
+import sql, { Sql, raw, join } from "../utils/sqlTag";
 import { ClazzType } from "../utils";
 import { UpdateData } from "../dialects/FindOption";
 import { OrmError } from "../errors/OrmError";

--- a/src/core/WhereResolver.ts
+++ b/src/core/WhereResolver.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import sql, { Sql, raw } from "sql-template-tag";
+import sql, { Sql, raw } from "../utils/sqlTag";
 import { Conditions } from "./Conditions";
 import { WhereClause, FILTER_OPERATOR_KEYS } from "../dialects/FindOption";
 import type { DialectExpression } from "../dialects/DialectExpression";

--- a/src/core/deserializer/ClassTransformerDeserializer.ts
+++ b/src/core/deserializer/ClassTransformerDeserializer.ts
@@ -45,6 +45,33 @@ export class ClassTransformerDeserializer implements Deserializer {
     this.fastPathEnabled = options?.fastPath !== false;
   }
 
+  /**
+   * Pre-loads class-transformer via dynamic import and fills the lazy caches.
+   *
+   * The lazy getters below load class-transformer with require(), which only
+   * exists in the CJS build. ESM runtimes must await this once before the
+   * first deserialize call — `DeserializerRegistry.ensureDefaultDetected()`
+   * (run during `EntityManager.register()`) does it automatically.
+   *
+   * @throws when class-transformer is not installed.
+   */
+  async warmup(): Promise<void> {
+    if (this._plainToClass && this._ctStorage !== undefined) return;
+
+    const ctModule: any = await import("class-transformer");
+    const ct = ctModule.default?.plainToClass ? ctModule.default : ctModule;
+    this._plainToClass = ct.plainToClass;
+
+    try {
+      const storageModule: any = await import("class-transformer/cjs/storage");
+      this._ctStorage = this.validateCtStorage(
+        (storageModule.default ?? storageModule)?.defaultMetadataStorage,
+      );
+    } catch {
+      this._ctStorage = null;
+    }
+  }
+
   private getPlainToClass(): Function {
     if (!this._plainToClass) {
       try {
@@ -54,7 +81,8 @@ export class ClassTransformerDeserializer implements Deserializer {
       } catch {
         throw new Error(
           "class-transformer is required for ClassTransformerDeserializer. " +
-            "Install it with: npm install class-transformer",
+            "Install it with: npm install class-transformer. " +
+            "In ESM runtimes (no require) call `await warmup()` once before use.",
         );
       }
     }
@@ -72,19 +100,24 @@ export class ClassTransformerDeserializer implements Deserializer {
     try {
       // eslint-disable-next-line @typescript-eslint/no-var-requires
       const storageModule = require("class-transformer/cjs/storage");
-      const storage = storageModule?.defaultMetadataStorage;
-      this._ctStorage =
-        storage &&
-        storage._typeMetadatas instanceof Map &&
-        storage._transformMetadatas instanceof Map &&
-        storage._exposeMetadatas instanceof Map &&
-        storage._excludeMetadatas instanceof Map
-          ? storage
-          : null;
+      this._ctStorage = this.validateCtStorage(
+        storageModule?.defaultMetadataStorage,
+      );
     } catch {
       this._ctStorage = null;
     }
     return this._ctStorage;
+  }
+
+  /** Returns the storage only when its internal shape is the expected one. */
+  private validateCtStorage(storage: any): any {
+    return storage &&
+      storage._typeMetadatas instanceof Map &&
+      storage._transformMetadatas instanceof Map &&
+      storage._exposeMetadatas instanceof Map &&
+      storage._excludeMetadatas instanceof Map
+      ? storage
+      : null;
   }
 
   /**

--- a/src/core/deserializer/DeserializerRegistry.ts
+++ b/src/core/deserializer/DeserializerRegistry.ts
@@ -2,6 +2,8 @@
 import { DeserializeOptions } from "./DeserializeOptions";
 import { Deserializer } from "./Deserializer";
 import { MyClassConstructor } from "../MyClassConstructor";
+import { ClassTransformerDeserializer } from "./ClassTransformerDeserializer";
+import { PlainObjectDeserializer } from "./PlainObjectDeserializer";
 
 /**
  * Registry that manages the deserialization strategy.
@@ -26,22 +28,54 @@ export class DeserializerRegistry {
 
   private deserializer: Deserializer;
 
+  /** True once a deserializer was chosen explicitly (constructor arg or setDeserializer). */
+  private explicitlySet = false;
+
   constructor(deserializer?: Deserializer) {
-    this.deserializer = deserializer ?? DeserializerRegistry.createDefaultDeserializer();
+    if (deserializer) {
+      this.deserializer = deserializer;
+      this.explicitlySet = true;
+    } else {
+      this.deserializer = DeserializerRegistry.createDefaultDeserializer();
+    }
   }
 
   /**
    * Returns ClassTransformerDeserializer when class-transformer is installed,
    * and PlainObjectDeserializer otherwise.
+   *
+   * The synchronous probe needs require(), which only exists in the CJS
+   * build. The ESM build starts on PlainObjectDeserializer;
+   * `ensureDefaultDetected()` (awaited during `EntityManager.register()`)
+   * upgrades it asynchronously when class-transformer is installed.
    */
   private static createDefaultDeserializer(): Deserializer {
     try {
       require.resolve("class-transformer");
-      const { ClassTransformerDeserializer } = require("./ClassTransformerDeserializer");
       return new ClassTransformerDeserializer();
     } catch {
-      const { PlainObjectDeserializer } = require("./PlainObjectDeserializer");
       return new PlainObjectDeserializer();
+    }
+  }
+
+  /**
+   * Async counterpart of the constructor's class-transformer auto-detection
+   * for runtimes without require() (the ESM build). No-op when the CJS
+   * detection already ran, or when a deserializer was set explicitly.
+   */
+  static async ensureDefaultDetected(): Promise<void> {
+    if (typeof require === "function") return;
+
+    const registry = DeserializerRegistry.getInstance();
+    if (registry.explicitlySet) return;
+    if (registry.deserializer instanceof ClassTransformerDeserializer) return;
+
+    try {
+      const ct = new ClassTransformerDeserializer();
+      await ct.warmup();
+      registry.deserializer = ct;
+    } catch {
+      // class-transformer is not installed — keep PlainObjectDeserializer
     }
   }
 
@@ -71,6 +105,7 @@ export class DeserializerRegistry {
    */
   setDeserializer(deserializer: Deserializer): void {
     this.deserializer = deserializer;
+    this.explicitlySet = true;
   }
 
   /**

--- a/src/core/entity-manager/DmlSqlBuilder.ts
+++ b/src/core/entity-manager/DmlSqlBuilder.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import sql, { Sql, join, raw } from "sql-template-tag";
+import sql, { Sql, join, raw } from "../../utils/sqlTag";
 import { EntityManagerInternals } from "../EntityManagerInternals";
 import { OrmError } from "../../errors/OrmError";
 import { OrmErrorCode } from "../../errors/OrmErrorCode";

--- a/src/core/entity-manager/RawQueryRunner.ts
+++ b/src/core/entity-manager/RawQueryRunner.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import sql, { Sql } from "sql-template-tag";
+import sql, { Sql } from "../../utils/sqlTag";
 import { ClazzType } from "../../utils";
 import { ENTITY_TOKEN } from "../../decorators/Entity";
 import { isTemplateStringsArray } from "./internal-utils";

--- a/src/core/entity-manager/ReadExecutor.ts
+++ b/src/core/entity-manager/ReadExecutor.ts
@@ -5,7 +5,7 @@ import { ISqlDriver } from "../../dialects/SqlDriver";
 import { TransactionSessionManager } from "../../dialects/TransactionSessionManager";
 import { FindOption, LockMode, UpdateData, UpdateManyOptions, WhereClause } from "../../dialects/FindOption";
 import { resolveWhereClause } from "../WhereResolver";
-import sql, { Sql, join, raw } from "sql-template-tag";
+import sql, { Sql, join, raw } from "../../utils/sqlTag";
 import { QueryResult } from "../../types/QueryResult";
 import { EntityResult } from "../../types/EntityResult";
 import { RawQueryBuilderFactory } from "../RawQueryBuilderFactory";

--- a/src/core/entity-manager/RelationExecutor.ts
+++ b/src/core/entity-manager/RelationExecutor.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import sql, { raw } from "sql-template-tag";
+import sql, { raw } from "../../utils/sqlTag";
 import { ClazzType } from "../../utils";
 import { EntityManagerInternals } from "../EntityManagerInternals";
 import { RelationMetadataResolver } from "../RelationMetadataResolver";

--- a/src/core/entity-manager/TenantScopeManager.ts
+++ b/src/core/entity-manager/TenantScopeManager.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { Sql } from "sql-template-tag";
+import { Sql } from "../../utils/sqlTag";
 import { ClazzType } from "../../utils";
 import { MetadataContext } from "../../metadata/MetadataContext";
 import { Conditions } from "../Conditions";

--- a/src/core/entity-manager/WriteExecutor.ts
+++ b/src/core/entity-manager/WriteExecutor.ts
@@ -5,7 +5,7 @@ import { ISqlDriver } from "../../dialects/SqlDriver";
 import { TransactionSessionManager } from "../../dialects/TransactionSessionManager";
 import { FindOption, LockMode, UpdateData, UpdateManyOptions, WhereClause } from "../../dialects/FindOption";
 import { resolveWhereClause } from "../WhereResolver";
-import sql, { Sql, join, raw, type RawValue } from "sql-template-tag";
+import sql, { Sql, join, raw, type RawValue } from "../../utils/sqlTag";
 import { DeleteResult } from "../../types/DeleteResult";
 import { Conditions } from "../Conditions";
 import { ResultTransformerFactory } from "../ResultTransformerFactory";

--- a/src/core/entity-manager/entity-access.ts
+++ b/src/core/entity-manager/entity-access.ts
@@ -1,4 +1,4 @@
-import type { RawValue } from "sql-template-tag";
+import type { RawValue } from "../../utils/sqlTag";
 import type { WhereClause } from "../../dialects/FindOption";
 
 /**

--- a/src/core/expressions/AggregateExpression.ts
+++ b/src/core/expressions/AggregateExpression.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import sql, { Sql, raw, join } from "sql-template-tag";
+import sql, { Sql, raw, join } from "../../utils/sqlTag";
 import type { ConditionLike, ColumnResolver } from "./ConditionLike";
 import type { DialectExpression } from "../../dialects/DialectExpression";
 import { OrderExpression } from "./OrderExpression";

--- a/src/core/expressions/AliasedExpression.ts
+++ b/src/core/expressions/AliasedExpression.ts
@@ -1,4 +1,4 @@
-import type { Sql } from "sql-template-tag";
+import type { Sql } from "../../utils/sqlTag";
 import type { ColumnResolver } from "./ConditionLike";
 import type { DialectExpression } from "../../dialects/DialectExpression";
 

--- a/src/core/expressions/CaseExpression.ts
+++ b/src/core/expressions/CaseExpression.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import sql, { Sql, raw, join } from "sql-template-tag";
+import sql, { Sql, raw, join } from "../../utils/sqlTag";
 import type { ConditionLike, ColumnResolver } from "./ConditionLike";
 import type { DialectExpression } from "../../dialects/DialectExpression";
 import { ScalarExpression } from "./ScalarExpression";

--- a/src/core/expressions/CastExpression.ts
+++ b/src/core/expressions/CastExpression.ts
@@ -1,4 +1,4 @@
-import sql, { Sql, raw } from "sql-template-tag";
+import sql, { Sql, raw } from "../../utils/sqlTag";
 import type { CastKind, DialectExpression } from "../../dialects/DialectExpression";
 import type { ColumnResolver } from "./ConditionLike";
 import { ScalarExpression } from "./ScalarExpression";

--- a/src/core/expressions/ComputedColumnExpression.ts
+++ b/src/core/expressions/ComputedColumnExpression.ts
@@ -1,4 +1,4 @@
-import sql, { Sql, raw } from "sql-template-tag";
+import sql, { Sql, raw } from "../../utils/sqlTag";
 import type { DialectName } from "../ColumnTypeRegistry";
 import { createDialectExpression } from "../../dialects/DialectExpression";
 import { escapeSqlLiteral } from "../../utils/escapeSqlLiteral";

--- a/src/core/expressions/ConditionLike.ts
+++ b/src/core/expressions/ConditionLike.ts
@@ -1,4 +1,4 @@
-import type { Sql } from "sql-template-tag";
+import type { Sql } from "../../utils/sqlTag";
 import type { DialectExpression } from "../../dialects/DialectExpression";
 
 /**

--- a/src/core/expressions/DateArithmeticExpression.ts
+++ b/src/core/expressions/DateArithmeticExpression.ts
@@ -1,4 +1,4 @@
-import sql, { Sql, raw } from "sql-template-tag";
+import sql, { Sql, raw } from "../../utils/sqlTag";
 import type {
   DateAddUnit,
   DateTruncUnit,

--- a/src/core/expressions/DateComponentExpression.ts
+++ b/src/core/expressions/DateComponentExpression.ts
@@ -1,9 +1,9 @@
-import sql, { raw } from "sql-template-tag";
+import sql, { raw } from "../../utils/sqlTag";
 import type {
   DateComponent,
   DialectExpression,
 } from "../../dialects/DialectExpression";
-import type { Sql } from "sql-template-tag";
+import type { Sql } from "../../utils/sqlTag";
 import type { ColumnResolver } from "./ConditionLike";
 import { ScalarExpression } from "./ScalarExpression";
 

--- a/src/core/expressions/JsonPathExpression.ts
+++ b/src/core/expressions/JsonPathExpression.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import sql, { Sql, raw, join } from "sql-template-tag";
+import sql, { Sql, raw, join } from "../../utils/sqlTag";
 import type {
   ColumnJsonMeta,
   DialectExpression,

--- a/src/core/expressions/LogicalCondition.ts
+++ b/src/core/expressions/LogicalCondition.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import sql, { Sql, join } from "sql-template-tag";
+import sql, { Sql, join } from "../../utils/sqlTag";
 import type { ConditionLike, ColumnResolver } from "./ConditionLike";
 import type { DialectExpression } from "../../dialects/DialectExpression";
 import {
@@ -441,7 +441,7 @@ export const Expressions = {
    *
    * @example
    * ```ts
-   * import sql from "sql-template-tag";
+   * import { sql } from "@stingerloom/orm";
    * const epoch = Expressions.raw<number>(
    *   sql`EXTRACT(epoch FROM ${u.col("createdAt")})`,
    * );

--- a/src/core/expressions/NullishExpression.ts
+++ b/src/core/expressions/NullishExpression.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import sql, { Sql, raw, join } from "sql-template-tag";
+import sql, { Sql, raw, join } from "../../utils/sqlTag";
 import type { ColumnResolver } from "./ConditionLike";
 import type { DialectExpression } from "../../dialects/DialectExpression";
 import { ScalarExpression } from "./ScalarExpression";

--- a/src/core/expressions/NumericExpression.ts
+++ b/src/core/expressions/NumericExpression.ts
@@ -1,4 +1,4 @@
-import sql, { Sql, raw } from "sql-template-tag";
+import sql, { Sql, raw } from "../../utils/sqlTag";
 import type { DialectExpression } from "../../dialects/DialectExpression";
 import type { ColumnResolver } from "./ConditionLike";
 import { ScalarExpression } from "./ScalarExpression";

--- a/src/core/expressions/OrderExpression.ts
+++ b/src/core/expressions/OrderExpression.ts
@@ -16,7 +16,7 @@ export type OrderDirection = "ASC" | "DESC";
  */
 export type NullsPosition = "FIRST" | "LAST";
 
-import type { Sql } from "sql-template-tag";
+import type { Sql } from "../../utils/sqlTag";
 import type { ColumnResolver } from "./ConditionLike";
 import type { DialectExpression } from "../../dialects/DialectExpression";
 

--- a/src/core/expressions/OrderedSetAggregateExpression.ts
+++ b/src/core/expressions/OrderedSetAggregateExpression.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import sql, { Sql, raw } from "sql-template-tag";
+import sql, { Sql, raw } from "../../utils/sqlTag";
 import type { ConditionLike, ColumnResolver } from "./ConditionLike";
 import type { DialectExpression } from "../../dialects/DialectExpression";
 import { OrmError } from "../../errors/OrmError";

--- a/src/core/expressions/RawExpression.ts
+++ b/src/core/expressions/RawExpression.ts
@@ -1,4 +1,4 @@
-import type { Sql } from "sql-template-tag";
+import type { Sql } from "../../utils/sqlTag";
 import { ScalarExpression } from "./ScalarExpression";
 
 /**
@@ -22,8 +22,7 @@ import { ScalarExpression } from "./ScalarExpression";
  *
  * @example
  * ```ts
- * import sql from "sql-template-tag";
- * import { Expressions, qAlias } from "@stingerloom/orm";
+ * import { sql, Expressions, qAlias } from "@stingerloom/orm";
  *
  * const u = qAlias(User, "u");
  * const epoch = Expressions.raw<number>(

--- a/src/core/expressions/ScalarExpression.ts
+++ b/src/core/expressions/ScalarExpression.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import sql, { Sql, raw, join } from "sql-template-tag";
+import sql, { Sql, raw, join } from "../../utils/sqlTag";
 import type { ConditionLike, ColumnResolver } from "./ConditionLike";
 import type {
   CastKind,

--- a/src/core/expressions/StringExpression.ts
+++ b/src/core/expressions/StringExpression.ts
@@ -1,4 +1,4 @@
-import sql, { Sql, raw, join } from "sql-template-tag";
+import sql, { Sql, raw, join } from "../../utils/sqlTag";
 import type { DialectExpression } from "../../dialects/DialectExpression";
 import type { ColumnResolver } from "./ConditionLike";
 import { ScalarExpression } from "./ScalarExpression";

--- a/src/core/expressions/SubqueryExpression.ts
+++ b/src/core/expressions/SubqueryExpression.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import sql, { Sql } from "sql-template-tag";
+import sql, { Sql } from "../../utils/sqlTag";
 import type { ConditionLike, ColumnResolver } from "./ConditionLike";
 import type { DialectExpression } from "../../dialects/DialectExpression";
 

--- a/src/core/expressions/TemporalExpression.ts
+++ b/src/core/expressions/TemporalExpression.ts
@@ -1,4 +1,4 @@
-import sql from "sql-template-tag";
+import sql from "../../utils/sqlTag";
 import { ScalarExpression } from "./ScalarExpression";
 
 /**

--- a/src/core/expressions/TupleExpression.ts
+++ b/src/core/expressions/TupleExpression.ts
@@ -1,4 +1,4 @@
-import sql, { Sql, join, raw, type RawValue } from "sql-template-tag";
+import sql, { Sql, join, raw, type RawValue } from "../../utils/sqlTag";
 import type { ConditionLike, ColumnResolver } from "./ConditionLike";
 import type { DialectExpression } from "../../dialects/DialectExpression";
 import { OrmError } from "../../errors/OrmError";

--- a/src/core/expressions/WindowExpression.ts
+++ b/src/core/expressions/WindowExpression.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import sql, { Sql, raw, join } from "sql-template-tag";
+import sql, { Sql, raw, join } from "../../utils/sqlTag";
 import type { ColumnResolver } from "./ConditionLike";
 import type { DialectExpression } from "../../dialects/DialectExpression";
 import type { AggregateExpression } from "./AggregateExpression";

--- a/src/core/expressions/WindowFunctions.ts
+++ b/src/core/expressions/WindowFunctions.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import sql, { Sql, raw } from "sql-template-tag";
+import sql, { Sql, raw } from "../../utils/sqlTag";
 import type { ColumnResolver } from "./ConditionLike";
 import type { DialectExpression } from "../../dialects/DialectExpression";
 import { WindowBuilder, type WindowHeadRenderer } from "./WindowExpression";

--- a/src/core/generators/SchemaDiff.ts
+++ b/src/core/generators/SchemaDiff.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import sql from "sql-template-tag";
+import sql from "../../utils/sqlTag";
 import { ClazzType } from "../../utils";
 import {
   COLUMN_TOKEN,

--- a/src/core/plugin/raw-pipeline/RawPipeline.ts
+++ b/src/core/plugin/raw-pipeline/RawPipeline.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import sql, { Sql, raw, join } from "sql-template-tag";
+import sql, { Sql, raw, join } from "../../../utils/sqlTag";
 import type { PluginContext } from "../PluginContext";
 import type { ClazzType } from "../../../utils/types";
 import type { FindOption, WhereClause } from "../../../dialects/FindOption";

--- a/src/core/query-builder/condition/ColumnCondition.ts
+++ b/src/core/query-builder/condition/ColumnCondition.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import sql, { Sql, raw } from "sql-template-tag";
+import sql, { Sql, raw } from "../../../utils/sqlTag";
 import { Conditions } from "../../Conditions";
 import type { ConditionLike } from "../../expressions/ConditionLike";
 import { LogicalCondition } from "../../expressions/LogicalCondition";

--- a/src/core/query-builder/expression/ColumnExpression.ts
+++ b/src/core/query-builder/expression/ColumnExpression.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import sql, { Sql, raw } from "sql-template-tag";
+import sql, { Sql, raw } from "../../../utils/sqlTag";
 import { ColumnCondition } from "../condition/ColumnCondition";
 import { OrmError } from "../../../errors/OrmError";
 import { OrmErrorCode } from "../../../errors/OrmErrorCode";

--- a/src/core/query-builder/join/JoinOnBuilder.ts
+++ b/src/core/query-builder/join/JoinOnBuilder.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import sql, { Sql, raw } from "sql-template-tag";
+import sql, { Sql, raw } from "../../../utils/sqlTag";
 import { Conditions } from "../../Conditions";
 import { OrmError } from "../../../errors/OrmError";
 import { OrmErrorCode } from "../../../errors/OrmErrorCode";

--- a/src/core/query-builder/where-group/WhereGroupBuilder.ts
+++ b/src/core/query-builder/where-group/WhereGroupBuilder.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import sql, { Sql, raw } from "sql-template-tag";
+import sql, { Sql, raw } from "../../../utils/sqlTag";
 import { Conditions } from "../../Conditions";
 import {
   isConditionLike,

--- a/src/decorators/Column.ts
+++ b/src/decorators/Column.ts
@@ -200,7 +200,30 @@ export type ResolvedColumnOption = Required<
  */
 export function inferColumnDefaults(
   designType: any,
+  where?: string,
 ): Pick<ResolvedColumnOption, "type" | "length" | "nullable"> {
+  return resolveColumnDefaults(designType, where, false);
+}
+
+/**
+ * Shared implementation behind `inferColumnDefaults`.
+ *
+ * `hasExplicitType` marks columns whose `@Column({ type })` was given by the
+ * user, so inference is only filling in length/nullable:
+ * - no fallback warnings are emitted (the fallback type is discarded anyway)
+ * - when design:type metadata is missing entirely (builds without
+ *   emitDecoratorMetadata: esbuild, tsx, swc, Vite), `nullable` defaults to
+ *   `false` — what tsc-built code produces for String/Number/Boolean/Date
+ *   properties — instead of silently drifting to `nullable: true`.
+ * When design:type metadata is present, behavior is identical in both modes
+ * so tsc-compiled entities are unaffected.
+ */
+function resolveColumnDefaults(
+  designType: any,
+  where: string | undefined,
+  hasExplicitType: boolean,
+): Pick<ResolvedColumnOption, "type" | "length" | "nullable"> {
+  const at = where ? ` for ${where}` : "";
   switch (designType) {
     case String:
       return { type: "varchar", length: 255, nullable: false };
@@ -212,11 +235,30 @@ export function inferColumnDefaults(
       return { type: "datetime", length: 0, nullable: false };
     case Buffer:
       return { type: "blob", length: 0, nullable: true };
-    default:
+    case undefined:
+    case null:
+      if (hasExplicitType) {
+        return { type: "text", length: 0, nullable: false };
+      }
+      // design:type is missing entirely: the code was compiled without
+      // emitDecoratorMetadata (esbuild, tsx, swc and Vite do not emit it),
+      // or reflect-metadata was not imported before the entity was loaded.
       columnLogger.warn(
-        `Unknown design:type "${designType?.name ?? designType}" — falling back to "text". ` +
-        `Specify an explicit type in @Column({ type: "..." }) to avoid this.`,
+        `No design:type metadata${at} — falling back to "text". ` +
+        `Decorator metadata is not emitted by your build tool (esbuild/tsx/swc/Vite) ` +
+        `or "reflect-metadata" was imported too late. ` +
+        `Fix: compile with emitDecoratorMetadata (tsc/ts-node), specify an explicit ` +
+        `@Column({ type: "..." }), or define the entity with defineEntity().`,
       );
+      return { type: "text", length: 0, nullable: true };
+    default:
+      if (!hasExplicitType) {
+        columnLogger.warn(
+          `Unknown design:type "${designType?.name ?? designType}"${at} — falling back to "text". ` +
+          `Union and optional property types erase to Object at runtime; ` +
+          `specify an explicit type in @Column({ type: "..." }) to avoid this.`,
+        );
+      }
       return { type: "text", length: 0, nullable: true };
   }
 }
@@ -241,7 +283,13 @@ export function Column(option?: ColumnOption): PropertyDecorator {
     // Infer defaults from design:type, then overlay user options.
     // If the user overrides type without specifying length, discard the
     // inferred length (e.g. String → 255) because it is invalid for the new type (e.g. date).
-    const defaults = inferColumnDefaults(injectParam);
+    // With an explicit type no inference (and no missing-metadata warning) is needed.
+    const where = `${target.constructor?.name ?? "?"}.${propertyKey.toString()}`;
+    const defaults = resolveColumnDefaults(
+      injectParam,
+      where,
+      option?.type !== undefined,
+    );
     const typeOverridden =
       option?.type !== undefined && option.type !== defaults.type;
     const lengthNotProvided = option?.length === undefined;

--- a/src/dialects/DialectExpression.ts
+++ b/src/dialects/DialectExpression.ts
@@ -1,4 +1,4 @@
-import type { Sql } from "sql-template-tag";
+import type { Sql } from "../utils/sqlTag";
 import type { DialectName } from "../core/ColumnTypeRegistry";
 import { PostgresExpression } from "./expression/PostgresExpression";
 import { MySqlExpression } from "./expression/MySqlExpression";

--- a/src/dialects/FindOption.ts
+++ b/src/dialects/FindOption.ts
@@ -1,6 +1,6 @@
 import { ISelectOption } from "./ISelectOption";
 import { IOrderBy } from "./IOrderBy";
-import { Sql } from "sql-template-tag";
+import { Sql } from "../utils/sqlTag";
 
 /**
  * Pessimistic lock modes for SELECT queries.

--- a/src/dialects/IQueryEngine.ts
+++ b/src/dialects/IQueryEngine.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { Sql } from "sql-template-tag";
+import { Sql } from "../utils/sqlTag";
 import { ITxEngine } from "./ITxEngine";
 import { TRANSACTION_ISOLATION_LEVEL } from "./IsolationLevel";
 

--- a/src/dialects/SqlDriver.ts
+++ b/src/dialects/SqlDriver.ts
@@ -3,7 +3,7 @@ import { ColumnType } from "../decorators/Column";
 import { ColumnMetadata } from "../scanner/ColumnScanner";
 import { MysqlSchemaInterface } from "./mysql/BaseSchema";
 import type { DriverQueryOptions } from "../types/DriverQueryOptions";
-import type { Sql } from "sql-template-tag";
+import type { Sql } from "../utils/sqlTag";
 import type { DbVersion } from "./DbVersion";
 import type { CommonCapabilities } from "./DialectCapabilities";
 

--- a/src/dialects/TransactionSessionManager.ts
+++ b/src/dialects/TransactionSessionManager.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { Sql } from "sql-template-tag";
+import { Sql } from "../utils/sqlTag";
 import { DatabaseClient } from "../DatabaseClient";
 import { IConnector } from "../core/IConnector";
 import { IDataSource } from "./IDataSource";

--- a/src/dialects/expression/MySqlExpression.ts
+++ b/src/dialects/expression/MySqlExpression.ts
@@ -1,5 +1,5 @@
-import sql, { raw, join } from "sql-template-tag";
-import type { Sql } from "sql-template-tag";
+import sql, { raw, join } from "../../utils/sqlTag";
+import type { Sql } from "../../utils/sqlTag";
 import type {
   AggregateFilterOptions,
   ArrayOperator,

--- a/src/dialects/expression/PostgresExpression.ts
+++ b/src/dialects/expression/PostgresExpression.ts
@@ -1,5 +1,5 @@
-import sql, { raw, join } from "sql-template-tag";
-import type { Sql, RawValue } from "sql-template-tag";
+import sql, { raw, join } from "../../utils/sqlTag";
+import type { Sql, RawValue } from "../../utils/sqlTag";
 import type {
   AggregateFilterOptions,
   ArrayOperator,

--- a/src/dialects/expression/SqliteExpression.ts
+++ b/src/dialects/expression/SqliteExpression.ts
@@ -1,5 +1,5 @@
-import sql, { raw } from "sql-template-tag";
-import type { Sql } from "sql-template-tag";
+import sql, { raw } from "../../utils/sqlTag";
+import type { Sql } from "../../utils/sqlTag";
 import { inlineFlagPrefix } from "../../core/expressions/RegexPattern";
 import type {
   AggregateFilterOptions,

--- a/src/dialects/mysql/MySqlConnector.ts
+++ b/src/dialects/mysql/MySqlConnector.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import type { Pool, PoolConnection } from "mysql2";
-import sql, { Sql } from "sql-template-tag";
+import sql, { Sql } from "../../utils/sqlTag";
 import { Logger } from "../../utils/Logger";
 import { Connection } from "./Connection";
 import { TRANSACTION_ISOLATION_LEVEL } from "../IsolationLevel";
@@ -28,11 +28,14 @@ export class MySqlConnector extends IConnector {
     try {
       let mysql: typeof import("mysql2");
       try {
-        mysql = require("mysql2");
+        // import() works in both builds: transpiled to require() in CJS,
+        // kept as a real dynamic import in ESM (where require() does not exist).
+        const mysqlModule: any = await import("mysql2");
+        mysql = mysqlModule.default ?? mysqlModule;
       } catch {
         throw new OrmError(
           OrmErrorCode.MISSING_DEPENDENCY,
-          "mysql2 패키지가 필요합니다.",
+          "The mysql2 package is required.",
           "Run: npm install mysql2",
         );
       }
@@ -95,7 +98,7 @@ export class MySqlConnector extends IConnector {
       if (e instanceof OrmError) throw e;
       throw new OrmError(
         OrmErrorCode.CONNECTION_FAILED,
-        `MySQL 연결에 실패했습니다. ${e}`,
+        `Failed to connect to MySQL. ${e}`,
         "Check that the MySQL server is running and reachable",
       );
     }

--- a/src/dialects/mysql/MySqlDriver.ts
+++ b/src/dialects/mysql/MySqlDriver.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import sql, { join, raw, Sql } from "sql-template-tag";
+import sql, { join, raw, Sql } from "../../utils/sqlTag";
 import { IConnector } from "../../core/IConnector";
 import { MysqlSchemaInterface } from "./BaseSchema";
 import { ColumnOption, ColumnType } from "../../decorators";

--- a/src/dialects/postgres/PostgresConnector.ts
+++ b/src/dialects/postgres/PostgresConnector.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import type { Pool, PoolClient } from "pg";
-import { Sql } from "sql-template-tag";
+import { Sql } from "../../utils/sqlTag";
 import { Logger } from "../../utils/Logger";
 import { TRANSACTION_ISOLATION_LEVEL } from "../IsolationLevel";
 import { ConnectionNotFound } from "./ConnectionNotFound";
@@ -66,11 +66,14 @@ export class PostgresConnector extends IConnector {
     try {
       let PgPool: typeof import("pg").Pool;
       try {
-        PgPool = require("pg").Pool;
+        // import() works in both builds: transpiled to require() in CJS,
+        // kept as a real dynamic import in ESM (where require() does not exist).
+        const pgModule: any = await import("pg");
+        PgPool = (pgModule.default ?? pgModule).Pool;
       } catch {
         throw new OrmError(
           OrmErrorCode.MISSING_DEPENDENCY,
-          "pg 패키지가 필요합니다.",
+          "The pg package is required.",
           "Run: npm install pg",
         );
       }
@@ -132,7 +135,7 @@ export class PostgresConnector extends IConnector {
       if (e instanceof OrmError) throw e;
       throw new OrmError(
         OrmErrorCode.CONNECTION_FAILED,
-        `PostgreSQL 연결에 실패했습니다. ${e}`,
+        `Failed to connect to PostgreSQL. ${e}`,
         "Check that the PostgreSQL server is running and reachable",
       );
     }

--- a/src/dialects/postgres/PostgresDataSource.ts
+++ b/src/dialects/postgres/PostgresDataSource.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { Sql } from "sql-template-tag";
+import { Sql } from "../../utils/sqlTag";
 import { IConnector } from "../../core/IConnector";
 import { IDataSource } from "../IDataSource";
 import { TRANSACTION_ISOLATION_LEVEL } from "../IsolationLevel";

--- a/src/dialects/postgres/PostgresDriver.ts
+++ b/src/dialects/postgres/PostgresDriver.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import sql, { join, raw, Sql } from "sql-template-tag";
+import sql, { join, raw, Sql } from "../../utils/sqlTag";
 import { IConnector } from "../../core/IConnector";
 import { MysqlSchemaInterface } from "../mysql/BaseSchema";
 import { ColumnOption, ColumnType } from "../../decorators";
@@ -262,7 +262,7 @@ export class PostgresDriver implements ISqlDriver {
 
     if (!rows || rows.length === 0) {
       throw new Exception(
-        `테이블 "${tableName}"에서 PRIMARY KEY 제약조건을 찾을 수 없습니다.`,
+        `No PRIMARY KEY constraint found on table "${tableName}".`,
         404,
       );
     }
@@ -305,7 +305,7 @@ export class PostgresDriver implements ISqlDriver {
 
     if (!rows || rows.length === 0) {
       throw new Exception(
-        `테이블 "${tableName}"의 컬럼 "${columnName}"에 대한 UNIQUE 제약조건을 찾을 수 없습니다.`,
+        `No UNIQUE constraint found for column "${columnName}" on table "${tableName}".`,
         404,
       );
     }
@@ -391,7 +391,7 @@ export class PostgresDriver implements ISqlDriver {
 
     if (!rows || rows.length === 0) {
       throw new Exception(
-        `테이블 "${tableName}"의 컬럼 "${columnName}"에 대한 FOREIGN KEY 제약조건을 찾을 수 없습니다.`,
+        `No FOREIGN KEY constraint found for column "${columnName}" on table "${tableName}".`,
         404,
       );
     }

--- a/src/dialects/sqlite/SqliteConnector.ts
+++ b/src/dialects/sqlite/SqliteConnector.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import type Database from "better-sqlite3";
-import { Sql } from "sql-template-tag";
+import { Sql } from "../../utils/sqlTag";
 import { Logger } from "../../utils/Logger";
 import { TRANSACTION_ISOLATION_LEVEL } from "../IsolationLevel";
 import { ConnectionNotFound } from "./ConnectionNotFound";
@@ -45,11 +45,14 @@ export class SqliteConnector extends IConnector {
     try {
       let DatabaseConstructor: typeof Database;
       try {
-        DatabaseConstructor = require("better-sqlite3");
+        // import() works in both builds: transpiled to require() in CJS,
+        // kept as a real dynamic import in ESM (where require() does not exist).
+        const sqliteModule: any = await import("better-sqlite3");
+        DatabaseConstructor = sqliteModule.default ?? sqliteModule;
       } catch {
         throw new OrmError(
           OrmErrorCode.MISSING_DEPENDENCY,
-          "better-sqlite3 패키지가 필요합니다.",
+          "The better-sqlite3 package is required.",
           "Run: npm install better-sqlite3",
         );
       }

--- a/src/dialects/sqlite/SqliteDataSource.ts
+++ b/src/dialects/sqlite/SqliteDataSource.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { Sql } from "sql-template-tag";
+import { Sql } from "../../utils/sqlTag";
 import { IConnector } from "../../core/IConnector";
 import { IDataSource } from "../IDataSource";
 import { TRANSACTION_ISOLATION_LEVEL } from "../IsolationLevel";

--- a/src/dialects/sqlite/SqliteDriver.ts
+++ b/src/dialects/sqlite/SqliteDriver.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import sql, { join, raw, Sql } from "sql-template-tag";
+import sql, { join, raw, Sql } from "../../utils/sqlTag";
 import { IConnector } from "../../core/IConnector";
 import { MysqlSchemaInterface } from "../mysql/BaseSchema";
 import { ColumnOption, ColumnType } from "../../decorators";

--- a/src/errors/DatabaseConnectionFailedError.ts
+++ b/src/errors/DatabaseConnectionFailedError.ts
@@ -12,8 +12,8 @@ export class DatabaseConnectionFailedError extends Exception {
           : undefined;
     super(
       detail
-        ? `데이터베이스 연결에 실패했습니다: ${detail}`
-        : "데이터베이스 연결에 실패했습니다.",
+        ? `Failed to connect to the database: ${detail}`
+        : "Failed to connect to the database.",
       500,
     );
     if (originalError !== undefined) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -738,5 +738,6 @@ export { generateUUIDv7, extractTimestampFromUUIDv7 } from "./utils/uuid-v7";
 // Kept public deliberately: `sql`/`raw`/`join`/`empty` appear in documented
 // updateMany examples and `Sql` is the accepted parameter type there, so the
 // coupling is part of the existing contract. Revisit wrapping it behind an
-// owned type in a future major.
-export { default as sql, Sql, raw, join, empty } from "sql-template-tag";
+// owned type in a future major. Routed through the sqlTag wrapper so the
+// `sql` default stays a function in the ESM build (see utils/sqlTag.ts).
+export { default as sql, Sql, raw, join, empty } from "./utils/sqlTag";

--- a/src/introspection/IntrospectionGenerator.ts
+++ b/src/introspection/IntrospectionGenerator.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import sql, { join, raw } from "sql-template-tag";
+import sql, { join, raw } from "../utils/sqlTag";
 import { IntrospectionDialect, IntrospectionTypeMapper } from "./TypeMapper";
 
 /**

--- a/src/types/class-transformer-storage.d.ts
+++ b/src/types/class-transformer-storage.d.ts
@@ -1,0 +1,6 @@
+/**
+ * class-transformer ships no types for its internal cjs/storage module.
+ * ClassTransformerDeserializer reaches into it for the fast-path metadata
+ * probe (same approach as @nestjs/swagger) and validates the shape at runtime.
+ */
+declare module "class-transformer/cjs/storage";

--- a/src/utils/resolveEntityGlobs.ts
+++ b/src/utils/resolveEntityGlobs.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-require-imports */
+import { pathToFileURL } from "url";
 import { OrmError } from "../errors/OrmError";
 import { OrmErrorCode } from "../errors/OrmErrorCode";
 import { Logger } from "./Logger";
@@ -38,10 +39,13 @@ export async function resolveEntityGlobs(
     return classRefs;
   }
 
-  // Dynamically require fast-glob (optional peer dependency)
+  // Dynamically load fast-glob (optional peer dependency).
+  // `import()` works in both builds: the CJS build transpiles it to require(),
+  // the ESM build keeps it as a real dynamic import (require() does not exist there).
   let fg: { sync: (patterns: string[], options?: any) => string[] };
   try {
-    fg = require("fast-glob");
+    const fgModule: any = await import("fast-glob");
+    fg = fgModule.default ?? fgModule;
   } catch {
     throw new OrmError(
       OrmErrorCode.MISSING_DEPENDENCY,
@@ -69,16 +73,29 @@ export async function resolveEntityGlobs(
 
   for (const filePath of matched) {
     try {
-      const mod = require(filePath);
+      // CJS build: import() transpiles to require(), which needs a plain path.
+      // ESM build: real import(), which needs a file:// URL to work on every OS
+      // and can load both ESM and CJS entity files.
+      const specifier =
+        typeof require === "function"
+          ? filePath
+          : pathToFileURL(filePath).href;
+      const mod: any = await import(specifier);
 
-      for (const exportKey of Object.keys(mod)) {
-        const value = mod[exportKey];
-        if (typeof value === "function" && ReflectManager.isEntity(value)) {
-          resolved.push(value);
+      const namespaces: any[] = [mod];
+      if (mod.default && typeof mod.default === "object") {
+        namespaces.push(mod.default);
+      }
+      for (const ns of namespaces) {
+        for (const exportKey of Object.keys(ns)) {
+          const value = ns[exportKey];
+          if (typeof value === "function" && ReflectManager.isEntity(value)) {
+            resolved.push(value);
+          }
         }
       }
     } catch (err: any) {
-      logger.warn(`Failed to require "${filePath}": ${err.message ?? err}`);
+      logger.warn(`Failed to load "${filePath}": ${err.message ?? err}`);
     }
   }
 

--- a/src/utils/sqlTag.ts
+++ b/src/utils/sqlTag.ts
@@ -1,0 +1,28 @@
+import sqlDefault, {
+  Sql,
+  raw,
+  join,
+  empty,
+  type RawValue,
+} from "sql-template-tag";
+
+/**
+ * Interop-safe access to sql-template-tag for both build outputs.
+ *
+ * sql-template-tag v4 is a CommonJS package that assigns
+ * `exports.default = sql`. The CJS build's `__importDefault` unwraps that
+ * correctly, but plain Node ESM sets the default binding to `module.exports`
+ * itself — an object whose `.default` holds the tag function. Every module
+ * in this codebase therefore imports the tag through this wrapper, which
+ * unwraps whichever shape arrives. Do not import "sql-template-tag" directly
+ * (guarded by __tests__/unit/sql-template-tag-wrapper.test.ts).
+ */
+const sqlAny = sqlDefault as unknown;
+const sql: typeof sqlDefault =
+  typeof sqlAny === "function"
+    ? (sqlAny as typeof sqlDefault)
+    : (sqlAny as { default: typeof sqlDefault }).default;
+
+export default sql;
+export { sql, Sql, raw, join, empty };
+export type { RawValue };


### PR DESCRIPTION
Investigated real-world usage without NestJS by running a packed tarball inside an Express 5 app (CJS and ESM) and fixed everything that surfaced.

## Fixed

- **ESM build was unusable under plain Node.** `dist/esm` was not marked `"type": "module"`, relative specifiers had no extensions, runtime `require()` calls threw `ReferenceError` (drivers surfaced it as a bogus "package is required" error), and the CJS-only `sql-template-tag` default import resolved to `module.exports` instead of the tag function. Fixes: `scripts/fix-esm.js` post-build step, `utils/sqlTag.ts` interop wrapper (all 69 importers routed through it, guarded by a unit test), lazy loads converted to `import()`, `DeserializerRegistry.ensureDefaultDetected()` awaited in `register()`.
- **Silent column degradation without `emitDecoratorMetadata`** (tsx/esbuild/swc/Vite): explicit-type columns no longer warn and keep `NOT NULL` matching tsc builds; remaining warnings name the property and diagnose the cause. Behavior with metadata present is unchanged.
- **`DatabaseClient.connect()` silently replaced a same-name connection** and leaked the old connector — now closes it and logs an actionable warning.
- **Connection-path error messages were Korean** — now English.

## Added

- `docs/express.md` + `docs/ko/express.md` (bootstrap order, repositories, transactions without DI, error middleware, graceful shutdown, tenant middleware, build-tool constraints), troubleshooting entries, sidebar/nav links.

## Verification

- Unit suite green (new suites: column-no-design-type, fix-esm-rewrite, database-client-reconnect-warning, sql-template-tag-wrapper), SQLite integration suite green, docs build green.
- Express 5 probe app on the packed tarball, both CJS and ESM: CRUD, `@Transactional` rollback, 20/20 concurrent writes, concurrent-transaction integrity, tenant context propagation 30/30, graceful shutdown.