### PR TITLE
refactor(core): type-safety sweep round 2 — SQB em seam, RelationLoader typing, buffer error codes (V2-T2-2)

### DIFF
--- a/src/core/RelationLoader.ts
+++ b/src/core/RelationLoader.ts
@@ -11,6 +11,13 @@ import { EntityManagerInternals } from "./EntityManagerInternals";
 import { Conditions } from "./Conditions";
 
 /**
+ * A loaded entity instance viewed as a property-indexable record. Relation
+ * loading reads parent PKs and writes loaded relations by property key onto
+ * instances the caller typed as `T`; this alias names that dynamic access.
+ */
+type EntityRecord = Record<string, unknown>;
+
+/**
  * Handler for relation sub-query loading (OneToMany, ManyToMany, OneToOne).
  * Invoked on behalf of EntityManager.
  *
@@ -23,16 +30,31 @@ export class RelationLoader {
   ) {}
 
   /**
+   * Normalizes the caller's parent result(s) into an array of indexable
+   * records — the single widening point for the dynamic property access
+   * every loader below performs.
+   */
+  private toParentRecords<T>(parentResults: T | T[]): EntityRecord[] {
+    const parents = Array.isArray(parentResults)
+      ? parentResults
+      : [parentResults];
+    return parents as unknown as EntityRecord[];
+  }
+
+  /**
    * Reads a parent's PK value by property name (falling back to the DB
    * column name for metadata without a propertyKey).
    */
