### PR TITLE
fix(postgres): bigint auto-increment PK generates BIGSERIAL instead of SERIAL

### DIFF
--- a/__tests__/unit/column-definition-builder.test.ts
+++ b/__tests__/unit/column-definition-builder.test.ts
@@ -271,8 +271,15 @@ describe("PostgresColumnDefinitionBuilder", () => {
       const option: ColumnOption = { type: "int", primary: true, autoIncrement: true, nullable: false };
       const result = builder.buildColumnDef(option, ctx);
       expect(result).toContain("SERIAL");
+      expect(result).not.toContain("BIGSERIAL");
       expect(result).toContain("NOT NULL");
       expect(result).toContain("PRIMARY KEY");
+    });
+
+    it("bigint auto increment → BIGSERIAL", () => {
+      const option: ColumnOption = { type: "bigint", primary: true, autoIncrement: true, nullable: false };
+      const result = builder.buildColumnDef(option, ctx);
+      expect(result).toBe('"test_col" BIGSERIAL NOT NULL PRIMARY KEY');
     });
 
     it("boolean → BOOLEAN (native)", () => {

--- a/__tests__/unit/schema-generator.test.ts
+++ b/__tests__/unit/schema-generator.test.ts
@@ -60,6 +60,15 @@ class Product {
 }
 
 @Entity()
+class BigintPkEvent {
+  @PrimaryGeneratedColumn({ type: "bigint" })
+  id!: number;
+
+  @Column({ type: "varchar", length: 100 })
+  name!: string;
+}
+
+@Entity()
 class Profile {
   @PrimaryGeneratedColumn()
   id!: number;
@@ -192,6 +201,12 @@ describe("SchemaGenerator", () => {
       const ddl = gen.generateCreateTableDDL(Category);
       expect(ddl).toContain("SERIAL");
       expect(ddl).not.toContain("AUTO_INCREMENT");
+    });
+
+    it("bigint auto increment에 BIGSERIAL을 사용해야 함", () => {
+      const ddl = gen.generateCreateTableDDL(BigintPkEvent);
+      expect(ddl).toContain("BIGSERIAL");
+      expect(ddl).not.toContain(" SERIAL");
     });
 
     it("boolean에 BOOLEAN을 사용해야 함 (TINYINT 아님)", () => {

--- a/src/dialects/postgres/PostgresColumnDefinitionBuilder.ts
+++ b/src/dialects/postgres/PostgresColumnDefinitionBuilder.ts
@@ -12,7 +12,7 @@ import type { DialectName } from "../../core/ColumnTypeRegistry";
  * - Boolean: native BOOLEAN
  * - Enum: "schema"."enumName" (schema-qualified custom type)
  * - Decimal: NUMERIC($p,$s), max precision 1000
- * - Auto-increment: SERIAL (early return) or GENERATED ALWAYS AS IDENTITY (PG 10+)
+ * - Auto-increment: SERIAL, or BIGSERIAL for bigint columns (early return)
  * - UUID PK: DEFAULT gen_random_uuid() (PG 13+) or uuid_generate_v4() (pgcrypto)
  * - Identifier quoting: double quote (")
  */
@@ -126,9 +126,11 @@ export class PostgresColumnDefinitionBuilder extends BaseColumnDefinitionBuilder
   ): string | null {
     if (!option.autoIncrement) return null;
 
+    // BIGSERIAL for bigint PKs — a plain SERIAL is int4 and overflows at ~2.1B rows.
+    const serialType = option.type === "bigint" ? "BIGSERIAL" : "SERIAL";
     const nullable = option.nullable ? "NULL" : "NOT NULL";
     const pk = option.primary && !ctx.isCompositePk ? " PRIMARY KEY" : "";
-    return `${this.wrapIdentifier(ctx.columnName)} SERIAL ${nullable}${pk}`;
+    return `${this.wrapIdentifier(ctx.columnName)} ${serialType} ${nullable}${pk}`;
   }
 
   protected buildUuidPk(


### PR DESCRIPTION
PostgresColumnDefinitionBuilder.buildAutoIncrement() returned SERIAL unconditionally, ignoring the declared column type. `@PrimaryGeneratedColumn({ type: "bigint" })` therefore created an int4 SERIAL column that overflows at ~2.1B rows, while MySQL correctly produced BIGINT AUTO_INCREMENT.

- bigint + autoIncrement now emits BIGSERIAL (other types keep SERIAL)
- unit tests: builder-level exact DDL pin + SchemaGenerator end-to-end pin
- introspection already maps BIGSERIAL back to bigint, so schema diff stays clean

Found in the 2026-08-13 bigint runtime audit (P0).