-  private parentIdOf(parent: unknown, pk: ColumnMetadata): any {
-    return (parent as any)[pk.propertyKey ?? pk.name];
+  private parentIdOf(parent: EntityRecord, pk: ColumnMetadata): unknown {
+    return parent[pk.propertyKey ?? pk.name];
   }
 
   /** Collects the non-null PK value of every parent. */
-  private collectParentIds(parents: unknown[], pk: ColumnMetadata): any[] {
-    const ids: any[] = [];
+  private collectParentIds(
+    parents: EntityRecord[],
+    pk: ColumnMetadata,
+  ): unknown[] {
+    const ids: unknown[] = [];
     for (const parent of parents) {
       const id = this.parentIdOf(parent, pk);
       if (id !== undefined && id !== null) ids.push(id);
@@ -71,9 +93,7 @@ export class RelationLoader {
     );
     if (!pk) return;
 
-    const parents = Array.isArray(parentResults)
-      ? parentResults
-      : [parentResults];
+    const parents = this.toParentRecords(parentResults);
 
     for (const rel of oneToManyMeta) {
       if (!relations.includes(rel.propertyKey)) continue;
@@ -98,7 +118,7 @@ export class RelationLoader {
 
       if (parentIds.length === 0) {
         for (const parent of parents) {
-          (parent as any)[rel.propertyKey] = [];
+          parent[rel.propertyKey] = [];
         }
         continue;
       }
@@ -154,7 +174,7 @@ export class RelationLoader {
       const resultTransformer = ResultTransformerFactory.create();
 
       if (queryResult.results && queryResult.results.length > 0) {
-        const rows = queryResult.results as any[];
+        const rows = queryResult.results;
         // Strip the FK alias before hydration, then bulk-deserialize. The query
         // has no JOINs, so toEntities() is 1:1 and order-preserving with rows —
         // letting us read each child's FK from the raw row by index.
@@ -183,7 +203,7 @@ export class RelationLoader {
       // 4. Assign the matching child array to each parent
       for (const parent of parents) {
         const parentId = this.parentIdOf(parent, pk);
-        (parent as any)[rel.propertyKey] = childrenByParentId.get(parentId) ?? [];
+        parent[rel.propertyKey] = childrenByParentId.get(parentId) ?? [];
       }
     }
   }
@@ -219,9 +239,7 @@ export class RelationLoader {
     );
     if (!pk) return;
 
-    const parents = Array.isArray(parentResults)
-      ? parentResults
-      : [parentResults];
+    const parents = this.toParentRecords(parentResults);
 
     for (const rel of manyToManyMeta) {
       if (!relations.includes(rel.propertyKey)) continue;
@@ -245,7 +263,7 @@ export class RelationLoader {
 
       if (parentIds.length === 0) {
         for (const parent of parents) {
-          (parent as any)[rel.propertyKey] = [];
+          parent[rel.propertyKey] = [];
         }
         continue;
       }
@@ -344,7 +362,7 @@ export class RelationLoader {
       // 4. Assign the matching child array to each parent
       for (const parent of parents) {
         const parentId = this.parentIdOf(parent, pk);
-        (parent as any)[rel.propertyKey] = childrenByParentId.get(parentId) ?? [];
+        parent[rel.propertyKey] = childrenByParentId.get(parentId) ?? [];
       }
     }
   }
@@ -377,9 +395,7 @@ export class RelationLoader {
     );
     if (!pk) return;
 
-    const parents = Array.isArray(parentResults)
-      ? parentResults
-      : [parentResults];
+    const parents = this.toParentRecords(parentResults);
 
     for (const rel of oneToOneMeta) {
       if (!relations.includes(rel.propertyKey)) continue;
@@ -407,7 +423,7 @@ export class RelationLoader {
 
         if (!ownerRel?.joinColumn) {
           for (const parent of parents) {
-            (parent as any)[rel.propertyKey] = null;
+            parent[rel.propertyKey] = null;
           }
           continue;
         }
@@ -424,7 +440,7 @@ export class RelationLoader {
 
         if (parentIds.length === 0) {
           for (const parent of parents) {
-            (parent as any)[rel.propertyKey] = null;
+            parent[rel.propertyKey] = null;
           }
           continue;
         }
@@ -480,11 +496,11 @@ export class RelationLoader {
 
         if (queryResult.results && queryResult.results.length > 0) {
           for (const row of queryResult.results) {
-            const fkValue = (row as any)[fkAlias];
+            const fkValue = row[fkAlias];
             if (fkValue === undefined || fkValue === null) continue;
 
             const entityRow = { ...row };
-            delete (entityRow as any)[fkAlias];
+            delete entityRow[fkAlias];
             const [related] = resultTransformer.toEntities(RelatedEntity, {
               results: [entityRow],
             } as QueryResult);
@@ -498,11 +514,11 @@ export class RelationLoader {
         // 4. Assign the matching related entity to each parent
         for (const parent of parents) {
           const parentId = this.parentIdOf(parent, pk);
-          (parent as any)[rel.propertyKey] = relatedByParentId.get(parentId) ?? null;
+          parent[rel.propertyKey] = relatedByParentId.get(parentId) ?? null;
         }
       } else {
         for (const parent of parents) {
-          (parent as any)[rel.propertyKey] = null;
+          parent[rel.propertyKey] = null;
         }
       }
     }

--- a/src/core/SelectQueryBuilder.ts
+++ b/src/core/SelectQueryBuilder.ts
@@ -106,6 +106,7 @@ import type { InheritanceStrategy } from "../decorators/Inheritance";
 import type { ColumnMetadata } from "../scanner/ColumnScanner";
 import type { DialectExpression } from "../dialects/DialectExpression";
 import type { RelationMetadataResolver } from "./RelationMetadataResolver";
+import type { EntityManagerInternals } from "./EntityManagerInternals";
 import type { EntityScannerMetadata } from "../scanner";
 import { JoinOnBuilder } from "./query-builder/join/JoinOnBuilder";
 import {
@@ -170,6 +171,25 @@ export { WhereGroupBuilder };
 export type { RowValidator, ArrayValidator, WhereOperator };
 
 /**
+ * Narrow, typed view of the `EntityManager` internals this builder reads.
+ *
+ * `EntityManager` keeps `resolver` and `_ctx` private on its public type, so
+ * the builder narrows through {@link SelectQueryBuilder.emInternals} — a
+ * single sanctioned cast — instead of scattering `as any` at every access
+ * site. Members mirror the real EntityManager, which always carries them;
+ * the runtime guards at the call sites stay in place because query-builder
+ * unit tests construct partial EM doubles that may omit any of these.
+ */
+interface EntityManagerInternalView {
+  readonly resolver: RelationMetadataResolver;
+  readonly _ctx: EntityManagerInternals;
+  emitAfterLoad(
+    entityClass: ClazzType<unknown>,
+    entities: unknown,
+  ): Promise<void>;
+}
+
+/**
  * Type-safe column reference: entity property keys (string keys only).
  */
 type ColumnOf<T> = keyof T & string;
@@ -214,6 +234,15 @@ export class SelectQueryBuilder<T, TResult = T> {
   protected readonly alias: string;
   protected readonly entity: ClazzType<T>;
   protected readonly em: EntityManager;
+
+  /**
+   * Single narrowing point for the EntityManager internals (see
+   * {@link EntityManagerInternalView}). Read live on every access — never
+   * cached — so test-time reassignment of `em.resolver` etc. is honored.
+   */
+  private get emInternals(): EntityManagerInternalView {
+    return this.em as unknown as EntityManagerInternalView;
+  }
 
   protected selectColumns: string[] | "*" = "*";
   protected distinct = false;
@@ -354,7 +383,7 @@ export class SelectQueryBuilder<T, TResult = T> {
   setPropertyToColumnMap(map: Map<string, string>): this {
     this.propertyToColumnMap = map;
     // Also register main entity in alias registry
-    const resolver = (this.em as any).resolver as RelationMetadataResolver | undefined;
+    const resolver = this.emInternals.resolver;
     if (resolver) {
       const metadata = resolver.resolveEntityMetadata(this.entity);
       if (metadata) {
@@ -623,7 +652,7 @@ export class SelectQueryBuilder<T, TResult = T> {
    * `ilike` / `search` operators render correctly.
    */
   private whereClauseResolverOptions(): WhereResolverOptions {
-    const ctx = (this.em as any)._ctx;
+    const ctx = this.emInternals._ctx;
     const dialect: "mysql" | "postgres" | "sqlite" = ctx?.isMySqlFamily?.()
       ? "mysql"
       : ctx?.isSqlite?.()
@@ -733,9 +762,7 @@ export class SelectQueryBuilder<T, TResult = T> {
       const prop = col.propertyKey ?? col.name;
       map.set(prop, col.name);
     }
-    const resolver = (this.em as any).resolver as
-      | RelationMetadataResolver
-      | undefined;
+    const resolver = this.emInternals.resolver;
     if (
       metadata.target &&
       typeof resolver?.collectFkPropertyMappings === "function"
@@ -1466,7 +1493,7 @@ export class SelectQueryBuilder<T, TResult = T> {
     onBuilder: (join: JoinOnBuilder) => JoinOnBuilder,
     andSelect = false,
   ): this {
-    const resolver = (this.em as any).resolver as RelationMetadataResolver;
+    const resolver = this.emInternals.resolver;
     if (!resolver) {
       throw new OrmError(
         OrmErrorCode.ENTITY_METADATA_NOT_FOUND,
@@ -1526,7 +1553,7 @@ export class SelectQueryBuilder<T, TResult = T> {
     property: string;
     kind: "many-to-one" | "one-to-one" | "one-to-many";
   } | null {
-    const resolver = (this.em as any).resolver as RelationMetadataResolver;
+    const resolver = this.emInternals.resolver;
     if (!resolver) return null;
 
     const m2o = resolver
@@ -1610,9 +1637,7 @@ export class SelectQueryBuilder<T, TResult = T> {
     ) {
       return star;
     }
-    const resolver = (this.em as any).resolver as
-      | RelationMetadataResolver
-      | undefined;
+    const resolver = this.emInternals.resolver;
     const rootMeta = resolver?.resolveEntityMetadata?.(this.entity);
     if (!rootMeta) return star;
 
@@ -1637,7 +1662,7 @@ export class SelectQueryBuilder<T, TResult = T> {
     alias: string,
     andSelect = false,
   ): this {
-    const resolver = (this.em as any).resolver as RelationMetadataResolver;
+    const resolver = this.emInternals.resolver;
     if (!resolver) {
       throw new OrmError(
         OrmErrorCode.ENTITY_METADATA_NOT_FOUND,
@@ -1884,7 +1909,7 @@ export class SelectQueryBuilder<T, TResult = T> {
     mode: "exists" | "count",
     fn?: (subQb: SelectQueryBuilder<any, any>) => void,
   ): Sql {
-    const resolver = (this.em as any).resolver as RelationMetadataResolver;
+    const resolver = this.emInternals.resolver;
     if (!resolver) {
       throw new OrmError(
         OrmErrorCode.ENTITY_METADATA_NOT_FOUND,
@@ -2315,7 +2340,7 @@ export class SelectQueryBuilder<T, TResult = T> {
    * Add FOR SHARE lock.
    */
   forShare(): this {
-    const internals = (this.em as any)._ctx;
+    const internals = this.emInternals._ctx;
     this.lockClause = internals.isMySqlFamily()
       ? "LOCK IN SHARE MODE"
       : "FOR SHARE";
@@ -2344,7 +2369,7 @@ export class SelectQueryBuilder<T, TResult = T> {
    * Add FOR SHARE NOWAIT lock (MySQL 8.0+, PostgreSQL 9.5+).
    */
   forShareNowait(): this {
-    const internals = (this.em as any)._ctx;
+    const internals = this.emInternals._ctx;
     this.lockClause = internals.isMySqlFamily()
       ? "LOCK IN SHARE MODE NOWAIT"
       : "FOR SHARE NOWAIT";
@@ -2355,7 +2380,7 @@ export class SelectQueryBuilder<T, TResult = T> {
    * Add FOR SHARE SKIP LOCKED lock (MySQL 8.0+, PostgreSQL 9.5+).
    */
   forShareSkipLocked(): this {
-    const internals = (this.em as any)._ctx;
+    const internals = this.emInternals._ctx;
     this.lockClause = internals.isMySqlFamily()
       ? "LOCK IN SHARE MODE SKIP LOCKED"
       : "FOR SHARE SKIP LOCKED";
@@ -2936,7 +2961,7 @@ export class SelectQueryBuilder<T, TResult = T> {
     const qb = RawQueryBuilderFactory.create() as RawQueryBuilder;
 
     // Database type
-    const internals = (this.em as any)._ctx;
+    const internals = this.emInternals._ctx;
     if (internals.isMySqlFamily()) qb.setDatabaseType("mysql");
     else if (internals.isSqlite?.()) qb.setDatabaseType("sqlite");
     else qb.setDatabaseType("postgresql");
@@ -3019,7 +3044,7 @@ export class SelectQueryBuilder<T, TResult = T> {
 
     // Soft delete auto-filter (use local copy to avoid mutating shared state)
     const effectiveWhere = [...this.whereClauses];
-    const resolver = (this.em as any).resolver;
+    const resolver = this.emInternals.resolver;
     if (resolver) {
       const deletedAtColumn = resolver.getDeletedAtColumn(this.entity);
       if (deletedAtColumn && !this.withDeletedFlag) {
@@ -3170,7 +3195,7 @@ export class SelectQueryBuilder<T, TResult = T> {
    */
   protected async notifyAfterLoad(entities: TResult[]): Promise<void> {
     if (!entities?.length) return;
-    const emit = (this.em as any).emitAfterLoad;
+    const emit = this.emInternals.emitAfterLoad;
     if (typeof emit !== "function") return;
     await emit.call(this.em, this.entity, entities);
   }
@@ -3188,7 +3213,7 @@ export class SelectQueryBuilder<T, TResult = T> {
    */
   protected transformJoinedEntityRows(rows: any[]): TResult[] {
     const transformer = ResultTransformerFactory.create();
-    const resolver = (this.em as any).resolver as RelationMetadataResolver;
+    const resolver = this.emInternals.resolver;
     const rootMeta = resolver?.resolveEntityMetadata?.(this.entity);
     const pkNamesOf = (entity: ClazzType<any>): string[] => {
       const meta = resolver?.resolveEntityMetadata?.(entity);
@@ -3982,9 +4007,7 @@ export class SelectQueryBuilder<T, TResult = T> {
    * grouping in {@link transformJoinedEntityRows} (`options.primary`).
    */
   protected resolveRootPkColumns(): Array<{ name: string; propertyKey: string }> {
-    const resolver = (this.em as any).resolver as
-      | RelationMetadataResolver
-      | undefined;
+    const resolver = this.emInternals.resolver;
     const meta = resolver?.resolveEntityMetadata?.(this.entity);
     if (!meta) return [];
     const pks: Array<{ name: string; propertyKey: string }> = [];
@@ -4025,7 +4048,7 @@ export class SelectQueryBuilder<T, TResult = T> {
 
     // Soft delete auto-filter (re-derive, don't mutate shared state)
     const countWhere = [...this.whereClauses];
-    const resolver = (this.em as any).resolver;
+    const resolver = this.emInternals.resolver;
     if (resolver) {
       const deletedAtColumn = resolver.getDeletedAtColumn(this.entity);
       if (deletedAtColumn && !this.withDeletedFlag) {
@@ -4053,7 +4076,7 @@ export class SelectQueryBuilder<T, TResult = T> {
    * COUNT semantics.
    */
   async getCount(): Promise<number> {
-    const internals = (this.em as any)._ctx;
+    const internals = this.emInternals._ctx;
     const dbType = internals.isMySqlFamily()
       ? "mysql"
       : internals.isSqlite?.()
@@ -4122,7 +4145,7 @@ export class SelectQueryBuilder<T, TResult = T> {
     fn: "SUM" | "AVG" | "MIN" | "MAX",
     column: ColumnOf<T>,
   ): Promise<number> {
-    const internals = (this.em as any)._ctx;
+    const internals = this.emInternals._ctx;
     const dbType = internals.isMySqlFamily()
       ? "mysql"
       : internals.isSqlite?.()
@@ -4284,7 +4307,7 @@ export class SelectQueryBuilder<T, TResult = T> {
     offset: number,
     limit: number | undefined,
   ): Promise<Array<Record<string, unknown>>> {
-    const internals = (this.em as any)._ctx;
+    const internals = this.emInternals._ctx;
     const isMySql = internals.isMySqlFamily();
     const dbType = isMySql
       ? "mysql"
@@ -4425,7 +4448,7 @@ export class SelectQueryBuilder<T, TResult = T> {
     const tableName = this.resolveTableName();
     const qb = RawQueryBuilderFactory.create() as RawQueryBuilder;
 
-    const internals = (this.em as any)._ctx;
+    const internals = this.emInternals._ctx;
     if (internals.isMySqlFamily()) qb.setDatabaseType("mysql");
     else if (internals.isSqlite?.()) qb.setDatabaseType("sqlite");
     else qb.setDatabaseType("postgresql");
@@ -4450,7 +4473,7 @@ export class SelectQueryBuilder<T, TResult = T> {
 
     // Soft delete auto-filter (don't mutate shared state)
     const existsWhere = [...this.whereClauses];
-    const resolver = (this.em as any).resolver;
+    const resolver = this.emInternals.resolver;
     if (resolver) {
       const deletedAtColumn = resolver.getDeletedAtColumn(this.entity);
       if (deletedAtColumn && !this.withDeletedFlag) {
@@ -4488,7 +4511,7 @@ export class SelectQueryBuilder<T, TResult = T> {
    * @throws InvalidQueryError when the active driver does not support EXPLAIN.
    */
   async explain(): Promise<ExplainResult> {
-    const internals = (this.em as any)._ctx;
+    const internals = this.emInternals._ctx;
     const driver = internals.getDriver?.();
     if (!driver || !driver.supportsExplain()) {
       throw new InvalidQueryError(
@@ -4505,7 +4528,7 @@ export class SelectQueryBuilder<T, TResult = T> {
     // Reuse the dialect-aware parser EntityManager.explain() relies on so the
     // ExplainResult shape (rows/type/possibleKeys/key/cost) stays identical.
     const handler = new ExplainQueryHandler(
-      (this.em as any).resolver,
+      this.emInternals.resolver,
       internals,
     );
     return handler.parseExplainResult(rawRows ?? []);
@@ -4583,7 +4606,7 @@ export class SelectQueryBuilder<T, TResult = T> {
     alias: string,
   ): void {
     if (this.withoutTenantScopeFlag) return;
-    const internals = (this.em as any)._ctx;
+    const internals = this.emInternals._ctx;
     if (!internals?.buildTenantWhereClause) return;
     const predicate = internals.buildTenantWhereClause(entity, alias);
     if (predicate) whereAccumulator.push(predicate);
@@ -4662,7 +4685,7 @@ export class SelectQueryBuilder<T, TResult = T> {
   }
 
   protected resolveTableName(): string {
-    const resolver = (this.em as any).resolver;
+    const resolver = this.emInternals.resolver;
     if (!resolver) {
       throw new OrmError(
         OrmErrorCode.ENTITY_METADATA_NOT_FOUND,

--- a/src/core/plugin/buffer/CascadeProcessor.ts
+++ b/src/core/plugin/buffer/CascadeProcessor.ts
@@ -5,6 +5,8 @@ import { ONE_TO_ONE_TOKEN } from "../../../decorators/OneToOne";
 import { MANY_TO_MANY_TOKEN } from "../../../decorators/ManyToMany";
 import { MANY_TO_ONE_TOKEN } from "../../../decorators/ManyToOne";
 import { hasCascade } from "../../../types/CascadeType";
+import { OrmError } from "../../../errors/OrmError";
+import { OrmErrorCode } from "../../../errors/OrmErrorCode";
 import { PluginContext } from "../PluginContext";
 import { TrackedEntry, DeleteEntry } from "./BufferEntry";
 import {
@@ -660,8 +662,13 @@ export class CascadeProcessor {
             await this.collectCascadeDeletes(txEm, ChildEntity, grandChildCriteria, out, visited);
           }
         } catch (err) {
-          // Only swallow "not registered" / "table not found" errors — re-throw others
-          if (err instanceof Error && /not.*registered|no.*entity|table.*not/i.test(err.message)) {
+          // Only swallow "entity not registered" — re-throw others. (The old
+          // message regex also aimed at driver "table not found" errors, but
+          // no MySQL/PostgreSQL/SQLite driver message actually matched it.)
+          if (
+            err instanceof OrmError &&
+            err.code === OrmErrorCode.ENTITY_METADATA_NOT_FOUND
+          ) {
             // skip recursive cascade for unregistered entities
           } else {
             throw err;

--- a/src/core/plugin/buffer/IdentityMapManager.ts
+++ b/src/core/plugin/buffer/IdentityMapManager.ts
@@ -10,6 +10,8 @@ import {
 } from "../../../decorators/TenantColumn";
 import { ColumnMetadata } from "../../../scanner/ColumnScanner";
 import { FindOption } from "../../../dialects/FindOption";
+import { OrmError } from "../../../errors/OrmError";
+import { OrmErrorCode } from "../../../errors/OrmErrorCode";
 import { MetadataContext } from "../../../metadata/MetadataContext";
 import { InheritanceResolver } from "../../InheritanceResolver";
 import { PluginContext } from "../PluginContext";
@@ -191,12 +193,27 @@ export class IdentityMapManager {
   }
 
   /**
+   * Whether an entity class is registered with the EntityManager.
+   *
+   * The non-throwing predicate for callers that treat an unregistered class
+   * as "skip" (lazy injection, cascade walks) — use {@link validateEntity}
+   * only where an unregistered class is a caller error.
+   */
+  isRegistered(entityClass: ClazzType<any>): boolean {
+    return this.ctx.getEntities().includes(entityClass);
+  }
+
+  /**
    * Validate that an entity class is registered with the EntityManager.
+   *
+   * @throws OrmError with code `ENTITY_METADATA_NOT_FOUND` — callers that
+   *         need to distinguish this from other failures match on the code,
+   *         never on the message.
    */
   validateEntity(entityClass: ClazzType<any>): void {
-    const entities = this.ctx.getEntities();
-    if (!entities.includes(entityClass)) {
-      throw new Error(
+    if (!this.isRegistered(entityClass)) {
+      throw new OrmError(
+        OrmErrorCode.ENTITY_METADATA_NOT_FOUND,
         `Cannot track instance of "${entityClass.name}": not a registered entity. ` +
         `Make sure the class is decorated with @Entity() and registered with the EntityManager.`,
       );
@@ -339,7 +356,11 @@ export class IdentityMapManager {
     const pkParts = pkColumns.map((pk) => {
       const value = instance[pk];
       if (value === undefined || value === null) {
-        throw new Error(
+        // Code PRIMARY_KEY_NOT_FOUND — callers that swallow "no usable PK"
+        // (merge, detachByPk, identity-map probes) match on it, not on the
+        // message.
+        throw new OrmError(
+          OrmErrorCode.PRIMARY_KEY_NOT_FOUND,
           `Cannot track instance of "${entityClass.name}": PK column "${pk}" is ${value}. ` +
           `Only persisted entities with assigned PK values can be tracked. ` +
           `Use save() to queue new entities for insertion instead.`,

--- a/src/core/plugin/buffer/LazyRelationInjector.ts
+++ b/src/core/plugin/buffer/LazyRelationInjector.ts
@@ -113,7 +113,7 @@ export class LazyRelationInjector {
       if ((fkValue === undefined || fkValue === null) && !hydrateStub) continue;
 
       const RelatedEntity = rel.getMappingEntity() as any as ClazzType<any>;
-      try { this.idMap.validateEntity(RelatedEntity); } catch { continue; }
+      if (!this.idMap.isRegistered(RelatedEntity)) continue;
 
       const relatedPkCols = this.idMap.getColumnInfo(RelatedEntity).pkColumns;
       const refColumn = rel.references ?? (relatedPkCols.length === 1 ? relatedPkCols[0] : null);
@@ -156,7 +156,7 @@ export class LazyRelationInjector {
       if (isRelationOccupied(instance, rel.propertyKey)) continue;
 
       const ChildEntity = rel.getRelatedEntity();
-      try { this.idMap.validateEntity(ChildEntity); } catch { continue; }
+      if (!this.idMap.isRegistered(ChildEntity)) continue;
 
       const fkColumn = resolveFkColumn(rel, ChildEntity);
       const parentPk = this.idMap.getParentPkValue(instance, entityClass);
@@ -183,7 +183,7 @@ export class LazyRelationInjector {
       if (isRelationOccupied(instance, rel.propertyKey)) continue;
 
       const RelatedEntity = rel.getRelatedEntity();
-      try { this.idMap.validateEntity(RelatedEntity); } catch { continue; }
+      if (!this.idMap.isRegistered(RelatedEntity)) continue;
 
       if (rel.joinColumn) {
         // Owning side - FK column on this entity
@@ -245,7 +245,7 @@ export class LazyRelationInjector {
       if (isRelationOccupied(instance, rel.propertyKey)) continue;
 
       const RelatedEntity = rel.getRelatedEntity();
-      try { this.idMap.validateEntity(RelatedEntity); } catch { continue; }
+      if (!this.idMap.isRegistered(RelatedEntity)) continue;
 
       const parentPk = this.idMap.getParentPkValue(instance, entityClass);
       if (parentPk === undefined || parentPk === null) continue;

--- a/src/core/plugin/buffer/WriteBuffer.ts
+++ b/src/core/plugin/buffer/WriteBuffer.ts
@@ -33,6 +33,8 @@ import type { ReparentedChildren } from "./CascadeProcessor";
 import { FlushExecutor } from "./FlushExecutor";
 import { EntityValidator } from "../../EntityValidator";
 import { EntityNotFoundError } from "../../../errors/EntityNotFoundError";
+import { OrmError } from "../../../errors/OrmError";
+import { OrmErrorCode } from "../../../errors/OrmErrorCode";
 import { LazyRelationInjector } from "./LazyRelationInjector";
 import { transactionStorage } from "../../../decorators/Transactional";
 import type { EntityManager } from "../../EntityManager";
@@ -792,7 +794,14 @@ export class WriteBuffer {
       }
     } catch (err) {
       // PK missing → track as new; only swallow identity key errors
-      if (!(err instanceof Error && /PK column/.test(err.message))) throw err;
+      if (
+        !(
+          err instanceof OrmError &&
+          err.code === OrmErrorCode.PRIMARY_KEY_NOT_FOUND
+        )
+      ) {
+        throw err;
+      }
     }
 
     if (!mergedIntoExisting) {
@@ -816,7 +825,12 @@ export class WriteBuffer {
       this.cascade.propagateToRelations(instance, entityClass, (child) => {
         try { this.merge(child, seen); } catch (err) {
           // Only swallow "not registered" errors
-          if (err instanceof Error && /not.*registered|no.*entity|table.*not/i.test(err.message)) return;
+          if (
+            err instanceof OrmError &&
+            err.code === OrmErrorCode.ENTITY_METADATA_NOT_FOUND
+          ) {
+            return;
+          }
           throw err;
         }
       });
@@ -1774,7 +1788,7 @@ export class WriteBuffer {
     resolved: Map<any, any>,
   ): void {
     if (!RelatedEntity) return;
-    try { this.idMap.validateEntity(RelatedEntity); } catch { return; }
+    if (!this.idMap.isRegistered(RelatedEntity)) return;
     const val = readLoadedRelationValue(fresh, prop);
     if (val === undefined || Array.isArray(val)) return;
     const child = this.resolveIdentityGraph(RelatedEntity, val, resolved);
@@ -1793,7 +1807,7 @@ export class WriteBuffer {
     resolved: Map<any, any>,
   ): void {
     if (!RelatedEntity) return;
-    try { this.idMap.validateEntity(RelatedEntity); } catch { return; }
+    if (!this.idMap.isRegistered(RelatedEntity)) return;
     const arr = readLoadedRelationValue(fresh, prop);
     if (!Array.isArray(arr)) return;
     const out = arr.map((item) =>


### PR DESCRIPTION
Behavior-unchanged refactor in three commits.

1. SelectQueryBuilder: 26 scattered `(this.em as any)` reads (resolver x14, _ctx x11, emitAfterLoad x1) replaced with a narrow `EntityManagerInternalView` behind a single private accessor. Live-read semantics preserved (test-time reassignment of `em.resolver` still honored); #226 subclass contract and public surface untouched.
2. RelationLoader: 12 `as any` removed via an `EntityRecord` indexing alias; parent widening happens once in `toParentRecords()`.
3. Buffer error normalization: `IdentityMapManager.validateEntity`/`buildIdentityKey` now throw `OrmError` with `ENTITY_METADATA_NOT_FOUND`/`PRIMARY_KEY_NOT_FOUND` (messages unchanged, so no docs/test churn). The message-regex swallow decisions in WriteBuffer.merge (2) and CascadeProcessor.collectCascadeDeletes (1) now match on error codes. New `isRegistered()` predicate replaces try/catch control flow at 6 sites (LazyRelationInjector x4, WriteBuffer x2). Note: the old CascadeProcessor regex nominally targeted driver "table not found" messages too, but no MySQL/PostgreSQL/SQLite driver message actually matched it, so the typed check is equivalent in practice.

Gates: tsc 0 errors, unit 5,444 passed (19 skipped, 0 failures), SQLite integration 670/670, dual CJS/ESM build clean.